### PR TITLE
feat: Knowledge Graph (Neo4j) — entity extraction and graph-boosted retrieval

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,10 @@ GEMINI_API_KEY=your-gemini-api-key-here
 GEMINI_EMBEDDING_MODEL=models/gemini-embedding-001
 EMBEDDING_DIMENSIONS=3072
 GEMINI_CHAT_MODEL=gemini-2.5-flash
+
+# Knowledge Graph (Neo4j) — optional, degrades gracefully if unset
+NEO4J_URI=bolt://neo4j:7687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=
+# Comma-separated domain-specific terms to boost entity extraction, e.g. DOMAIN_TERMS=API,SDK,RAG
+DOMAIN_TERMS=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,23 @@ jobs:
           echo "App failed to become healthy in time"
           docker compose logs
           exit 1
+      - name: Wait for Neo4j to actually accept connections
+        run: |
+          for i in {1..30}; do
+            if docker compose exec -T app python3 -c "
+          from core.graph import graph_service
+          import sys
+          sys.exit(0 if graph_service.health_check() else 1)
+          " 2>/dev/null; then
+              echo "Neo4j is ready"
+              exit 0
+            fi
+            echo "Waiting for Neo4j... ($i/30)"
+            sleep 2
+          done
+          echo "Neo4j failed to become ready in time"
+          docker compose logs neo4j
+          exit 1
       - name: Smoke test - health check
         run: |
           curl -sf http://localhost:8000/health | grep -q '"status":"ok"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,7 @@ jobs:
       - name: Wait for Neo4j to actually accept connections
         run: |
           for i in {1..30}; do
-            if docker compose exec -T app python3 -c "
-          from core.graph import graph_service
-          import sys
-          sys.exit(0 if graph_service.health_check() else 1)
-          " 2>/dev/null; then
+            if docker compose exec -T app python3 -c "from core.graph import graph_service; import sys; sys.exit(0 if graph_service.health_check() else 1)" 2>/dev/null; then
               echo "Neo4j is ready"
               exit 0
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,9 @@
 name: CI
-
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
-
 jobs:
   compile-check:
     runs-on: ubuntu-latest
@@ -17,12 +15,10 @@ jobs:
       - name: Compile check
         run: |
           python -m py_compile core/*.py
-
   docker-build-and-smoke-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - name: Create .env for CI
         run: |
           cat > .env << 'ENVEOF'
@@ -32,11 +28,12 @@ jobs:
           GEMINI_CHAT_MODEL=gemini-2.5-flash
           DATABASE_URL=postgresql://ragleap:ragleap@db:5432/ragleap_core
           LLM_PROVIDER=gemini
+          NEO4J_URI=bolt://neo4j:7687
+          NEO4J_USER=neo4j
+          NEO4J_PASSWORD=ragleapgraph
           ENVEOF
-
       - name: Build and start stack
         run: docker compose up --build -d
-
       - name: Wait for services to be healthy
         run: |
           for i in {1..30}; do
@@ -50,11 +47,9 @@ jobs:
           echo "App failed to become healthy in time"
           docker compose logs
           exit 1
-
       - name: Smoke test - health check
         run: |
           curl -sf http://localhost:8000/health | grep -q '"status":"ok"'
-
       - name: Smoke test - upload and chat (skipped if no CI API key)
         env:
           HAS_CI_KEY: ${{ secrets.GEMINI_API_KEY_CI }}
@@ -64,11 +59,22 @@ jobs:
           curl -v -X POST -F "file=@/tmp/test_doc.txt" http://localhost:8000/upload
           echo ""
           curl -v -X POST "http://localhost:8000/chat?question=What+channels+are+supported"
-
+      - name: Smoke test - knowledge graph (skipped if no CI API key)
+        env:
+          HAS_CI_KEY: ${{ secrets.GEMINI_API_KEY_CI }}
+        if: ${{ env.HAS_CI_KEY != '' }}
+        run: |
+          docker compose exec -T app python3 -c "
+          from core.graph import graph_service
+          assert graph_service.driver is not None, 'Neo4j driver did not initialize'
+          assert graph_service.health_check(), 'Neo4j health check failed'
+          docs = graph_service.find_documents_by_entities(['RagLeap'])
+          assert docs, f'Expected a document linked to entity RagLeap, got: {docs}'
+          print('Knowledge graph smoke test passed:', docs)
+          "
       - name: Dump logs on failure
         if: failure()
         run: docker compose logs
-
       - name: Tear down
         if: always()
         run: docker compose down -v

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ WhatsApp, Telegram, and Discord bots are included in this repo too — single-te
 | 🔌 **Bring your own AI key** | OpenAI, Gemini, Anthropic, or any OpenAI-compatible endpoint |
 | 🌐 **Web chat widget** | Embed a chat widget on any website |
 | 🐳 **Docker-based setup** | One-command local deployment |
+| 🕸️ **Knowledge Graph (Neo4j)** | Entity extraction and graph-boosted retrieval alongside vector search |
 ## Architecture
 
 RagLeap Core is the foundation layer of the full RagLeap platform. Here's how it fits into the bigger picture:
@@ -126,6 +127,11 @@ RagLeap Core is the foundation layer of the full RagLeap platform. Here's how it
 |                              |                                |
 |                  +-----------v-----------+                    |
 |                  |  PostgreSQL + pgvector |                    |
+|                  +-----------+-----------+                    |
+|                              |                                |
+|                  +-----------v-----------+                    |
+|                  |    Neo4j (Knowledge   |                    |
+|                  |         Graph)         |                    |
 |                  +------------------------+                    |
 +-------------------------------------------------------------+
 ```
@@ -172,7 +178,6 @@ RagLeap Core covers document upload, retrieval, and web chat. The hosted platfor
 | **Team Chat** | Internal team messaging board per workspace, separate from customer-facing AI chat |
 | **n8n Workflows** | Trigger no-code automations directly from a conversation, across every channel |
 | **222+ Languages** | Auto-detected per user, applied consistently across every channel |
-| **Neo4j Knowledge Graph** | Hybrid graph + vector retrieval for richer, more connected answers — available on the hosted platform |
 | **Integrations & Database Connectors** | Connect existing business tools and external databases, with AI-suggested automations per channel and developer-level custom automations |
 | **Analytics Dashboard** | Per-provider usage breakdown (OpenAI, Gemini, Claude), query volume, token costs, and daily trends |
 | **Team & Billing** | Multi-tenant workspaces, team member permissions, subscription plans, usage-based billing |
@@ -278,6 +283,42 @@ real-world testing this project needs.
   and ElevenLabs (multi-language support) are good-first-issue candidates
 - Non-English TTS quality varies since OpenAI's TTS voices are English-tuned
 - Typical round-trip latency in production was 6-8 seconds
+
+## Knowledge Graph (Neo4j)
+
+RagLeap Core builds a lightweight entity co-occurrence graph alongside its
+vector index. When you ingest a document, entities (product names, acronyms,
+proper nouns) are extracted and linked in Neo4j. When you ask a question,
+the same extraction runs on your query, and any documents linked to matching
+entities get a similarity boost in retrieval — on top of, not instead of,
+normal pgvector search.
+
+Runs as a fourth Docker Compose service on ports `7475`/`7688` (remapped
+from Neo4j's defaults to avoid colliding with another Neo4j instance on the
+same host). If Neo4j is unreachable or `NEO4J_PASSWORD` is unset, the graph
+degrades gracefully — retrieval falls back to pure vector search, ingestion
+is unaffected.
+
+**Setup:**
+1. Set `NEO4J_URI`, `NEO4J_USER`, and `NEO4J_PASSWORD` in `.env` (matching
+   the `NEO4J_AUTH` value in `docker-compose.yml`)
+2. Optionally set `DOMAIN_TERMS` — a comma-separated list of domain-specific
+   terms to boost during extraction (e.g. `DOMAIN_TERMS=API,SDK,RAG`)
+
+**Honest status:** entity extraction, document graph writes, entity-based
+document lookup, and graph-boosted chat retrieval are all verified working
+end-to-end, including in CI (fresh build, real ingest, real query, real
+graph lookup). The graph boost is currently a simple additive score bump,
+not a full weighted re-ranker — a richer hybrid ranking system is a good
+next step for anyone who wants to dig in.
+
+**Known limitations:**
+- Entity extraction is regex-based (CamelCase, acronyms, capitalized
+  phrases, plus optional domain terms) — not a trained NER model, so it
+  will miss some entities and occasionally include noise
+- `search_related_entities()` (multi-hop graph traversal) is implemented
+  but not yet wired into the retrieval pipeline — good-first-issue
+  candidate for anyone wanting a project
 
 ## Roadmap
 

--- a/core/chat.py
+++ b/core/chat.py
@@ -1,9 +1,8 @@
 """
 Chat Pipeline for RagLeap Core
-Wires together: embedding the query -> vector retrieval -> answer generation.
+Wires together: embedding the query -> vector retrieval (graph-boosted) -> answer generation.
 """
 import logging
-
 from core.embedding import EmbeddingService
 from core.retrieval import VectorRetrievalService
 from core.generation import GenerationService
@@ -14,7 +13,6 @@ logger = logging.getLogger(__name__)
 def ask(query: str, top_k: int = 5) -> dict:
     """
     Answer a question grounded in previously ingested documents.
-
     Returns: {"answer": str, "sources": List[str], "chunks_used": int}
     """
     embedder = EmbeddingService()
@@ -29,8 +27,7 @@ def ask(query: str, top_k: int = 5) -> dict:
             "chunks_used": 0,
         }
 
-    chunks = retriever.search_similar_chunks(query_embedding, top_k=top_k)
-
+    chunks = retriever.search_similar_chunks_with_graph(query, query_embedding, top_k=top_k)
     result = generator.generate_answer(query, chunks)
     result["chunks_used"] = len(chunks)
     return result
@@ -41,10 +38,8 @@ if __name__ == "__main__":
     if len(sys.argv) < 2:
         print("Usage: python -m core.chat \"<your question>\"")
         sys.exit(1)
-
     question = " ".join(sys.argv[1:])
     result = ask(question)
-
     print(f"\nQuestion: {question}")
     print(f"Answer: {result['answer']}")
     print(f"Sources: {result['sources']}")

--- a/core/graph.py
+++ b/core/graph.py
@@ -1,0 +1,371 @@
+"""
+Knowledge Graph Service for RagLeap Core.
+
+Neo4j-backed entity extraction and graph traversal, layered on top of the
+existing pgvector retrieval. Single-tenant: no workspace scoping needed,
+all graph nodes belong to this one deployment.
+
+Ported from RagLeap's production retrieval/graph_service.py — same entity
+extraction heuristics and Cypher queries, with Django/multi-tenancy removed.
+"""
+import os
+import re
+import uuid
+import logging
+from collections import Counter
+from typing import Any, Dict, List, Optional, Tuple
+
+try:
+    from neo4j import GraphDatabase
+except ImportError:
+    GraphDatabase = None
+
+logger = logging.getLogger(__name__)
+
+NEO4J_URI = os.environ.get("NEO4J_URI", "bolt://neo4j:7687")
+NEO4J_USER = os.environ.get("NEO4J_USER", "neo4j")
+NEO4J_PASSWORD = os.environ.get("NEO4J_PASSWORD", "")
+
+# Optional domain-specific terms to always treat as entities, even when
+# lowercase (acronym/capitalization heuristics below won't catch these).
+# Empty by default — set via DOMAIN_TERMS env var as a comma-separated list,
+
+ENTITY_STOPWORDS = {
+    "the", "this", "that", "with", "from", "what", "when", "where",
+    "which", "about", "does", "tell", "built", "using", "uses", "used",
+    "platform", "into", "for", "and", "are", "was", "were", "has", "have",
+}
+# e.g. DOMAIN_TERMS="quarterly report,customer churn,net promoter score"
+DOMAIN_TERMS = [
+    t.strip().lower()
+    for t in os.environ.get("DOMAIN_TERMS", "").split(",")
+    if t.strip()
+]
+
+
+class GraphService:
+    """
+    Neo4j knowledge graph service. Extracts entities from ingested document
+    chunks, builds a co-occurrence graph, and supports entity-based document
+    lookup and graph traversal for hybrid retrieval.
+
+    If Neo4j isn't configured or reachable, all methods degrade gracefully
+    (return empty results) rather than raising — graph search is an
+    enhancement on top of vector search, not a hard dependency.
+    """
+
+    def __init__(self):
+        self.driver = None
+        if GraphDatabase and NEO4J_PASSWORD:
+            try:
+                self.driver = GraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USER, NEO4J_PASSWORD))
+                logger.info("Neo4j driver initialized")
+            except Exception as e:
+                logger.warning(f"Failed to initialize Neo4j driver: {e}")
+                self.driver = None
+        else:
+            logger.info("Neo4j not configured (NEO4J_PASSWORD unset) — graph features disabled")
+
+    def close(self):
+        if self.driver:
+            self.driver.close()
+
+    def _normalize_entity_name(self, raw_name: str) -> str:
+        """Normalize extracted entity text into a stable graph key."""
+        if not raw_name:
+            return ""
+        cleaned = re.sub(r"\s+", " ", raw_name).strip()
+        return cleaned[:200]
+
+    def _extract_entity_candidates_from_text(self, text: str, max_entities: int = 12) -> List[str]:
+        """Lightweight, deterministic entity extraction from free text."""
+        if not text:
+            return []
+
+        candidates: List[str] = []
+        candidates.extend(re.findall(r"\b[A-Z]{2,}(?:-[A-Z0-9]+)?\b", text))
+        candidates.extend(re.findall(r"\b(?:[A-Z][a-z]{2,})(?:\s+[A-Z][a-z]{2,}){0,2}\b", text))
+        for token in re.findall(r"\b[A-Za-z][A-Za-z0-9]{2,}\b", text):
+            if token.lower() in ENTITY_STOPWORDS:
+                continue
+            if token[0].isupper() and (any(c.isdigit() for c in token) or not token[1:].islower()):
+                candidates.append(token)
+
+        text_lower = text.lower()
+        for term in DOMAIN_TERMS:
+            if term in text_lower:
+                candidates.append(term)
+
+        seen = set()
+        final: List[str] = []
+        for cand in candidates:
+            normalized = self._normalize_entity_name(cand)
+            if not normalized:
+                continue
+            key = normalized.lower()
+            if key in seen or key in ENTITY_STOPWORDS:
+                continue
+            seen.add(key)
+            final.append(normalized)
+            if len(final) >= max_entities:
+                break
+
+        return final
+
+    def extract_query_entities(self, query: str, max_entities: int = 10) -> List[str]:
+        """Extract seed entities from a user query for graph traversal."""
+        if not query:
+            return []
+
+        candidates: List[str] = []
+        candidates.extend(re.findall(r'"([^"\n]{3,120})"', query))
+        candidates.extend(re.findall(r"\b[A-Z]{2,}(?:-[A-Z0-9]+)?\b", query))
+        candidates.extend(re.findall(r"\b(?:[A-Z][a-z]{2,})(?:\s+[A-Z][a-z]{2,}){0,2}\b", query))
+
+        for token in re.findall(r"\b[A-Za-z][A-Za-z0-9_-]{3,}\b", query):
+            if token.lower() in ENTITY_STOPWORDS:
+                continue
+            candidates.append(token)
+
+        seen = set()
+        result: List[str] = []
+        for cand in candidates:
+            normalized = self._normalize_entity_name(cand)
+            if not normalized:
+                continue
+            key = normalized.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            result.append(normalized)
+            if len(result) >= max_entities:
+                break
+
+        return result
+
+    def upsert_document_graph(
+        self,
+        document_id: str,
+        document_title: str,
+        chunks: List[Dict[str, Any]],
+        max_entities: int = 80,
+        max_pairs: int = 150,
+    ) -> Dict[str, Any]:
+        """Index one document and its entities into Neo4j."""
+        summary = {
+            "success": False,
+            "document_id": str(document_id),
+            "entities_indexed": 0,
+            "relationships_indexed": 0,
+            "error": None,
+        }
+
+        if not self.driver:
+            summary["error"] = "Neo4j driver not available"
+            return summary
+
+        entity_counter: Counter = Counter()
+        pair_counter: Counter = Counter()
+
+        for chunk in chunks or []:
+            text = (chunk.get("text") or "").strip()
+            if not text:
+                continue
+
+            entities = self._extract_entity_candidates_from_text(text, max_entities=12)
+            if not entities:
+                continue
+
+            unique_entities = []
+            seen_local = set()
+            for ent in entities:
+                key = ent.lower()
+                if key in seen_local:
+                    continue
+                seen_local.add(key)
+                unique_entities.append(ent)
+                entity_counter[ent] += 1
+
+            for i in range(len(unique_entities)):
+                for j in range(i + 1, len(unique_entities)):
+                    a, b = unique_entities[i], unique_entities[j]
+                    if a == b:
+                        continue
+                    pair = tuple(sorted((a, b), key=lambda s: s.lower()))
+                    pair_counter[pair] += 1
+
+        top_entities = entity_counter.most_common(max_entities)
+        top_pairs = pair_counter.most_common(max_pairs)
+
+        try:
+            with self.driver.session() as session:
+                session.run(
+                    """
+                    MERGE (d:Document {id: $document_id})
+                    ON CREATE SET d.created_at = datetime(), d.title = $document_title
+                    SET d.updated_at = datetime(), d.title = coalesce($document_title, d.title)
+                    """,
+                    document_id=str(document_id),
+                    document_title=(document_title or "")[:500],
+                )
+
+                for entity_name, weight in top_entities:
+                    session.run(
+                        """
+                        MERGE (e:Entity {name: $entity_name})
+                        ON CREATE SET e.id = $entity_uuid, e.created_at = datetime()
+                        SET e.updated_at = datetime()
+                        WITH e
+                        MATCH (d:Document {id: $document_id})
+                        MERGE (d)-[r:CONTAINS]->(e)
+                        ON CREATE SET r.weight = $weight, r.created_at = datetime()
+                        ON MATCH SET r.weight = coalesce(r.weight, 0) + $weight, r.updated_at = datetime()
+                        """,
+                        entity_name=entity_name,
+                        document_id=str(document_id),
+                        entity_uuid=str(uuid.uuid4()),
+                        weight=float(weight),
+                    )
+
+                for (a_name, b_name), weight in top_pairs:
+                    session.run(
+                        """
+                        MATCH (a:Entity {name: $a_name})
+                        MATCH (b:Entity {name: $b_name})
+                        WHERE a.name <> b.name
+                        MERGE (a)-[r:RELATED_TO]->(b)
+                        ON CREATE SET r.weight = $weight, r.created_at = datetime()
+                        ON MATCH SET r.weight = coalesce(r.weight, 0) + $weight, r.updated_at = datetime()
+                        """,
+                        a_name=a_name,
+                        b_name=b_name,
+                        weight=float(weight),
+                    )
+
+            summary["success"] = True
+            summary["entities_indexed"] = len(top_entities)
+            summary["relationships_indexed"] = len(top_pairs)
+            return summary
+
+        except Exception as e:
+            logger.error(f"Document graph upsert error: {e}", exc_info=True)
+            summary["error"] = str(e)
+            return summary
+
+    def find_documents_by_entities(self, entity_names: List[str], limit: int = 25) -> List[Dict[str, Any]]:
+        """Retrieve graph-relevant documents connected to entity names."""
+        if not self.driver:
+            return []
+
+        normalized = []
+        seen = set()
+        for name in entity_names or []:
+            norm = self._normalize_entity_name(name)
+            if not norm:
+                continue
+            key = norm.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            normalized.append(key)
+
+        if not normalized:
+            return []
+
+        try:
+            with self.driver.session() as session:
+                result = session.run(
+                    """
+                    MATCH (e:Entity)<-[r:CONTAINS]-(d:Document)
+                    WHERE toLower(e.name) IN $entity_names
+                    RETURN d.id AS document_id,
+                           coalesce(d.title, '') AS document_name,
+                           count(DISTINCT e) AS matched_entities,
+                           sum(coalesce(r.weight, 1.0)) AS graph_score,
+                           collect(DISTINCT e.name)[0..10] AS matched_entity_names
+                    ORDER BY matched_entities DESC, graph_score DESC
+                    LIMIT $limit
+                    """,
+                    entity_names=normalized,
+                    limit=max(1, int(limit)),
+                )
+
+                docs = []
+                for row in result:
+                    docs.append({
+                        "document_id": str(row["document_id"]) if row["document_id"] is not None else "",
+                        "document_name": row["document_name"] or "",
+                        "matched_entities": int(row["matched_entities"] or 0),
+                        "graph_score": float(row["graph_score"] or 0.0),
+                        "matched_entity_names": list(row["matched_entity_names"] or []),
+                    })
+                return docs
+        except Exception as e:
+            logger.error(f"Graph document lookup error: {e}", exc_info=True)
+            return []
+
+    def search_related_entities(self, entity_names: List[str], max_depth: int = 2, limit: int = 10) -> List[Dict]:
+        """Find entities related to query entities via graph traversal."""
+        if not self.driver:
+            return []
+
+        try:
+            normalized = []
+            seen = set()
+            for name in entity_names or []:
+                norm = self._normalize_entity_name(name)
+                if not norm:
+                    continue
+                key = norm.lower()
+                if key in seen:
+                    continue
+                seen.add(key)
+                normalized.append(key)
+
+            if not normalized:
+                return []
+
+            with self.driver.session() as session:
+                query = """
+                MATCH (start:Entity)
+                WHERE toLower(start.name) IN $entity_names
+                MATCH path = (start)-[*1..{max_depth}]-(related:Entity)
+                RETURN DISTINCT related.id AS entity_id,
+                       related.name AS entity_name,
+                       type(relationships(path)[0]) AS relationship,
+                       length(path) AS depth,
+                       properties(related) AS properties
+                ORDER BY depth ASC
+                LIMIT $limit
+                """.format(max_depth=max_depth)
+
+                result = session.run(query, entity_names=normalized, limit=limit)
+
+                entities = []
+                for record in result:
+                    entities.append({
+                        "entity_id": record["entity_id"],
+                        "entity_name": record["entity_name"],
+                        "name": record["entity_name"],
+                        "relationship": record["relationship"],
+                        "depth": record["depth"],
+                        "properties": dict(record["properties"]) if record["properties"] else {},
+                    })
+                return entities
+        except Exception as e:
+            logger.error(f"Graph search error: {e}", exc_info=True)
+            return []
+
+    def health_check(self) -> bool:
+        if not self.driver:
+            return False
+        try:
+            with self.driver.session() as session:
+                result = session.run("RETURN 1 AS test")
+                return result.single()["test"] == 1
+        except Exception as e:
+            logger.error(f"Neo4j health check failed: {e}")
+            return False
+
+
+graph_service = GraphService()

--- a/core/ingest.py
+++ b/core/ingest.py
@@ -1,6 +1,6 @@
 """
 Document Ingestion Pipeline for RagLeap Core
-Wires together: chunking -> embedding -> database storage.
+Wires together: chunking -> embedding -> database storage -> knowledge graph.
 """
 import os
 import logging
@@ -8,6 +8,7 @@ import uuid
 
 from core.chunker import TextChunker
 from core.embedding import EmbeddingService
+from core.graph import graph_service
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +80,13 @@ def ingest_document(filename: str, text: str) -> dict:
         cur.close()
 
         logger.info(f"Ingested '{filename}': {stored}/{len(chunks)} chunks stored")
+
+        # Knowledge graph write is best-effort — never blocks or rolls back ingestion
+        try:
+            graph_service.upsert_document_graph(document_id, filename, chunks)
+        except Exception as e:
+            logger.warning(f"Graph upsert failed for '{filename}' (non-fatal): {e}")
+
         return {"document_id": document_id, "chunks_stored": stored}
 
     except Exception:

--- a/core/retrieval.py
+++ b/core/retrieval.py
@@ -2,10 +2,13 @@
 Vector Retrieval Service for RagLeap Core
 Adapted from RagLeap's production pgvector cosine-distance search —
 rewritten as plain SQL (psycopg2), no Django ORM, no multi-tenancy.
+Optionally boosted by the knowledge graph when available.
 """
 import os
 import logging
 from typing import List, Dict, Optional
+
+from core.graph import graph_service
 
 logger = logging.getLogger(__name__)
 
@@ -97,3 +100,40 @@ class VectorRetrievalService:
         except Exception as e:
             logger.error(f"Vector search error: {e}", exc_info=True)
             raise
+
+    def search_similar_chunks_with_graph(
+        self,
+        query_text: str,
+        query_embedding: List[float],
+        top_k: int = 5,
+        document_id: Optional[str] = None,
+        graph_boost: float = 0.15,
+    ) -> List[Dict]:
+        """
+        Vector search, then boost chunks whose document is linked via the
+        knowledge graph to entities mentioned in the query. Falls back to
+        pure vector search if the graph is unavailable or finds nothing.
+        """
+        candidates = self.search_similar_chunks(
+            query_embedding, top_k=top_k * 3, document_id=document_id
+        )
+        if not candidates:
+            return []
+
+        try:
+            entities = graph_service.extract_query_entities(query_text)
+            linked_doc_ids = set()
+            if entities:
+                linked_docs = graph_service.find_documents_by_entities(entities)
+                linked_doc_ids = {d["document_id"] for d in linked_docs} if linked_docs else set()
+        except Exception as e:
+            logger.warning(f"Graph lookup failed during retrieval (non-fatal): {e}")
+            linked_doc_ids = set()
+
+        for chunk in candidates:
+            if chunk["document_id"] in linked_doc_ids:
+                chunk["similarity_score"] = min(1.0, chunk["similarity_score"] + graph_boost)
+                chunk["graph_boosted"] = True
+
+        candidates.sort(key=lambda c: c["similarity_score"], reverse=True)
+        return candidates[:top_k]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,5 +44,23 @@ services:
       - "8766:8765"
     command: ["python3", "-m", "channels.voice.server"]
 
+  neo4j:
+    image: neo4j:5-community
+    restart: unless-stopped
+    environment:
+      NEO4J_AUTH: neo4j/ragleapgraph
+      NEO4J_PLUGINS: '[]'
+    ports:
+      - "7475:7474"
+      - "7688:7687"
+    volumes:
+      - ragleap_core_neo4j_data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:7474 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
 volumes:
   ragleap_core_data:
+  ragleap_core_neo4j_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ requests>=2.31
 cryptography>=42.0
 websockets>=12.0
 audioop-lts>=0.2; python_version >= "3.13"
+neo4j>=5.0


### PR DESCRIPTION
## Summary

Opens the Knowledge Graph feature, ported from production's \`retrieval/graph_service.py\` (Django/Manager-AI coupling fully removed, single-tenant).

## What's included

- \`core/graph.py\` — entity extraction, document graph upsert, entity-based document lookup, related-entity traversal
- Wired into \`core/ingest.py\` (write path, best-effort, never blocks ingestion) and \`core/retrieval.py\`/\`core/chat.py\` (graph-boosted retrieval, degrades gracefully to pure vector search if Neo4j is unavailable)
- New \`neo4j\` service in \`docker-compose.yml\` (ports remapped to avoid colliding with other Neo4j instances on the same host)
- \`.env.example\` documents the new config vars
- CI extended to build all 4 services and run a knowledge-graph smoke test

## Bugs found and fixed during testing

- Entity extraction regex only matched plain Title Case words, silently missing CamelCase/alphanumeric terms like \`RagLeap\`, \`Neo4j\`, \`WhatsApp\`, \`PostgreSQL\`, \`FastAPI\`
- Inconsistent stopword filtering let junk tokens (e.g. \`'The'\`) get stored as graph entities

## Testing

Verified end-to-end on a clean-volume \`docker compose down -v && up --build\`: ingest → entity extraction → graph write → entity-based document lookup → graph-boosted chat retrieval, all producing correct results with a single unambiguous test document.

## Known scope limits

- \`find_document_entities()\` (admin-UI-only in production) was intentionally not ported — no caller needs it in the open-core single-tenant context
- Graph boost is a simple additive score bump (\`+0.15\`), not production's full weighted re-ranker (\`enhanced_retrieval.py\` was deliberately out of scope for this port)