### PR TITLE
feat: Language detection (langdetect) for ingestion and chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,9 @@ NEO4J_USER=neo4j
 NEO4J_PASSWORD=
 # Comma-separated domain-specific terms to boost entity extraction, e.g. DOMAIN_TERMS=API,SDK,RAG
 DOMAIN_TERMS=
+
+# Language Detection (langdetect) — optional, defaults shown below
+DEFAULT_LANGUAGE=en
+LANGUAGE_DETECTION_CONFIDENCE_THRESHOLD=0.7
+# Comma-separated list of language codes to restrict detection to (blank = unrestricted)
+LANGUAGE_DETECTION_SUPPORTED_LANGUAGES=

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ WhatsApp, Telegram, and Discord bots are included in this repo too — single-te
 | 🌐 **Web chat widget** | Embed a chat widget on any website |
 | 🐳 **Docker-based setup** | One-command local deployment |
 | 🕸️ **Knowledge Graph (Neo4j)** | Entity extraction and graph-boosted retrieval alongside vector search |
+| 🌍 **Language detection** | Auto-detects document and query language, applied across every channel |
 ## Architecture
 
 RagLeap Core is the foundation layer of the full RagLeap platform. Here's how it fits into the bigger picture:
@@ -88,7 +89,6 @@ RagLeap Core is the foundation layer of the full RagLeap platform. Here's how it
 |  [locked] AI Employees — role-based persistent memory        |
 |  [locked] n8n Workflow Automation                            |
 |  [locked] Persistent Memory (cross-channel, cross-session)   |
-|  [locked] 222+ Language auto-detection, all channels         |
 |  [locked] Multi-tenant Billing, Teams & Permissions           |
 |  [locked] Audit History / Compliance logging                 |
 |  [locked] Embed Widget Control Center (white-label)           |
@@ -177,7 +177,7 @@ RagLeap Core covers document upload, retrieval, and web chat. The hosted platfor
 | **Advanced AI Settings** | Model selection (Gemini/OpenAI/Claude), temperature tuning, bring-your-own-key per provider, and automatic failover across a fallback key pool |
 | **Team Chat** | Internal team messaging board per workspace, separate from customer-facing AI chat |
 | **n8n Workflows** | Trigger no-code automations directly from a conversation, across every channel |
-| **222+ Languages** | Auto-detected per user, applied consistently across every channel |
+| **222+ Languages** | This repo includes language detection (langdetect, ~55 languages) across all channels; the hosted platform extends this to 222+ languages with per-user persisted preferences |
 | **Integrations & Database Connectors** | Connect existing business tools and external databases, with AI-suggested automations per channel and developer-level custom automations |
 | **Analytics Dashboard** | Per-provider usage breakdown (OpenAI, Gemini, Claude), query volume, token costs, and daily trends |
 | **Team & Billing** | Multi-tenant workspaces, team member permissions, subscription plans, usage-based billing |
@@ -319,6 +319,39 @@ next step for anyone who wants to dig in.
 - `search_related_entities()` (multi-hop graph traversal) is implemented
   but not yet wired into the retrieval pipeline — good-first-issue
   candidate for anyone wanting a project
+
+## Language Detection
+
+RagLeap Core auto-detects language during document ingestion (per chunk)
+and during chat (per query), using the `langdetect` library plus
+script-based heuristics for CJK, Hangul, and Kana text. Since every
+channel (WhatsApp, Telegram, Discord, Voice, and the API directly)
+routes through the same core chat pipeline, detection applies
+consistently everywhere without per-channel wiring.
+
+**Setup:** works out of the box with no configuration. Optionally set
+`DEFAULT_LANGUAGE` (fallback when detection fails or text is too short),
+`LANGUAGE_DETECTION_CONFIDENCE_THRESHOLD` (default `0.7`), and
+`LANGUAGE_DETECTION_SUPPORTED_LANGUAGES` (comma-separated allowlist,
+blank = unrestricted).
+
+**Honest status:** verified working end-to-end — document-level
+detection tested at high confidence (0.9999) on a real mixed-language
+document, and query-level detection confirmed working via both the API
+and CLI.
+
+**Known limitations:**
+- `langdetect` covers roughly 55 languages — noticeably fewer than the
+  hosted platform's 222+, which layers additional detection and
+  per-user language preferences on top
+- Short queries in closely-related languages can be misdetected (in
+  testing, a short French query was detected as Italian) — this is an
+  inherent limitation of statistical detection on short text, not
+  specific to this port. A good-first-issue candidate for anyone
+  wanting to improve short-query accuracy
+- Detection is one-way only: RagLeap Core detects the query's language
+  and surfaces it, but does not yet steer the AI's response language
+  to match — that's a reasonable next step for a contributor
 
 ## Roadmap
 

--- a/core/chat.py
+++ b/core/chat.py
@@ -1,11 +1,13 @@
 """
 Chat Pipeline for RagLeap Core
-Wires together: embedding the query -> vector retrieval (graph-boosted) -> answer generation.
+Wires together: query language detection -> embedding the query -> vector
+retrieval (graph-boosted) -> answer generation.
 """
 import logging
 from core.embedding import EmbeddingService
 from core.retrieval import VectorRetrievalService
 from core.generation import GenerationService
+from core.language import language_detector
 
 logger = logging.getLogger(__name__)
 
@@ -13,11 +15,17 @@ logger = logging.getLogger(__name__)
 def ask(query: str, top_k: int = 5) -> dict:
     """
     Answer a question grounded in previously ingested documents.
-    Returns: {"answer": str, "sources": List[str], "chunks_used": int}
+    Returns: {"answer": str, "sources": List[str], "chunks_used": int, "detected_language": str}
     """
     embedder = EmbeddingService()
     retriever = VectorRetrievalService()
     generator = GenerationService()
+
+    try:
+        detected_language, _confidence = language_detector.detect_query_language(query)
+    except Exception as e:
+        logger.warning(f"Query language detection failed (non-fatal): {e}")
+        detected_language = None
 
     query_embedding = embedder.embed_text(query)
     if query_embedding is None:
@@ -25,11 +33,13 @@ def ask(query: str, top_k: int = 5) -> dict:
             "answer": "Sorry, I couldn't process your question (embedding failed).",
             "sources": [],
             "chunks_used": 0,
+            "detected_language": detected_language,
         }
 
     chunks = retriever.search_similar_chunks_with_graph(query, query_embedding, top_k=top_k)
     result = generator.generate_answer(query, chunks)
     result["chunks_used"] = len(chunks)
+    result["detected_language"] = detected_language
     return result
 
 
@@ -41,6 +51,7 @@ if __name__ == "__main__":
     question = " ".join(sys.argv[1:])
     result = ask(question)
     print(f"\nQuestion: {question}")
+    print(f"Detected language: {result.get('detected_language')}")
     print(f"Answer: {result['answer']}")
     print(f"Sources: {result['sources']}")
     print(f"Chunks used: {result['chunks_used']}")

--- a/core/ingest.py
+++ b/core/ingest.py
@@ -1,6 +1,7 @@
 """
 Document Ingestion Pipeline for RagLeap Core
-Wires together: chunking -> embedding -> database storage -> knowledge graph.
+Wires together: chunking -> embedding -> database storage -> knowledge graph
+-> language detection.
 """
 import os
 import logging
@@ -9,6 +10,7 @@ import uuid
 from core.chunker import TextChunker
 from core.embedding import EmbeddingService
 from core.graph import graph_service
+from core.language import language_detector
 
 logger = logging.getLogger(__name__)
 
@@ -53,10 +55,16 @@ def ingest_document(filename: str, text: str) -> dict:
 
             embedding_literal = "[" + ",".join(str(float(x)) for x in embedding) + "]"
 
+            try:
+                detected_language, language_confidence = language_detector.detect_language(chunk["text"])
+            except Exception as e:
+                logger.warning(f"Language detection failed for chunk {chunk['chunk_index']} (non-fatal): {e}")
+                detected_language, language_confidence = None, None
+
             cur.execute(
                 """
-                INSERT INTO chunks (document_id, document_name, chunk_index, text, token_count, embedding)
-                VALUES (%s, %s, %s, %s, %s, %s::vector)
+                INSERT INTO chunks (document_id, document_name, chunk_index, text, token_count, embedding, detected_language, language_confidence)
+                VALUES (%s, %s, %s, %s, %s, %s::vector, %s, %s)
                 """,
                 (
                     document_id,
@@ -65,6 +73,8 @@ def ingest_document(filename: str, text: str) -> dict:
                     chunk["text"],
                     chunk["token_count"],
                     embedding_literal,
+                    detected_language,
+                    language_confidence,
                 ),
             )
             stored += 1

--- a/core/language.py
+++ b/core/language.py
@@ -1,0 +1,262 @@
+"""
+Language Detection Service for RagLeap Core
+Ported from production's multilingual/language_detector.py — single-tenant,
+Django settings replaced with .env vars, dead/unreachable code removed.
+"""
+import os
+import re
+import logging
+
+import langdetect
+from langdetect import detect_langs
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_LANGUAGE = os.environ.get("DEFAULT_LANGUAGE", "en")
+CONFIDENCE_THRESHOLD = float(os.environ.get("LANGUAGE_DETECTION_CONFIDENCE_THRESHOLD", "0.7"))
+
+_detection_langs_raw = os.environ.get("LANGUAGE_DETECTION_SUPPORTED_LANGUAGES", "")
+DETECTION_LANGUAGES = (
+    {lang.strip() for lang in _detection_langs_raw.split(",") if lang.strip()}
+    if _detection_langs_raw
+    else None
+)
+
+_stop_words_raw = os.environ.get("RAG_CONTENT_LANG_STOP_WORDS", "")
+CONTENT_LANG_STOP_WORDS = {w.strip() for w in _stop_words_raw.split(",") if w.strip()}
+CONTENT_LANG_MIN_TERMS = int(os.environ.get("RAG_CONTENT_LANG_MIN_TERMS", "2"))
+CONTENT_LANG_MIN_TERM_LEN = int(os.environ.get("RAG_CONTENT_LANG_MIN_TERM_LEN", "4"))
+CONTENT_LANG_MIN_CONFIDENCE = float(os.environ.get("RAG_CONTENT_LANG_MIN_CONFIDENCE", "0.85"))
+ENABLE_CONTENT_LANG_DETECTION = os.environ.get("RAG_ENABLE_CONTENT_LANG_DETECTION", "true").lower() == "true"
+
+
+class LanguageDetector:
+    """
+    Language detection service using the langdetect library, with
+    script-based heuristics (CJK/Hangul/Kana) and query-specific
+    overrides for short, mostly-English queries with foreign tokens.
+    """
+
+    CONFIDENCE_THRESHOLD = CONFIDENCE_THRESHOLD
+    DETECTION_LANGUAGES = DETECTION_LANGUAGES
+
+    def detect_language(self, text: str, fallback: str = None) -> tuple[str, float]:
+        """
+        Detect language of text with confidence score.
+
+        Returns:
+            Tuple of (language_code, confidence_score), e.g. ('ta', 0.92)
+        """
+        if not text or len(text.strip()) < 10:
+            default = fallback or DEFAULT_LANGUAGE
+            logger.warning(f"Text too short for detection, using default: {default}")
+            return (default, 0.0)
+
+        total_chars = max(len(text), 1)
+        ascii_letters = sum(1 for c in text if ord(c) < 128 and c.isalpha())
+        cjk_count = sum(1 for c in text if '\u4e00' <= c <= '\u9fff')
+        hiragana_count = sum(1 for c in text if '\u3040' <= c <= '\u309f')
+        katakana_count = sum(1 for c in text if '\u30a0' <= c <= '\u30ff')
+        hangul_count = sum(1 for c in text if '\uac00' <= c <= '\ud7a3')
+
+        script_chars = cjk_count + hiragana_count + katakana_count + hangul_count
+        script_ratio = script_chars / total_chars
+
+        script_infer = None
+        if hangul_count > max(cjk_count, hiragana_count + katakana_count) and hangul_count > 0:
+            script_infer = 'ko'
+        elif (hiragana_count + katakana_count) > 0 and (hiragana_count + katakana_count) > cjk_count:
+            script_infer = 'ja'
+        elif cjk_count > 0 and (cjk_count / max(ascii_letters + cjk_count, 1)) > 0.25:
+            script_infer = 'zh'
+
+        cleaned = re.sub(r"Page\s*\d+", " ", text, flags=re.IGNORECASE)
+        cleaned = re.sub(r"\b[A-Z]{2,}\d+\b", " ", cleaned)
+        cleaned = re.sub(r"[^\w\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7a3\s]", " ", cleaned)
+        cleaned = re.sub(r"\d+", " ", cleaned)
+        cleaned = re.sub(r"_+", " ", cleaned)
+        cleaned = re.sub(r"\s+", " ", cleaned).strip()
+
+        try:
+            lang_probs = detect_langs(cleaned) if cleaned else []
+        except Exception:
+            lang_probs = []
+
+        if not lang_probs:
+            default = fallback or DEFAULT_LANGUAGE
+            if script_infer and script_ratio >= 0.10:
+                return (script_infer, 0.95)
+            return (default, 0.0)
+
+        top_lang = lang_probs[0]
+        detected_code = self._normalize_language_code(top_lang.lang)
+        confidence = top_lang.prob
+
+        if self.DETECTION_LANGUAGES and detected_code not in self.DETECTION_LANGUAGES:
+            logger.warning(
+                f"Detected unsupported language '{detected_code}' with confidence {confidence:.2f}. Falling back to default."
+            )
+            default = fallback or DEFAULT_LANGUAGE
+            return (default, 0.0)
+
+        if script_infer:
+            if confidence < self.CONFIDENCE_THRESHOLD or script_ratio >= 0.20:
+                logger.info(
+                    f"Script-based inference ({script_infer}) preferred over statistical detection "
+                    f"({detected_code}) due to script_ratio={script_ratio:.2f} or low confidence={confidence:.2f}"
+                )
+                return (script_infer, 0.95)
+
+        if confidence < self.CONFIDENCE_THRESHOLD:
+            logger.warning(
+                f"Low confidence detection: {detected_code} ({confidence:.2f}). Using default: {fallback or DEFAULT_LANGUAGE}"
+            )
+            default = fallback or DEFAULT_LANGUAGE
+            return (default, confidence)
+
+        logger.info(f"Detected language: {detected_code} (confidence: {confidence:.2f})")
+        return (detected_code, confidence)
+
+    def detect_query_language(
+        self,
+        text: str,
+        fallback: str = None,
+        min_confidence: float = 0.85,
+        ascii_ratio_threshold: float = 0.9,
+    ) -> tuple[str, float]:
+        """Detect language for short user queries with an ASCII heuristic.
+
+        Helps avoid misclassifying mostly-English queries that contain a
+        few foreign tokens.
+        """
+        detected, confidence = self.detect_language(text, fallback=fallback)
+
+        if not text:
+            return (detected, confidence)
+
+        text_lower = text.lower()
+        context_lang = None
+        context_conf = 0.0
+        if 'context:' in text_lower:
+            try:
+                start = text_lower.index('context:') + len('context:')
+                end = text_lower.find(')', start)
+                snippet = text[start:end].strip() if end != -1 else text[start:].strip()
+                if snippet:
+                    context_lang, context_conf = self.detect_language(snippet, fallback=fallback)
+            except Exception:
+                context_lang, context_conf = None, 0.0
+
+        letters = [c for c in text if c.isalpha()]
+        if letters:
+            ascii_letters = sum(1 for c in letters if ord(c) < 128)
+            ascii_ratio = ascii_letters / max(len(letters), 1)
+            non_ascii_ratio = 1.0 - ascii_ratio
+        else:
+            ascii_ratio = 1.0
+            non_ascii_ratio = 0.0
+
+        fallback_lang = fallback or DEFAULT_LANGUAGE
+
+        content_terms = re.findall(r"\b\w+\b", text_lower)
+        if ENABLE_CONTENT_LANG_DETECTION:
+            content_terms = [
+                t for t in content_terms
+                if t not in CONTENT_LANG_STOP_WORDS and len(t) >= CONTENT_LANG_MIN_TERM_LEN
+            ]
+        else:
+            content_terms = []
+
+        if len(content_terms) >= CONTENT_LANG_MIN_TERMS:
+            content_text = " ".join(content_terms)
+            try:
+                lang_probs = detect_langs(content_text)
+                if lang_probs:
+                    top_lang = lang_probs[0]
+                    content_lang = self._normalize_language_code(top_lang.lang)
+                    if content_lang != fallback_lang:
+                        non_ascii_term = any(any(ord(c) > 127 for c in t) for t in content_terms)
+                        if non_ascii_term or top_lang.prob >= CONTENT_LANG_MIN_CONFIDENCE:
+                            logger.info(
+                                f"Query language content override: {detected}->{content_lang} "
+                                f"(content_confidence={top_lang.prob:.2f})"
+                            )
+                            return (content_lang, top_lang.prob)
+            except Exception:
+                pass
+
+        if context_lang and context_conf >= 0.85:
+            logger.info(
+                f"Query language context override: {detected}->{context_lang} "
+                f"(context_confidence={context_conf:.2f}, non_ascii_ratio={non_ascii_ratio:.2f})"
+            )
+            return (context_lang, context_conf)
+
+        if context_lang and context_conf >= 0.7 and non_ascii_ratio >= 0.1:
+            logger.info(
+                f"Query language context override: {detected}->{context_lang} "
+                f"(context_confidence={context_conf:.2f}, non_ascii_ratio={non_ascii_ratio:.2f})"
+            )
+            return (context_lang, context_conf)
+
+        if ascii_ratio >= ascii_ratio_threshold and non_ascii_ratio < 0.1:
+            english_markers = (
+                'what', 'who', 'when', 'where', 'which', 'how', 'why',
+                'is', 'are', 'do', 'does', 'did', 'can', 'could', 'would',
+                'should', 'summarize', 'summary', 'explain', 'describe',
+                'provide', 'details', 'mention', 'context'
+            )
+            has_english_marker = any(f" {m} " in f" {text_lower} " for m in english_markers)
+
+            if detected != fallback_lang and has_english_marker and confidence < min_confidence:
+                logger.info(
+                    f"Query language heuristic override: {detected}->{fallback_lang} "
+                    f"(confidence={confidence:.2f}, ascii_ratio={ascii_ratio:.2f}, english_markers={has_english_marker})"
+                )
+                return (fallback_lang, confidence)
+
+        return (detected, confidence)
+
+    def detect_language_simple(self, text: str, fallback: str = None) -> str:
+        """Simplified detection returning only the language code."""
+        language, _ = self.detect_language(text, fallback)
+        return language
+
+    def is_supported_language(self, lang_code: str) -> bool:
+        """Check if language code is supported."""
+        return (not self.DETECTION_LANGUAGES) or (lang_code in self.DETECTION_LANGUAGES)
+
+    def _normalize_language_code(self, lang_code: str) -> str:
+        """Normalize language codes like zh-cn -> zh, pt-br -> pt."""
+        if not lang_code:
+            return lang_code
+        code = lang_code.strip().lower().replace('_', '-')
+        aliases = {
+            'zh-cn': 'zh',
+            'zh-tw': 'zh',
+            'zh-hk': 'zh',
+            'pt-br': 'pt',
+            'pt-pt': 'pt',
+        }
+        if code in aliases:
+            return aliases[code]
+        if '-' in code:
+            return code.split('-')[0]
+        return code
+
+    def detect_with_manual_override(self, text: str, user_specified_lang: str = None) -> tuple[str, float]:
+        """Detect language with an optional user-provided override, which
+        takes precedence with full confidence if supported."""
+        if user_specified_lang:
+            if self.is_supported_language(user_specified_lang):
+                logger.info(f"Using user-specified language: {user_specified_lang}")
+                return (user_specified_lang, 1.0)
+            else:
+                logger.warning(
+                    f"User specified unsupported language: {user_specified_lang}. Falling back to detection."
+                )
+        return self.detect_language(text)
+
+
+# Singleton instance, matching production's pattern
+language_detector = LanguageDetector()

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -17,6 +17,8 @@ CREATE TABLE IF NOT EXISTS chunks (
     text TEXT NOT NULL,
     token_count INTEGER,
     embedding vector(3072),
+    detected_language TEXT,
+    language_confidence REAL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ cryptography>=42.0
 websockets>=12.0
 audioop-lts>=0.2; python_version >= "3.13"
 neo4j>=5.0
+langdetect>=1.0.9


### PR DESCRIPTION
## Summary

Opens language auto-detection, ported from production's \`multilingual/language_detector.py\` (Django settings replaced with \`.env\` vars, single-tenant, dead code removed).

## What's included

- \`core/language.py\` — \`LanguageDetector\` class: script-based heuristics (CJK/Hangul/Kana), confidence thresholds, and query-specific overrides (ASCII ratio, context snippets, content-term detection) for short queries mixing mostly-English text with foreign tokens
- Wired into \`core/ingest.py\` — each chunk's language + confidence detected and stored (best-effort, never blocks ingestion)
- Wired into \`core/chat.py\` — query language detected and surfaced as \`detected_language\` in the response
- \`detected_language\`/\`language_confidence\` columns added to \`chunks\` table in \`db/schema.sql\`
- \`langdetect\` added to \`requirements.txt\`
- \`.env.example\` documents the new config vars

## Bug found and fixed during porting

The original \`detect_language()\` had a dead, unreachable duplicate \`try/except\` block sitting after an earlier \`return\` statement — leftover from an earlier refactor. Removed during the port.

## Testing

Verified end-to-end: ingested a mixed English/French document (French sentence correctly detected at 0.9999 confidence), queried in both English and French.

## Known limitation

Short queries in closely-related languages can be misdetected — in testing, a French query (\"Quel framework utilise RagLeap Core?\") was detected as Italian. This is an inherent \`langdetect\` limitation on short text, not a regression from the port. Production's own query-detection heuristics (ASCII ratio, context snippets) exist specifically to mitigate, not eliminate, this class of error. Worth filing as a good-first-issue for anyone wanting to improve short-query accuracy (e.g. a lightweight n-gram model or a confidence-gated fallback to \`DEFAULT_LANGUAGE\`).