### PR TITLE
feat: External data source integrations (9 connectors)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,9 @@ DEFAULT_LANGUAGE=en
 LANGUAGE_DETECTION_CONFIDENCE_THRESHOLD=0.7
 # Comma-separated list of language codes to restrict detection to (blank = unrestricted)
 LANGUAGE_DETECTION_SUPPORTED_LANGUAGES=
+
+# Integrations — Fernet key for encrypting stored connection strings/API
+# keys. Generate one with:
+#   python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+ADDON_ENCRYPTION_KEY=
+

--- a/core/api.py
+++ b/core/api.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 from core.ingest import ingest_document
 from core.parsers import extract_text
 from core.chat import ask
+from core.integrations import service as integrations_service
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("ragleap-core.api")
@@ -42,21 +43,16 @@ class UploadResponse(BaseModel):
     chunks_stored: int
 
 
-@app.get("/health")
-def health():
-    return {"status": "ok"}
-    question: str
-
-
-class ChatResponse(BaseModel):
-    answer: str
-    sources: list[str]
-    chunks_used: int
-
-
-class UploadResponse(BaseModel):
-    document_id: str
-    chunks_stored: int
+class DataSourceCreateRequest(BaseModel):
+    name: str
+    source_type: str
+    connection_string: str | None = None
+    api_endpoint: str | None = None
+    api_key: str | None = None
+    api_headers: dict = {}
+    query_template: str | None = None
+    field_mappings: dict = {}
+    user_identifier_field: str = "user_id"
 
 
 @app.get("/health")
@@ -216,3 +212,50 @@ async def discord_webhook(request: Request):
     handle_incoming_message(channel_id, content)
 
     return {"ok": True}
+
+
+# ============================================================================
+# INTEGRATIONS — external data sources (databases, CRMs, SaaS APIs)
+# ============================================================================
+
+@app.post("/integrations")
+def create_integration(req: DataSourceCreateRequest):
+    try:
+        result = integrations_service.create_data_source(
+            name=req.name,
+            source_type=req.source_type,
+            connection_string=req.connection_string,
+            api_endpoint=req.api_endpoint,
+            api_key=req.api_key,
+            api_headers=req.api_headers,
+            query_template=req.query_template,
+            field_mappings=req.field_mappings,
+            user_identifier_field=req.user_identifier_field,
+        )
+        return result
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception as exc:
+        logger.exception("Failed to create integration")
+        raise HTTPException(status_code=500, detail=f"Failed to create integration: {exc}") from exc
+
+
+@app.get("/integrations")
+def list_integrations():
+    return {"data_sources": integrations_service.list_data_sources()}
+
+
+@app.post("/integrations/{data_source_id}/test")
+def test_integration(data_source_id: str):
+    result = integrations_service.test_data_source(data_source_id)
+    if not result.get("success") and result.get("error") == "Data source not found":
+        raise HTTPException(status_code=404, detail="Data source not found")
+    return result
+
+
+@app.post("/integrations/{data_source_id}/sync")
+def sync_integration(data_source_id: str):
+    result = integrations_service.sync_data_source(data_source_id)
+    if not result.get("success") and result.get("error") == "Data source not found":
+        raise HTTPException(status_code=404, detail="Data source not found")
+    return result

--- a/core/integrations/base.py
+++ b/core/integrations/base.py
@@ -1,0 +1,172 @@
+"""
+Base classes for RagLeap Core's data source integrations.
+Ported from production's api/addon_models.py + api/addon_services.py —
+Django model fields replaced with a plain dataclass, Fernet encryption
+kept (same library, no Django dependency), workspace scoping removed
+(single-tenant).
+"""
+import os
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Dict, Any, Tuple, List, Optional
+
+logger = logging.getLogger(__name__)
+
+try:
+    from cryptography.fernet import Fernet
+    _FERNET_AVAILABLE = True
+except ImportError:
+    _FERNET_AVAILABLE = False
+
+
+def _get_fernet():
+    """Return a Fernet instance from ADDON_ENCRYPTION_KEY, or None if unavailable/unset."""
+    if not _FERNET_AVAILABLE:
+        return None
+    key = os.environ.get("ADDON_ENCRYPTION_KEY")
+    if not key:
+        return None
+    return Fernet(key.encode() if isinstance(key, str) else key)
+
+
+def encrypt_value(value: Optional[str]) -> Optional[str]:
+    """Encrypt a value for storage. Returns the plaintext unchanged if no key is configured."""
+    if value is None:
+        return value
+    fernet = _get_fernet()
+    if fernet:
+        return fernet.encrypt(value.encode()).decode()
+    return value
+
+
+def decrypt_value(value: Optional[str]) -> Optional[str]:
+    """Decrypt a stored value. Returns the value unchanged if no key is configured."""
+    if value is None:
+        return value
+    fernet = _get_fernet()
+    if fernet:
+        try:
+            return fernet.decrypt(value.encode()).decode()
+        except Exception:
+            logger.error(
+                "Decryption failed for a data source credential — possible "
+                "ADDON_ENCRYPTION_KEY mismatch or corrupted data."
+            )
+            return "[DECRYPTION_FAILED]"
+    return value
+
+
+@dataclass
+class DataSource:
+    """
+    Plain data holder replacing the Django ExternalDataSource model.
+    Field names match production exactly so ported connector logic
+    (self.data_source.connection_string, etc.) works unmodified.
+    """
+    id: str
+    name: str
+    source_type: str
+    connection_string: Optional[str] = None
+    api_endpoint: Optional[str] = None
+    api_key: Optional[str] = None
+    api_headers: Dict[str, str] = field(default_factory=dict)
+    query_template: Optional[str] = None
+    field_mappings: Dict[str, str] = field(default_factory=dict)
+    user_identifier_field: str = "user_id"
+    documents_table_name: str = "documents"
+
+
+class BaseDatabaseConnector(ABC):
+    """Abstract base class for all data source connectors."""
+
+    # Tables/collections that must never be exposed, regardless of source type
+    BLACKLISTED_TABLE_PATTERNS = [
+        'auth_', 'django_', 'api_key', 'secret', 'password', 'token',
+        'session', 'payment', 'credit_card', 'billing_alert', 'admin_',
+        'oauth', 'social_auth', 'celery_',
+    ]
+
+    SENSITIVE_COLUMN_PATTERNS = [
+        'password', 'secret', 'token', 'api_key', 'private_key',
+        'credit_card', 'ssn', 'social_security', 'cvv', 'pin',
+        'encryption_key', 'salt', 'hash',
+    ]
+
+    def __init__(self, data_source: DataSource):
+        self.data_source = data_source
+
+    @abstractmethod
+    def test_connection(self) -> Tuple[bool, str]:
+        """Test the connection. Returns (success, message)."""
+        pass
+
+    @abstractmethod
+    def fetch_data(self, user_identifier: str = None) -> List[Dict]:
+        """Fetch data from the external source."""
+        pass
+
+    def introspect_schema(self) -> Dict[str, Any]:
+        """Discover tables/collections with blacklist filtering. Override in subclass."""
+        return {'tables': [], 'filtered_count': 0, 'message': 'Schema introspection not supported for this source type'}
+
+    def check_required_schema(self) -> Dict[str, Any]:
+        """Check if RagLeap's required tables exist in the user's database."""
+        return {'supported': False, 'message': 'Schema check not supported for this source type'}
+
+    def create_required_schema(self) -> Dict[str, Any]:
+        """Create RagLeap's required tables in the user's database."""
+        return {'supported': False, 'message': 'Schema creation not supported for this source type'}
+
+    def insert_document(self, table_name: str, title: str, content: str,
+                        metadata: Optional[Dict] = None, source_type: str = 'upload') -> Dict[str, Any]:
+        """Insert an uploaded document into the user's external database."""
+        return {'success': False, 'error': 'Insert not supported for this source type'}
+
+    REQUIRED_TABLES = {
+        'ragleap_documents': {
+            'description': 'Source documents ingested into the RAG pipeline',
+            'columns': [
+                ('id', 'UUID / Primary Key'),
+                ('source_id', 'Text — external reference ID'),
+                ('title', 'Text — document title'),
+                ('content', 'Text — full document body'),
+                ('metadata', 'JSON — extra attributes'),
+                ('created_at', 'Timestamp'),
+            ],
+        },
+        'ragleap_chunks': {
+            'description': 'Text chunks split from documents for embedding',
+            'columns': [
+                ('id', 'UUID / Primary Key'),
+                ('document_id', 'UUID — FK -> ragleap_documents'),
+                ('chunk_text', 'Text — chunk content'),
+                ('chunk_index', 'Integer — position in document'),
+                ('metadata', 'JSON — chunk attributes'),
+                ('created_at', 'Timestamp'),
+            ],
+        },
+        'ragleap_embeddings': {
+            'description': 'Vector embeddings for similarity search',
+            'columns': [
+                ('id', 'UUID / Primary Key'),
+                ('chunk_id', 'UUID — FK -> ragleap_chunks'),
+                ('embedding', 'vector(3072) — embedding array'),
+                ('created_at', 'Timestamp'),
+            ],
+        },
+    }
+
+    def _is_table_blacklisted(self, table_name: str) -> bool:
+        lower_name = table_name.lower()
+        for pattern in self.BLACKLISTED_TABLE_PATTERNS:
+            if lower_name.startswith(pattern) or pattern in lower_name:
+                return True
+        return False
+
+    def _is_column_sensitive(self, column_name: str) -> bool:
+        lower_name = column_name.lower()
+        for pattern in self.SENSITIVE_COLUMN_PATTERNS:
+            if pattern in lower_name:
+                return True
+        return False

--- a/core/integrations/crm_connectors.py
+++ b/core/integrations/crm_connectors.py
@@ -1,0 +1,352 @@
+"""
+CRM / SaaS connectors for RagLeap Core integrations: Salesforce, HubSpot,
+Shopify, Google Sheets, Stripe. Ported from production's
+api/addon_services.py — logic unchanged. All use BYOK credentials the
+user provides directly (username/password/token, private-app token,
+admin API token, service-account JSON, or secret key) — none require a
+RagLeap-owned OAuth app registration.
+"""
+import logging
+from datetime import date
+from typing import Dict, Any, Tuple, List
+
+from core.integrations.base import BaseDatabaseConnector
+
+logger = logging.getLogger(__name__)
+
+
+class SalesforceConnector(BaseDatabaseConnector):
+    """
+    Connector for Salesforce CRM using the simple_salesforce library.
+    Credentials (3 options):
+    Option A (recommended): username+password+security_token stored in connection_string as JSON
+        {"username":"user@co.com","password":"pass","security_token":"TOKEN","domain":"login"}
+        -> Permanent, never expires
+    Option B: api_key=access_token + api_endpoint=instance_url (OAuth2, expires every 2h)
+    Option C: connection_string stores JSON with instance_url + access_token
+    """
+
+    def _get_client(self):
+        try:
+            from simple_salesforce import Salesforce
+        except ImportError:
+            raise ImportError("simple_salesforce not installed. Run: pip install simple-salesforce")
+
+        try:
+            import json as _json
+            creds = _json.loads(self.data_source.connection_string or '{}')
+            username = creds.get('username', '')
+            password = creds.get('password', '')
+            security_token = creds.get('security_token', '')
+            domain = creds.get('domain', 'login')
+            if username and password:
+                return Salesforce(
+                    username=username, password=password,
+                    security_token=security_token, domain=domain
+                )
+        except Exception:
+            pass
+
+        instance_url = (self.data_source.api_endpoint or '').rstrip('/')
+        access_token = (self.data_source.api_key or '').strip()
+        if not instance_url or not access_token:
+            try:
+                import json as _json
+                creds = _json.loads(self.data_source.connection_string or '{}')
+                instance_url = creds.get('instance_url', instance_url)
+                access_token = creds.get('access_token', access_token)
+            except Exception:
+                pass
+        if instance_url and access_token:
+            return Salesforce(instance_url=instance_url, session_id=access_token)
+
+        raise ValueError(
+            "Salesforce requires username+password in connection_string JSON "
+            "or api_endpoint+api_key for OAuth token."
+        )
+
+    def test_connection(self) -> Tuple[bool, str]:
+        try:
+            sf = self._get_client()
+            sf.describe()
+            return True, "Salesforce connection successful"
+        except ImportError as e:
+            return False, str(e)
+        except Exception as e:
+            return False, f"Salesforce connection failed: {e}"
+
+    def fetch_data(self, user_identifier: str = None) -> List[Dict]:
+        try:
+            sf = self._get_client()
+            query = (self.data_source.query_template or '').strip()
+            if not query:
+                return []
+            result = sf.query_all(query)
+            records = result.get('records', [])
+            return [{k: v for k, v in r.items() if k != 'attributes'} for r in records]
+        except Exception as e:
+            logger.error(f"SalesforceConnector.fetch_data error: {e}")
+            raise
+
+    def introspect_schema(self) -> Dict[str, Any]:
+        try:
+            sf = self._get_client()
+            desc = sf.describe()
+            sobjects = desc.get('sobjects', [])
+            tables = []
+            for obj in sobjects[:50]:
+                name = obj.get('name', '')
+                if self._is_table_blacklisted(name):
+                    continue
+                tables.append({'name': name, 'label': obj.get('label', name), 'columns': []})
+            return {'tables': tables, 'filtered_count': max(0, len(sobjects) - len(tables))}
+        except Exception as e:
+            return {'error': str(e), 'tables': [], 'filtered_count': 0}
+
+    def execute_query(self, query: str) -> List[Dict]:
+        sf = self._get_client()
+        result = sf.query_all(query)
+        records = result.get('records', [])
+        return [{k: v for k, v in r.items() if k != 'attributes'} for r in records]
+
+
+class HubSpotConnector(BaseDatabaseConnector):
+    """
+    Connector for HubSpot CRM using the hubspot-api-client library.
+    api_key stores the Private App access token.
+    """
+
+    def _get_client(self):
+        try:
+            from hubspot import HubSpot
+        except ImportError:
+            raise ImportError("hubspot-api-client not installed. Run: pip install hubspot-api-client")
+
+        token = (self.data_source.api_key or '').strip()
+        if not token:
+            raise ValueError("HubSpot connector requires api_key (Private App access token)")
+        return HubSpot(access_token=token)
+
+    def test_connection(self) -> Tuple[bool, str]:
+        try:
+            client = self._get_client()
+            client.crm.contacts.basic_api.get_page(limit=1)
+            return True, "HubSpot connection successful"
+        except ImportError as e:
+            return False, str(e)
+        except Exception as e:
+            return False, f"HubSpot connection failed: {e}"
+
+    def fetch_data(self, user_identifier: str = None) -> List[Dict]:
+        try:
+            client = self._get_client()
+            object_type = (self.data_source.query_template or 'contacts').strip() or 'contacts'
+            api = getattr(client.crm, object_type, None)
+            if api is None:
+                return []
+            page = api.basic_api.get_page(limit=100)
+            return [r.to_dict() for r in (page.results or [])]
+        except Exception as e:
+            logger.error(f"HubSpotConnector.fetch_data error: {e}")
+            raise
+
+    def introspect_schema(self) -> Dict[str, Any]:
+        objects = ['contacts', 'companies', 'deals', 'tickets', 'products', 'line_items']
+        tables = [{'name': obj, 'label': obj.title(), 'columns': []} for obj in objects]
+        return {'tables': tables, 'filtered_count': 0}
+
+    def execute_query(self, query: str) -> List[Dict]:
+        return self.fetch_data()
+
+
+class ShopifyConnector(BaseDatabaseConnector):
+    """
+    Connector for Shopify stores using the ShopifyAPI library.
+    api_endpoint stores the shop URL (e.g. mystore.myshopify.com),
+    api_key stores the Admin API access token.
+    """
+
+    def _setup_session(self):
+        try:
+            import shopify
+        except ImportError:
+            raise ImportError("ShopifyAPI not installed. Run: pip install ShopifyAPI")
+
+        shop_url = (self.data_source.api_endpoint or '').strip().rstrip('/')
+        token = (self.data_source.api_key or '').strip()
+        if not shop_url or not token:
+            raise ValueError("Shopify connector requires api_endpoint (shop URL) and api_key (access token)")
+
+        try:
+            import shopify as _shopify
+            api_version = _shopify.ApiVersion.STABLE_SHOPIFY_API_VERSION
+        except Exception:
+            y = date.today().year
+            q = (date.today().month - 1) // 3
+            quarters = ['01', '04', '07', '10']
+            api_version = f"{y}-{quarters[max(q-1,0)]}"
+        session = shopify.Session(shop_url, api_version, token)
+        shopify.ShopifyResource.activate_session(session)
+        return shopify
+
+    def test_connection(self) -> Tuple[bool, str]:
+        try:
+            shopify = self._setup_session()
+            shop = shopify.Shop.current()
+            return True, f"Shopify connected: {shop.name}"
+        except ImportError as e:
+            return False, str(e)
+        except Exception as e:
+            return False, f"Shopify connection failed: {e}"
+
+    def fetch_data(self, user_identifier: str = None) -> List[Dict]:
+        try:
+            shopify = self._setup_session()
+            resource_name = (self.data_source.query_template or 'Order').strip() or 'Order'
+            resource_class = getattr(shopify, resource_name, None)
+            if resource_class is None:
+                return []
+            items = resource_class.find(limit=250)
+            return [item.to_dict() for item in items]
+        except Exception as e:
+            logger.error(f"ShopifyConnector.fetch_data error: {e}")
+            raise
+
+    def introspect_schema(self) -> Dict[str, Any]:
+        resources = ['Order', 'Product', 'Customer', 'Variant', 'Collection',
+                     'DraftOrder', 'Fulfillment', 'Refund', 'Transaction']
+        tables = [{'name': r, 'label': r, 'columns': []} for r in resources]
+        return {'tables': tables, 'filtered_count': 0}
+
+    def execute_query(self, query: str) -> List[Dict]:
+        return self.fetch_data()
+
+
+class GoogleSheetsConnector(BaseDatabaseConnector):
+    """
+    Connector for Google Sheets using the gspread library.
+    connection_string stores JSON service-account credentials (as a JSON string),
+    api_endpoint stores the spreadsheet URL or ID,
+    query_template stores the worksheet name (default: first sheet).
+    """
+
+    def _get_client(self):
+        try:
+            import gspread
+            from google.oauth2.service_account import Credentials
+        except ImportError:
+            raise ImportError("gspread not installed. Run: pip install gspread")
+
+        creds_json = (self.data_source.connection_string or '').strip()
+        if not creds_json:
+            raise ValueError("Google Sheets connector requires connection_string (service account JSON)")
+
+        import json as _json
+        creds_dict = _json.loads(creds_json)
+        scopes = ['https://spreadsheets.google.com/feeds', 'https://www.googleapis.com/auth/drive']
+        creds = Credentials.from_service_account_info(creds_dict, scopes=scopes)
+        return gspread.authorize(creds)
+
+    def test_connection(self) -> Tuple[bool, str]:
+        try:
+            gc = self._get_client()
+            spreadsheet_id = (self.data_source.api_endpoint or '').strip()
+            if spreadsheet_id:
+                gc.open_by_url(spreadsheet_id) if spreadsheet_id.startswith('http') else gc.open_by_key(spreadsheet_id)
+            return True, "Google Sheets connection successful"
+        except ImportError as e:
+            return False, str(e)
+        except Exception as e:
+            return False, f"Google Sheets connection failed: {e}"
+
+    def fetch_data(self, user_identifier: str = None) -> List[Dict]:
+        try:
+            gc = self._get_client()
+            spreadsheet_id = (self.data_source.api_endpoint or '').strip()
+            worksheet_name = (self.data_source.query_template or '').strip() or None
+            sh = gc.open_by_url(spreadsheet_id) if spreadsheet_id.startswith('http') else gc.open_by_key(spreadsheet_id)
+            ws = sh.worksheet(worksheet_name) if worksheet_name else sh.get_worksheet(0)
+            return ws.get_all_records()
+        except Exception as e:
+            logger.error(f"GoogleSheetsConnector.fetch_data error: {e}")
+            raise
+
+    def introspect_schema(self) -> Dict[str, Any]:
+        try:
+            gc = self._get_client()
+            spreadsheet_id = (self.data_source.api_endpoint or '').strip()
+            sh = gc.open_by_url(spreadsheet_id) if spreadsheet_id.startswith('http') else gc.open_by_key(spreadsheet_id)
+            tables = []
+            for ws in sh.worksheets():
+                headers = ws.row_values(1) if ws.row_count > 0 else []
+                columns = [{'name': h, 'type': 'string'} for h in headers if h]
+                tables.append({'name': ws.title, 'label': ws.title, 'columns': columns})
+            return {'tables': tables, 'filtered_count': 0}
+        except Exception as e:
+            return {'error': str(e), 'tables': [], 'filtered_count': 0}
+
+    def execute_query(self, query: str) -> List[Dict]:
+        return self.fetch_data()
+
+
+class StripeConnector(BaseDatabaseConnector):
+    """
+    Connector for Stripe Payments using the stripe library.
+    api_key stores the Stripe Secret Key.
+    query_template stores the resource type (e.g. 'charges', 'customers', 'invoices').
+    """
+
+    def _get_stripe(self):
+        try:
+            import stripe
+        except ImportError:
+            raise ImportError("stripe not installed. Run: pip install stripe")
+
+        secret_key = (self.data_source.api_key or '').strip()
+        if not secret_key:
+            raise ValueError("Stripe connector requires api_key (Stripe Secret Key)")
+
+        stripe.api_key = secret_key
+        return stripe
+
+    def test_connection(self) -> Tuple[bool, str]:
+        try:
+            stripe = self._get_stripe()
+            stripe.Balance.retrieve()
+            return True, "Stripe connection successful"
+        except ImportError as e:
+            return False, str(e)
+        except Exception as e:
+            return False, f"Stripe connection failed: {e}"
+
+    def fetch_data(self, user_identifier: str = None) -> List[Dict]:
+        try:
+            stripe = self._get_stripe()
+            resource_name = (self.data_source.query_template or 'charges').strip().lower() or 'charges'
+            resource_map = {
+                'charges': stripe.Charge,
+                'customers': stripe.Customer,
+                'invoices': stripe.Invoice,
+                'subscriptions': stripe.Subscription,
+                'paymentintents': stripe.PaymentIntent,
+                'payment_intents': stripe.PaymentIntent,
+                'products': stripe.Product,
+                'prices': stripe.Price,
+                'refunds': stripe.Refund,
+                'payouts': stripe.Payout,
+            }
+            resource_class = resource_map.get(resource_name, stripe.Charge)
+            items = resource_class.list(limit=100)
+            return [item.to_dict() for item in items.auto_paging_iter()]
+        except Exception as e:
+            logger.error(f"StripeConnector.fetch_data error: {e}")
+            raise
+
+    def introspect_schema(self) -> Dict[str, Any]:
+        resources = ['charges', 'customers', 'invoices', 'subscriptions',
+                     'payment_intents', 'products', 'prices', 'refunds', 'payouts']
+        tables = [{'name': r, 'label': r.replace('_', ' ').title(), 'columns': []} for r in resources]
+        return {'tables': tables, 'filtered_count': 0}
+
+    def execute_query(self, query: str) -> List[Dict]:
+        return self.fetch_data()

--- a/core/integrations/factory.py
+++ b/core/integrations/factory.py
@@ -1,0 +1,38 @@
+"""
+Connector factory for RagLeap Core integrations.
+Ported from production's DatabaseConnector.get_connector().
+"""
+from core.integrations.base import BaseDatabaseConnector, DataSource
+from core.integrations.sql_connectors import MySQLConnector, PostgreSQLConnector
+from core.integrations.mongodb import MongoDBConnector
+from core.integrations.rest_api import RestAPIConnector
+from core.integrations.crm_connectors import (
+    SalesforceConnector,
+    HubSpotConnector,
+    ShopifyConnector,
+    GoogleSheetsConnector,
+    StripeConnector,
+)
+
+CONNECTOR_MAP = {
+    'mysql': MySQLConnector,
+    'postgresql': PostgreSQLConnector,
+    'mongodb': MongoDBConnector,
+    'rest_api': RestAPIConnector,
+    'salesforce': SalesforceConnector,
+    'hubspot': HubSpotConnector,
+    'shopify': ShopifyConnector,
+    'google_sheets': GoogleSheetsConnector,
+    'stripe': StripeConnector,
+}
+
+
+def get_connector(data_source: DataSource) -> BaseDatabaseConnector:
+    """Get the appropriate connector for a data source."""
+    connector_class = CONNECTOR_MAP.get(data_source.source_type)
+    if not connector_class:
+        raise ValueError(
+            f"Unsupported source type: {data_source.source_type}. "
+            f"Supported types: {', '.join(sorted(CONNECTOR_MAP.keys()))}"
+        )
+    return connector_class(data_source)

--- a/core/integrations/mongodb.py
+++ b/core/integrations/mongodb.py
@@ -1,0 +1,290 @@
+"""
+MongoDB connector for RagLeap Core integrations.
+Ported from production's api/addon_services.py — logic unchanged,
+only the makerag_* required-collection names renamed to ragleap_*.
+"""
+import json
+import logging
+from datetime import datetime
+from typing import Dict, Any, Tuple, List
+
+from core.integrations.base import BaseDatabaseConnector
+
+logger = logging.getLogger(__name__)
+
+
+class MongoDBConnector(BaseDatabaseConnector):
+    """MongoDB database connector"""
+
+    def test_connection(self) -> Tuple[bool, str]:
+        try:
+            from pymongo import MongoClient
+
+            conn_string = self.data_source.connection_string
+            client = MongoClient(conn_string, serverSelectionTimeoutMS=10000)
+            client.admin.command('ping')
+            client.close()
+
+            return True, "Connection successful"
+        except ImportError:
+            return False, "pymongo not installed. Run: pip install pymongo"
+        except Exception as e:
+            return False, f"Connection failed: {str(e)}"
+
+    def fetch_data(self, user_identifier: str = None) -> List[Dict]:
+        try:
+            from pymongo import MongoClient
+            import bson
+
+            client = MongoClient(self.data_source.connection_string)
+
+            try:
+                query_config = json.loads(self.data_source.query_template)
+                database = query_config.get('database')
+                collection = query_config.get('collection')
+                filter_query = query_config.get('filter', {})
+                projection = query_config.get('projection')
+
+                if user_identifier:
+                    safe_identifier = str(user_identifier).replace('$', '').replace('{', '').replace('}', '')
+                    filter_str = json.dumps(filter_query)
+                    filter_str = filter_str.replace('{{user_id}}', safe_identifier)
+                    filter_str = filter_str.replace('{{user_identifier}}', safe_identifier)
+                    filter_query = json.loads(filter_str)
+
+                db = client[database]
+                coll = db[collection]
+
+                cursor = coll.find(filter_query, projection)
+                results = []
+
+                for doc in cursor:
+                    if '_id' in doc and isinstance(doc['_id'], bson.ObjectId):
+                        doc['_id'] = str(doc['_id'])
+                    results.append(doc)
+
+                return results
+            finally:
+                client.close()
+
+        except Exception as e:
+            logger.error(f"MongoDB fetch error: {e}")
+            raise
+
+    def introspect_schema(self) -> Dict[str, Any]:
+        try:
+            from pymongo import MongoClient
+
+            client = MongoClient(self.data_source.connection_string, serverSelectionTimeoutMS=10000)
+
+            try:
+                db_name = None
+                try:
+                    query_config = json.loads(self.data_source.query_template)
+                    db_name = query_config.get('database')
+                except Exception:
+                    pass
+
+                if not db_name:
+                    import re as _re
+                    m = _re.search(r'/([^/?]+)(\?|$)', self.data_source.connection_string)
+                    if m:
+                        db_name = m.group(1)
+
+                if not db_name:
+                    return {'tables': [], 'error': 'No database specified in connection string or query template'}
+
+                db = client[db_name]
+                all_collections = db.list_collection_names()
+
+                allowed_collections = []
+                filtered_count = 0
+
+                for coll_name in sorted(all_collections):
+                    if self._is_table_blacklisted(coll_name):
+                        filtered_count += 1
+                        continue
+
+                    coll = db[coll_name]
+                    sample = coll.find_one()
+                    doc_count = coll.estimated_document_count()
+
+                    fields = []
+                    if sample:
+                        for key, value in sample.items():
+                            fields.append({
+                                'name': key,
+                                'type': type(value).__name__,
+                                'is_sensitive': self._is_column_sensitive(key),
+                            })
+
+                    allowed_collections.append({
+                        'name': coll_name,
+                        'columns': fields,
+                        'column_count': len(fields),
+                        'document_count': doc_count,
+                    })
+
+                return {
+                    'tables': allowed_collections,
+                    'total_tables': len(all_collections),
+                    'allowed_tables': len(allowed_collections),
+                    'filtered_count': filtered_count,
+                    'database': db_name,
+                    'db_type': 'mongodb',
+                }
+            finally:
+                client.close()
+        except Exception as e:
+            logger.error(f"MongoDB schema introspection error: {e}")
+            return {'tables': [], 'error': str(e)}
+
+    def _get_mongo_db(self):
+        db_name = None
+        try:
+            query_config = json.loads(self.data_source.query_template)
+            db_name = query_config.get('database')
+        except Exception:
+            pass
+        if not db_name:
+            import re as _re
+            m = _re.search(r'/([^/?]+)(\?|$)', self.data_source.connection_string)
+            if m:
+                db_name = m.group(1)
+        return db_name
+
+    def check_required_schema(self) -> Dict[str, Any]:
+        try:
+            from pymongo import MongoClient
+
+            client = MongoClient(self.data_source.connection_string, serverSelectionTimeoutMS=10000)
+            try:
+                db_name = self._get_mongo_db()
+                if not db_name:
+                    return {'supported': True, 'error': 'No database specified'}
+
+                db = client[db_name]
+                existing = set(db.list_collection_names())
+
+                required_collections = {
+                    'ragleap_documents': self.REQUIRED_TABLES['ragleap_documents'],
+                    'ragleap_chunks': self.REQUIRED_TABLES['ragleap_chunks'],
+                    'ragleap_embeddings': self.REQUIRED_TABLES['ragleap_embeddings'],
+                }
+
+                tables = {}
+                for coll_name, info in required_collections.items():
+                    tables[coll_name] = {
+                        'exists': coll_name in existing,
+                        'status': 'ready' if coll_name in existing else 'missing',
+                        'description': info['description'],
+                        'columns': info['columns'],
+                    }
+
+                return {
+                    'supported': True,
+                    'tables': tables,
+                    'all_ready': all(t['exists'] for t in tables.values()),
+                    'missing_count': sum(1 for t in tables.values() if not t['exists']),
+                    'has_pgvector': False,
+                    'db_type': 'mongodb',
+                }
+            finally:
+                client.close()
+        except ImportError:
+            return {'supported': False, 'message': 'pymongo not installed'}
+        except Exception as e:
+            logger.error(f"MongoDB schema check error: {e}")
+            return {'supported': True, 'tables': {}, 'error': str(e)}
+
+    def create_required_schema(self) -> Dict[str, Any]:
+        try:
+            from pymongo import MongoClient, ASCENDING
+
+            client = MongoClient(self.data_source.connection_string, serverSelectionTimeoutMS=10000)
+            created = []
+            skipped = []
+            errors = []
+
+            try:
+                db_name = self._get_mongo_db()
+                if not db_name:
+                    return {'supported': True, 'success': False, 'error': 'No database specified'}
+
+                db = client[db_name]
+                existing = set(db.list_collection_names())
+
+                if 'ragleap_documents' in existing:
+                    skipped.append('ragleap_documents')
+                else:
+                    try:
+                        db.create_collection('ragleap_documents')
+                        db['ragleap_documents'].create_index([('source_id', ASCENDING)])
+                        db['ragleap_documents'].create_index([('created_at', ASCENDING)])
+                        created.append('ragleap_documents')
+                    except Exception as e:
+                        errors.append({'table': 'ragleap_documents', 'error': str(e)})
+
+                if 'ragleap_chunks' in existing:
+                    skipped.append('ragleap_chunks')
+                else:
+                    try:
+                        db.create_collection('ragleap_chunks')
+                        db['ragleap_chunks'].create_index([('document_id', ASCENDING)])
+                        db['ragleap_chunks'].create_index([('chunk_index', ASCENDING)])
+                        created.append('ragleap_chunks')
+                    except Exception as e:
+                        errors.append({'table': 'ragleap_chunks', 'error': str(e)})
+
+                if 'ragleap_embeddings' in existing:
+                    skipped.append('ragleap_embeddings')
+                else:
+                    try:
+                        db.create_collection('ragleap_embeddings')
+                        db['ragleap_embeddings'].create_index([('chunk_id', ASCENDING)])
+                        created.append('ragleap_embeddings')
+                    except Exception as e:
+                        errors.append({'table': 'ragleap_embeddings', 'error': str(e)})
+
+                return {
+                    'supported': True,
+                    'created': created,
+                    'skipped': skipped,
+                    'errors': errors,
+                    'success': len(errors) == 0,
+                    'has_pgvector': False,
+                    'db_type': 'mongodb',
+                }
+            finally:
+                client.close()
+        except ImportError:
+            return {'supported': False, 'message': 'pymongo not installed'}
+        except Exception as e:
+            logger.error(f"MongoDB schema creation error: {e}")
+            return {'supported': True, 'success': False, 'error': str(e)}
+
+    def insert_document(self, table_name: str, title: str, content: str,
+                        metadata=None, source_type: str = 'upload') -> Dict[str, Any]:
+        try:
+            from pymongo import MongoClient
+
+            client = MongoClient(self.data_source.connection_string, serverSelectionTimeoutMS=10000)
+            try:
+                db_name = self._get_mongo_db()
+                if not db_name:
+                    return {'success': False, 'error': 'No database specified'}
+
+                db = client[db_name]
+                result = db[table_name].insert_one({
+                    'title': title,
+                    'content': content,
+                    'metadata': metadata or {},
+                    'source_type': source_type,
+                    'created_at': datetime.utcnow(),
+                })
+                return {'success': True, 'id': str(result.inserted_id)}
+            finally:
+                client.close()
+        except Exception as e:
+            logger.error(f"MongoDB insert_document error: {e}")
+            return {'success': False, 'error': str(e)}

--- a/core/integrations/rest_api.py
+++ b/core/integrations/rest_api.py
@@ -1,0 +1,64 @@
+"""
+Generic REST API connector for RagLeap Core integrations.
+Ported from production's api/addon_services.py — logic unchanged.
+"""
+import logging
+import requests
+from typing import Dict, List, Tuple
+
+from core.integrations.base import BaseDatabaseConnector
+
+logger = logging.getLogger(__name__)
+
+
+class RestAPIConnector(BaseDatabaseConnector):
+    """REST API connector"""
+
+    def test_connection(self) -> Tuple[bool, str]:
+        try:
+            endpoint = self.data_source.api_endpoint
+            headers = self.data_source.api_headers or {}
+
+            if self.data_source.api_key:
+                headers['Authorization'] = f'Bearer {self.data_source.api_key}'
+
+            response = requests.get(endpoint, headers=headers, timeout=10)
+
+            if response.status_code == 200:
+                return True, "Connection successful"
+            else:
+                return False, f"API returned status {response.status_code}"
+
+        except Exception as e:
+            return False, f"Connection failed: {str(e)}"
+
+    def fetch_data(self, user_identifier: str = None) -> List[Dict]:
+        try:
+            endpoint = self.data_source.api_endpoint
+            headers = self.data_source.api_headers or {}
+
+            if self.data_source.api_key:
+                headers['Authorization'] = f'Bearer {self.data_source.api_key}'
+
+            if user_identifier:
+                endpoint = endpoint.replace('{{user_id}}', user_identifier)
+                endpoint = endpoint.replace('{{user_identifier}}', user_identifier)
+
+            response = requests.get(endpoint, headers=headers, timeout=30)
+            response.raise_for_status()
+
+            data = response.json()
+
+            if isinstance(data, list):
+                return data
+            elif isinstance(data, dict):
+                for key in ['data', 'results', 'items', 'records']:
+                    if key in data and isinstance(data[key], list):
+                        return data[key]
+                return [data]
+
+            return []
+
+        except Exception as e:
+            logger.error(f"REST API fetch error: {e}")
+            raise

--- a/core/integrations/service.py
+++ b/core/integrations/service.py
@@ -1,0 +1,228 @@
+"""
+Data source CRUD and sync orchestration for RagLeap Core integrations.
+Talks directly to Postgres (plain psycopg2, matching core/ingest.py and
+core/retrieval.py's pattern) rather than through an ORM.
+"""
+import os
+import json
+import logging
+import uuid
+from typing import Dict, Any, List, Optional
+
+from core.integrations.base import DataSource, encrypt_value, decrypt_value
+from core.integrations.factory import get_connector, CONNECTOR_MAP
+
+logger = logging.getLogger(__name__)
+
+DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://ragleap:ragleap@localhost:5433/ragleap_core")
+
+
+def _get_connection():
+    import psycopg2
+    return psycopg2.connect(DATABASE_URL)
+
+
+def _row_to_data_source(row) -> DataSource:
+    """Build a DataSource from a DB row, decrypting credentials."""
+    (id_, name, source_type, connection_string, api_endpoint, api_key,
+     api_headers, query_template, field_mappings, user_identifier_field,
+     documents_table_name) = row
+    return DataSource(
+        id=str(id_),
+        name=name,
+        source_type=source_type,
+        connection_string=decrypt_value(connection_string),
+        api_endpoint=api_endpoint,
+        api_key=decrypt_value(api_key),
+        api_headers=api_headers or {},
+        query_template=query_template,
+        field_mappings=field_mappings or {},
+        user_identifier_field=user_identifier_field,
+        documents_table_name=documents_table_name,
+    )
+
+
+def create_data_source(
+    name: str,
+    source_type: str,
+    connection_string: Optional[str] = None,
+    api_endpoint: Optional[str] = None,
+    api_key: Optional[str] = None,
+    api_headers: Optional[Dict] = None,
+    query_template: Optional[str] = None,
+    field_mappings: Optional[Dict] = None,
+    user_identifier_field: str = "user_id",
+) -> Dict[str, Any]:
+    """Create a new data source. Sensitive fields are encrypted before storage."""
+    if source_type not in CONNECTOR_MAP:
+        raise ValueError(
+            f"Unsupported source type: {source_type}. "
+            f"Supported types: {', '.join(sorted(CONNECTOR_MAP.keys()))}"
+        )
+
+    conn = _get_connection()
+    try:
+        cur = conn.cursor()
+        data_source_id = str(uuid.uuid4())
+        cur.execute(
+            """
+            INSERT INTO data_sources
+                (id, name, source_type, connection_string, api_endpoint, api_key,
+                 api_headers, query_template, field_mappings, user_identifier_field)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                data_source_id, name, source_type,
+                encrypt_value(connection_string), api_endpoint, encrypt_value(api_key),
+                json.dumps(api_headers or {}), query_template,
+                json.dumps(field_mappings or {}), user_identifier_field,
+            ),
+        )
+        conn.commit()
+        cur.close()
+        logger.info(f"Created data source '{name}' ({source_type})")
+        return {"id": data_source_id, "name": name, "source_type": source_type}
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def get_data_source(data_source_id: str) -> Optional[DataSource]:
+    """Fetch a single data source by ID, with credentials decrypted."""
+    conn = _get_connection()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT id, name, source_type, connection_string, api_endpoint, api_key,
+                   api_headers, query_template, field_mappings, user_identifier_field,
+                   documents_table_name
+            FROM data_sources WHERE id = %s
+            """,
+            (data_source_id,),
+        )
+        row = cur.fetchone()
+        cur.close()
+        return _row_to_data_source(row) if row else None
+    finally:
+        conn.close()
+
+
+def list_data_sources() -> List[Dict[str, Any]]:
+    """List all data sources, without exposing decrypted credentials."""
+    conn = _get_connection()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT id, name, source_type, is_active, last_sync_at,
+                   last_sync_status, last_sync_record_count
+            FROM data_sources ORDER BY created_at DESC
+            """
+        )
+        rows = cur.fetchall()
+        cur.close()
+        return [
+            {
+                "id": str(r[0]), "name": r[1], "source_type": r[2],
+                "is_active": r[3], "last_sync_at": r[4].isoformat() if r[4] else None,
+                "last_sync_status": r[5], "last_sync_record_count": r[6],
+            }
+            for r in rows
+        ]
+    finally:
+        conn.close()
+
+
+def test_data_source(data_source_id: str) -> Dict[str, Any]:
+    """Test a data source's connection without syncing any data."""
+    data_source = get_data_source(data_source_id)
+    if not data_source:
+        return {"success": False, "error": "Data source not found"}
+
+    connector = get_connector(data_source)
+    success, message = connector.test_connection()
+    return {"success": success, "message": message}
+
+
+def sync_data_source(data_source_id: str) -> Dict[str, Any]:
+    """
+    Fetch data from the external source and store it as synced context,
+    keyed by each record's user_identifier_field. Updates last_sync_*
+    tracking fields on the data source regardless of outcome.
+    """
+    data_source = get_data_source(data_source_id)
+    if not data_source:
+        return {"success": False, "error": "Data source not found"}
+
+    conn = _get_connection()
+    try:
+        connector = get_connector(data_source)
+        records = connector.fetch_data()
+
+        cur = conn.cursor()
+        synced_count = 0
+        id_field = data_source.user_identifier_field
+
+        for record in records:
+            user_identifier = record.get(id_field)
+            if not user_identifier:
+                continue
+
+            cur.execute(
+                """
+                INSERT INTO synced_context_data (data_source_id, user_identifier, context_data)
+                VALUES (%s, %s, %s)
+                ON CONFLICT (data_source_id, user_identifier)
+                DO UPDATE SET context_data = EXCLUDED.context_data, last_updated = now()
+                """,
+                (data_source_id, str(user_identifier), json.dumps(record, default=str)),
+            )
+            synced_count += 1
+
+        cur.execute(
+            """
+            UPDATE data_sources
+            SET last_sync_at = now(), last_sync_status = %s,
+                last_sync_error = NULL, last_sync_record_count = %s
+            WHERE id = %s
+            """,
+            ("success", synced_count, data_source_id),
+        )
+        conn.commit()
+        cur.close()
+
+        logger.info(f"Synced data source '{data_source.name}': {synced_count} records")
+        return {"success": True, "records_synced": synced_count}
+
+    except Exception as e:
+        conn.rollback()
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE data_sources SET last_sync_at = now(), last_sync_status = %s, last_sync_error = %s WHERE id = %s",
+            ("failed", str(e), data_source_id),
+        )
+        conn.commit()
+        cur.close()
+        logger.error(f"Sync failed for data source {data_source_id}: {e}")
+        return {"success": False, "error": str(e)}
+    finally:
+        conn.close()
+
+
+def get_synced_context(data_source_id: str, user_identifier: str) -> Optional[Dict[str, Any]]:
+    """Look up synced context data for a specific user from a specific data source."""
+    conn = _get_connection()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT context_data FROM synced_context_data WHERE data_source_id = %s AND user_identifier = %s",
+            (data_source_id, user_identifier),
+        )
+        row = cur.fetchone()
+        cur.close()
+        return row[0] if row else None
+    finally:
+        conn.close()

--- a/core/integrations/sql_connectors.py
+++ b/core/integrations/sql_connectors.py
@@ -1,0 +1,681 @@
+"""
+MySQL and PostgreSQL connectors for RagLeap Core integrations.
+Ported from production's api/addon_services.py — logic unchanged,
+only the makerag_* required-table names renamed to ragleap_*.
+"""
+import re
+import json
+import logging
+from typing import Dict, Any, Tuple, List, Optional
+
+from core.integrations.base import BaseDatabaseConnector
+
+logger = logging.getLogger(__name__)
+
+
+class MySQLConnector(BaseDatabaseConnector):
+    """MySQL database connector"""
+
+    def test_connection(self) -> Tuple[bool, str]:
+        try:
+            import pymysql
+
+            conn_string = self.data_source.connection_string
+            pattern = r'mysql://([^:]+):([^@]+)@([^:]+):(\d+)/(.+)'
+            match = re.match(pattern, conn_string)
+
+            if not match:
+                return False, "Invalid connection string format"
+
+            user, password, host, port, database = match.groups()
+
+            connection = pymysql.connect(
+                host=host, port=int(port), user=user, password=password,
+                database=database, connect_timeout=10
+            )
+            connection.close()
+
+            return True, "Connection successful"
+        except ImportError:
+            return False, "pymysql not installed. Run: pip install pymysql"
+        except Exception as e:
+            return False, f"Connection failed: {str(e)}"
+
+    def fetch_data(self, user_identifier: str = None) -> List[Dict]:
+        try:
+            import pymysql
+
+            conn_string = self.data_source.connection_string
+            pattern = r'mysql://([^:]+):([^@]+)@([^:]+):(\d+)/(.+)'
+            match = re.match(pattern, conn_string)
+
+            if not match:
+                raise ValueError("Invalid connection string format")
+
+            user, password, host, port, database = match.groups()
+
+            connection = pymysql.connect(
+                host=host, port=int(port), user=user, password=password,
+                database=database, cursorclass=pymysql.cursors.DictCursor
+            )
+
+            try:
+                with connection.cursor() as cursor:
+                    query = self.data_source.query_template
+                    params = []
+
+                    if user_identifier:
+                        query = query.replace('{{user_id}}', '%s')
+                        query = query.replace('{{user_identifier}}', '%s')
+                        params = [user_identifier] * query.count('%s')
+
+                    cursor.execute(query, params if params else None)
+                    results = cursor.fetchall()
+
+                    mapped_results = []
+                    for row in results:
+                        mapped_row = self._apply_field_mappings(row)
+                        mapped_results.append(mapped_row)
+
+                    return mapped_results
+            finally:
+                connection.close()
+
+        except Exception as e:
+            logger.error(f"MySQL fetch error: {e}")
+            raise
+
+    def _apply_field_mappings(self, row: Dict) -> Dict:
+        mappings = self.data_source.field_mappings
+        if not mappings:
+            return row
+
+        result = {}
+        for source_field, target_field in mappings.items():
+            if source_field in row:
+                result[target_field] = row[source_field]
+
+        for key, value in row.items():
+            if key not in mappings:
+                result[key] = value
+
+        return result
+
+    def introspect_schema(self) -> Dict[str, Any]:
+        try:
+            import pymysql
+
+            conn_string = self.data_source.connection_string
+            pattern = r'mysql://([^:]+):([^@]+)@([^:]+):(\d+)/(.+)'
+            match = re.match(pattern, conn_string)
+            if not match:
+                return {'tables': [], 'error': 'Invalid connection string format'}
+
+            user, password, host, port, database = match.groups()
+            connection = pymysql.connect(
+                host=host, port=int(port), user=user, password=password,
+                database=database, cursorclass=pymysql.cursors.DictCursor,
+                connect_timeout=10
+            )
+
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute("SHOW TABLES")
+                    all_tables = [list(row.values())[0] for row in cursor.fetchall()]
+
+                    allowed_tables = []
+                    filtered_count = 0
+
+                    for table in all_tables:
+                        if self._is_table_blacklisted(table):
+                            filtered_count += 1
+                            continue
+
+                        cursor.execute(f"DESCRIBE `{table}`")
+                        columns = []
+                        for col in cursor.fetchall():
+                            col_name = col.get('Field', '')
+                            columns.append({
+                                'name': col_name,
+                                'type': col.get('Type', ''),
+                                'nullable': col.get('Null', '') == 'YES',
+                                'is_key': col.get('Key', '') == 'PRI',
+                                'is_sensitive': self._is_column_sensitive(col_name),
+                            })
+
+                        allowed_tables.append({
+                            'name': table,
+                            'columns': columns,
+                            'column_count': len(columns),
+                        })
+
+                    return {
+                        'tables': allowed_tables,
+                        'total_tables': len(all_tables),
+                        'allowed_tables': len(allowed_tables),
+                        'filtered_count': filtered_count,
+                        'database': database,
+                        'db_type': 'mysql',
+                    }
+            finally:
+                connection.close()
+        except Exception as e:
+            logger.error(f"MySQL schema introspection error: {e}")
+            return {'tables': [], 'error': str(e)}
+
+    def _parse_mysql_conn(self):
+        conn_string = self.data_source.connection_string
+        pattern = r'mysql://([^:]+):([^@]+)@([^:]+):(\d+)/(.+)'
+        match = re.match(pattern, conn_string)
+        if not match:
+            return None
+        user, password, host, port, database = match.groups()
+        return {'user': user, 'password': password, 'host': host, 'port': int(port), 'database': database}
+
+    def check_required_schema(self) -> Dict[str, Any]:
+        try:
+            import pymysql
+
+            params = self._parse_mysql_conn()
+            if not params:
+                return {'supported': True, 'error': 'Invalid connection string format'}
+
+            connection = pymysql.connect(
+                host=params['host'], port=params['port'],
+                user=params['user'], password=params['password'],
+                database=params['database'], connect_timeout=10,
+            )
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute("SHOW TABLES")
+                    existing = {list(row)[0] for row in cursor.fetchall()}
+
+                    tables = {}
+                    for tbl in self.REQUIRED_TABLES:
+                        tables[tbl] = {
+                            'exists': tbl in existing,
+                            'status': 'ready' if tbl in existing else 'missing',
+                            'description': self.REQUIRED_TABLES[tbl]['description'],
+                            'columns': self.REQUIRED_TABLES[tbl]['columns'],
+                        }
+
+                    return {
+                        'supported': True,
+                        'tables': tables,
+                        'all_ready': all(t['exists'] for t in tables.values()),
+                        'missing_count': sum(1 for t in tables.values() if not t['exists']),
+                        'has_pgvector': False,
+                        'db_type': 'mysql',
+                    }
+            finally:
+                connection.close()
+        except ImportError:
+            return {'supported': False, 'message': 'pymysql not installed'}
+        except Exception as e:
+            logger.error(f"MySQL schema check error: {e}")
+            return {'supported': True, 'tables': {}, 'error': str(e)}
+
+    def create_required_schema(self) -> Dict[str, Any]:
+        try:
+            import pymysql
+
+            params = self._parse_mysql_conn()
+            if not params:
+                return {'supported': True, 'success': False, 'error': 'Invalid connection string format'}
+
+            connection = pymysql.connect(
+                host=params['host'], port=params['port'],
+                user=params['user'], password=params['password'],
+                database=params['database'], connect_timeout=15,
+                autocommit=False,
+            )
+            created = []
+            skipped = []
+            errors = []
+
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute("SHOW TABLES")
+                    existing = {list(row)[0] for row in cursor.fetchall()}
+
+                    if 'ragleap_documents' in existing:
+                        skipped.append('ragleap_documents')
+                    else:
+                        try:
+                            cursor.execute("""
+                                CREATE TABLE ragleap_documents (
+                                    id CHAR(36) PRIMARY KEY DEFAULT (UUID()),
+                                    source_id TEXT,
+                                    title TEXT,
+                                    content LONGTEXT,
+                                    metadata JSON,
+                                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                                    INDEX idx_rl_docs_source (source_id(255)),
+                                    INDEX idx_rl_docs_created (created_at)
+                                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+                            """)
+                            connection.commit()
+                            created.append('ragleap_documents')
+                        except Exception as e:
+                            connection.rollback()
+                            errors.append({'table': 'ragleap_documents', 'error': str(e)})
+
+                    if 'ragleap_chunks' in existing:
+                        skipped.append('ragleap_chunks')
+                    else:
+                        try:
+                            cursor.execute("""
+                                CREATE TABLE ragleap_chunks (
+                                    id CHAR(36) PRIMARY KEY DEFAULT (UUID()),
+                                    document_id CHAR(36),
+                                    chunk_text LONGTEXT,
+                                    chunk_index INT,
+                                    metadata JSON,
+                                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                                    INDEX idx_rl_chunks_doc (document_id),
+                                    INDEX idx_rl_chunks_idx (chunk_index),
+                                    FOREIGN KEY (document_id) REFERENCES ragleap_documents(id) ON DELETE CASCADE
+                                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+                            """)
+                            connection.commit()
+                            created.append('ragleap_chunks')
+                        except Exception as e:
+                            connection.rollback()
+                            errors.append({'table': 'ragleap_chunks', 'error': str(e)})
+
+                    if 'ragleap_embeddings' in existing:
+                        skipped.append('ragleap_embeddings')
+                    else:
+                        try:
+                            cursor.execute("""
+                                CREATE TABLE ragleap_embeddings (
+                                    id CHAR(36) PRIMARY KEY DEFAULT (UUID()),
+                                    chunk_id CHAR(36),
+                                    embedding JSON,
+                                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                                    INDEX idx_rl_embed_chunk (chunk_id),
+                                    FOREIGN KEY (chunk_id) REFERENCES ragleap_chunks(id) ON DELETE CASCADE
+                                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+                            """)
+                            connection.commit()
+                            created.append('ragleap_embeddings')
+                        except Exception as e:
+                            connection.rollback()
+                            errors.append({'table': 'ragleap_embeddings', 'error': str(e)})
+
+                return {
+                    'supported': True,
+                    'created': created,
+                    'skipped': skipped,
+                    'errors': errors,
+                    'success': len(errors) == 0,
+                    'has_pgvector': False,
+                    'db_type': 'mysql',
+                }
+            finally:
+                connection.close()
+        except ImportError:
+            return {'supported': False, 'message': 'pymysql not installed'}
+        except Exception as e:
+            logger.error(f"MySQL schema creation error: {e}")
+            return {'supported': True, 'success': False, 'error': str(e)}
+
+    def insert_document(self, table_name: str, title: str, content: str,
+                        metadata: Optional[Dict] = None, source_type: str = 'upload') -> Dict[str, Any]:
+        try:
+            import pymysql
+
+            params = self._parse_mysql_conn()
+            if not params:
+                return {'success': False, 'error': 'Invalid connection string format'}
+
+            connection = pymysql.connect(
+                host=params['host'], port=params['port'],
+                user=params['user'], password=params['password'],
+                database=params['database'], connect_timeout=10,
+                autocommit=False,
+            )
+            try:
+                with connection.cursor() as cursor:
+                    import uuid
+                    doc_id = str(uuid.uuid4())
+                    meta_json = json.dumps(metadata or {})
+                    cursor.execute(
+                        f"INSERT INTO `{table_name}` (id, title, content, metadata, source_type, created_at) "
+                        "VALUES (%s, %s, %s, %s, %s, NOW())",
+                        (doc_id, title, content, meta_json, source_type),
+                    )
+                    connection.commit()
+                    return {'success': True, 'id': doc_id}
+            finally:
+                connection.close()
+        except Exception as e:
+            logger.error(f"MySQL insert_document error: {e}")
+            return {'success': False, 'error': str(e)}
+
+
+class PostgreSQLConnector(BaseDatabaseConnector):
+    """PostgreSQL database connector"""
+
+    def test_connection(self) -> Tuple[bool, str]:
+        try:
+            import psycopg2
+
+            conn_string = self.data_source.connection_string
+            connection = psycopg2.connect(conn_string, connect_timeout=10)
+            connection.close()
+
+            return True, "Connection successful"
+        except ImportError:
+            return False, "psycopg2 not installed. Run: pip install psycopg2-binary"
+        except Exception as e:
+            return False, f"Connection failed: {str(e)}"
+
+    def fetch_data(self, user_identifier: str = None) -> List[Dict]:
+        try:
+            import psycopg2
+            import psycopg2.extras
+
+            connection = psycopg2.connect(self.data_source.connection_string)
+
+            try:
+                with connection.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cursor:
+                    query = self.data_source.query_template
+                    params = []
+
+                    if user_identifier:
+                        query = query.replace('{{user_id}}', '%s')
+                        query = query.replace('{{user_identifier}}', '%s')
+                        params = [user_identifier] * query.count('%s')
+
+                    cursor.execute(query, params if params else None)
+                    results = cursor.fetchall()
+
+                    return [dict(row) for row in results]
+            finally:
+                connection.close()
+
+        except Exception as e:
+            logger.error(f"PostgreSQL fetch error: {e}")
+            raise
+
+    def introspect_schema(self) -> Dict[str, Any]:
+        try:
+            import psycopg2
+            import psycopg2.extras
+
+            connection = psycopg2.connect(self.data_source.connection_string, connect_timeout=10)
+
+            try:
+                with connection.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cursor:
+                    cursor.execute("""
+                        SELECT table_name
+                        FROM information_schema.tables
+                        WHERE table_schema = 'public'
+                        AND table_type = 'BASE TABLE'
+                        ORDER BY table_name
+                    """)
+                    all_tables = [row['table_name'] for row in cursor.fetchall()]
+
+                    allowed_tables = []
+                    filtered_count = 0
+
+                    for table in all_tables:
+                        if self._is_table_blacklisted(table):
+                            filtered_count += 1
+                            continue
+
+                        cursor.execute("""
+                            SELECT column_name, data_type, is_nullable,
+                                   column_default, character_maximum_length
+                            FROM information_schema.columns
+                            WHERE table_schema = 'public' AND table_name = %s
+                            ORDER BY ordinal_position
+                        """, (table,))
+
+                        columns = []
+                        for col in cursor.fetchall():
+                            col_name = col['column_name']
+                            col_type = col['data_type']
+                            if col.get('character_maximum_length'):
+                                col_type += f"({col['character_maximum_length']})"
+                            columns.append({
+                                'name': col_name,
+                                'type': col_type,
+                                'nullable': col['is_nullable'] == 'YES',
+                                'has_default': col['column_default'] is not None,
+                                'is_sensitive': self._is_column_sensitive(col_name),
+                            })
+
+                        cursor.execute("""
+                            SELECT kcu.column_name
+                            FROM information_schema.table_constraints tc
+                            JOIN information_schema.key_column_usage kcu
+                                ON tc.constraint_name = kcu.constraint_name
+                            WHERE tc.table_name = %s AND tc.constraint_type = 'PRIMARY KEY'
+                        """, (table,))
+                        pk_cols = {row['column_name'] for row in cursor.fetchall()}
+                        for col in columns:
+                            col['is_key'] = col['name'] in pk_cols
+
+                        allowed_tables.append({
+                            'name': table,
+                            'columns': columns,
+                            'column_count': len(columns),
+                        })
+
+                    db_name = ''
+                    try:
+                        m = re.search(r'/([^/?]+)(\?|$)', self.data_source.connection_string)
+                        if m:
+                            db_name = m.group(1)
+                    except Exception:
+                        pass
+
+                    return {
+                        'tables': allowed_tables,
+                        'total_tables': len(all_tables),
+                        'allowed_tables': len(allowed_tables),
+                        'filtered_count': filtered_count,
+                        'database': db_name,
+                        'db_type': 'postgresql',
+                    }
+            finally:
+                connection.close()
+        except Exception as e:
+            logger.error(f"PostgreSQL schema introspection error: {e}")
+            return {'tables': [], 'error': str(e)}
+
+    def check_required_schema(self) -> Dict[str, Any]:
+        try:
+            import psycopg2
+
+            required = list(self.REQUIRED_TABLES.keys())
+            connection = psycopg2.connect(self.data_source.connection_string, connect_timeout=10)
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute("""
+                        SELECT table_name FROM information_schema.tables
+                        WHERE table_schema = 'public' AND table_name = ANY(%s)
+                    """, (required,))
+                    existing = {row[0] for row in cursor.fetchall()}
+
+                    cursor.execute("SELECT 1 FROM pg_extension WHERE extname = 'vector'")
+                    has_pgvector = cursor.fetchone() is not None
+
+                    tables = {}
+                    for tbl in required:
+                        tables[tbl] = {
+                            'exists': tbl in existing,
+                            'status': 'ready' if tbl in existing else 'missing',
+                            'description': self.REQUIRED_TABLES[tbl]['description'],
+                            'columns': self.REQUIRED_TABLES[tbl]['columns'],
+                        }
+
+                    return {
+                        'supported': True,
+                        'tables': tables,
+                        'all_ready': all(t['exists'] for t in tables.values()),
+                        'missing_count': sum(1 for t in tables.values() if not t['exists']),
+                        'has_pgvector': has_pgvector,
+                        'db_type': 'postgresql',
+                    }
+            finally:
+                connection.close()
+        except ImportError:
+            return {'supported': False, 'message': 'psycopg2 not installed'}
+        except Exception as e:
+            logger.error(f"PostgreSQL schema check error: {e}")
+            return {'supported': True, 'tables': {}, 'error': str(e)}
+
+    def create_required_schema(self) -> Dict[str, Any]:
+        try:
+            import psycopg2
+
+            connection = psycopg2.connect(self.data_source.connection_string, connect_timeout=15)
+            created = []
+            skipped = []
+            errors = []
+
+            try:
+                has_pgvector = False
+                try:
+                    connection.autocommit = True
+                    with connection.cursor() as cursor:
+                        cursor.execute("CREATE EXTENSION IF NOT EXISTS vector")
+                    has_pgvector = True
+                except Exception as ext_err:
+                    logger.info(f"pgvector extension not available: {ext_err}")
+                finally:
+                    connection.autocommit = False
+
+                with connection.cursor() as cursor:
+                    try:
+                        cursor.execute("""
+                            SELECT 1 FROM information_schema.tables
+                            WHERE table_schema = 'public' AND table_name = 'ragleap_documents'
+                        """)
+                        if cursor.fetchone():
+                            skipped.append('ragleap_documents')
+                        else:
+                            cursor.execute("""
+                                CREATE TABLE ragleap_documents (
+                                    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                                    source_id TEXT,
+                                    title TEXT,
+                                    content TEXT,
+                                    metadata JSONB DEFAULT '{}',
+                                    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+                                )
+                            """)
+                            cursor.execute("CREATE INDEX idx_rl_docs_source ON ragleap_documents(source_id)")
+                            cursor.execute("CREATE INDEX idx_rl_docs_created ON ragleap_documents(created_at)")
+                            connection.commit()
+                            created.append('ragleap_documents')
+                    except Exception as e:
+                        connection.rollback()
+                        errors.append({'table': 'ragleap_documents', 'error': str(e)})
+
+                    try:
+                        cursor.execute("""
+                            SELECT 1 FROM information_schema.tables
+                            WHERE table_schema = 'public' AND table_name = 'ragleap_chunks'
+                        """)
+                        if cursor.fetchone():
+                            skipped.append('ragleap_chunks')
+                        else:
+                            cursor.execute("""
+                                CREATE TABLE ragleap_chunks (
+                                    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                                    document_id UUID REFERENCES ragleap_documents(id) ON DELETE CASCADE,
+                                    chunk_text TEXT,
+                                    chunk_index INTEGER,
+                                    metadata JSONB DEFAULT '{}',
+                                    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+                                )
+                            """)
+                            cursor.execute("CREATE INDEX idx_rl_chunks_doc ON ragleap_chunks(document_id)")
+                            cursor.execute("CREATE INDEX idx_rl_chunks_idx ON ragleap_chunks(chunk_index)")
+                            connection.commit()
+                            created.append('ragleap_chunks')
+                    except Exception as e:
+                        connection.rollback()
+                        errors.append({'table': 'ragleap_chunks', 'error': str(e)})
+
+                    try:
+                        cursor.execute("""
+                            SELECT 1 FROM information_schema.tables
+                            WHERE table_schema = 'public' AND table_name = 'ragleap_embeddings'
+                        """)
+                        if cursor.fetchone():
+                            skipped.append('ragleap_embeddings')
+                        else:
+                            if has_pgvector:
+                                cursor.execute("""
+                                    CREATE TABLE ragleap_embeddings (
+                                        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                                        chunk_id UUID REFERENCES ragleap_chunks(id) ON DELETE CASCADE,
+                                        embedding vector(3072),
+                                        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+                                    )
+                                """)
+                                cursor.execute("""
+                                    CREATE INDEX idx_rl_embed_vec
+                                    ON ragleap_embeddings
+                                    USING hnsw (embedding vector_cosine_ops)
+                                """)
+                            else:
+                                cursor.execute("""
+                                    CREATE TABLE ragleap_embeddings (
+                                        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                                        chunk_id UUID REFERENCES ragleap_chunks(id) ON DELETE CASCADE,
+                                        embedding JSONB,
+                                        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+                                    )
+                                """)
+                            cursor.execute("CREATE INDEX idx_rl_embed_chunk ON ragleap_embeddings(chunk_id)")
+                            connection.commit()
+                            created.append('ragleap_embeddings')
+                    except Exception as e:
+                        connection.rollback()
+                        errors.append({'table': 'ragleap_embeddings', 'error': str(e)})
+
+                return {
+                    'supported': True,
+                    'created': created,
+                    'skipped': skipped,
+                    'errors': errors,
+                    'success': len(errors) == 0,
+                    'has_pgvector': has_pgvector,
+                    'db_type': 'postgresql',
+                }
+            finally:
+                connection.close()
+        except ImportError:
+            return {'supported': False, 'message': 'psycopg2 not installed'}
+        except Exception as e:
+            logger.error(f"PostgreSQL schema creation error: {e}")
+            return {'supported': True, 'success': False, 'error': str(e)}
+
+    def insert_document(self, table_name: str, title: str, content: str,
+                        metadata: Optional[Dict] = None, source_type: str = 'upload') -> Dict[str, Any]:
+        try:
+            import psycopg2
+
+            connection = psycopg2.connect(self.data_source.connection_string, connect_timeout=10)
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute(
+                        f'INSERT INTO "{table_name}" (title, content, metadata, created_at) '
+                        "VALUES (%s, %s, %s, NOW()) RETURNING id",
+                        (title, content, json.dumps(metadata or {})),
+                    )
+                    row = cursor.fetchone()
+                    connection.commit()
+                    doc_id = str(row[0]) if row else None
+                    return {'success': True, 'id': doc_id}
+            finally:
+                connection.close()
+        except Exception as e:
+            logger.error(f"PostgreSQL insert_document error: {e}")
+            return {'success': False, 'error': str(e)}

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -28,3 +28,53 @@ CREATE TABLE IF NOT EXISTS chunks (
 -- that limit, matching the same workaround used in RagLeap's production schema.
 CREATE INDEX IF NOT EXISTS chunks_embedding_idx
     ON chunks USING hnsw ((embedding::halfvec(3072)) halfvec_cosine_ops);
+
+-- Integrations: external data sources (databases, CRMs, SaaS APIs) that can
+-- sync per-user context into RAG responses. Single-tenant — no workspace scoping.
+CREATE TABLE IF NOT EXISTS data_sources (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL UNIQUE,
+    source_type TEXT NOT NULL,
+
+    -- Connection details (encrypted at the application layer via Fernet
+    -- before being written here — never store plaintext credentials)
+    connection_string TEXT,
+    api_endpoint TEXT,
+    api_key TEXT,
+    api_headers JSONB DEFAULT '{}',
+
+    -- Query configuration
+    query_template TEXT,
+    field_mappings JSONB DEFAULT '{}',
+    user_identifier_field TEXT NOT NULL DEFAULT 'user_id',
+    documents_table_name TEXT NOT NULL DEFAULT 'documents',
+
+    -- Sync configuration
+    sync_interval_minutes INTEGER NOT NULL DEFAULT 360,
+    last_sync_at TIMESTAMPTZ,
+    last_sync_status TEXT NOT NULL DEFAULT 'pending',
+    last_sync_error TEXT,
+    last_sync_record_count INTEGER NOT NULL DEFAULT 0,
+
+    is_active BOOLEAN NOT NULL DEFAULT true,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Customer/user context synced from external data sources, used to
+-- personalize RAG responses.
+CREATE TABLE IF NOT EXISTS synced_context_data (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    data_source_id UUID NOT NULL REFERENCES data_sources(id) ON DELETE CASCADE,
+    user_identifier TEXT NOT NULL,
+    context_data JSONB NOT NULL DEFAULT '{}',
+    synced_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_updated TIMESTAMPTZ NOT NULL DEFAULT now(),
+    source_updated_at TIMESTAMPTZ,
+    UNIQUE (data_source_id, user_identifier)
+);
+
+CREATE INDEX IF NOT EXISTS synced_context_data_lookup_idx
+    ON synced_context_data (data_source_id, user_identifier);
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,14 @@ websockets>=12.0
 audioop-lts>=0.2; python_version >= "3.13"
 neo4j>=5.0
 langdetect>=1.0.9
+
+# Integrations (all optional — connectors degrade gracefully if a specific
+# SDK isn't installed; only install the ones for the sources you use)
+pymysql>=1.1.0
+psycopg2-binary>=2.9.0
+pymongo>=4.6.0
+simple-salesforce>=1.12.0
+hubspot-api-client>=8.2.0
+ShopifyAPI>=12.5.0
+gspread>=6.0.0
+stripe>=8.0.0


### PR DESCRIPTION
## Summary

Opens the integrations/CRM connectors feature, ported from production's \`api/addon_models.py\` + \`api/addon_services.py\` (single-tenant, Django ORM replaced with a plain dataclass + psycopg2).

## What's included

- \`core/integrations/base.py\` — \`DataSource\` dataclass, \`BaseDatabaseConnector\` abstract class, security blacklists, Fernet encryption helpers
- 9 connectors across \`sql_connectors.py\` (MySQL, PostgreSQL), \`mongodb.py\`, \`rest_api.py\`, and \`crm_connectors.py\` (Salesforce, HubSpot, Shopify, Google Sheets, Stripe)
- \`factory.py\` — connector dispatch, \`service.py\` — DB CRUD + sync orchestration
- New \`/integrations\`, \`/integrations/{id}/test\`, \`/integrations/{id}/sync\` endpoints
- \`data_sources\` and \`synced_context_data\` tables in \`db/schema.sql\`
- All 9 connector SDKs added as dependencies, each degrading gracefully with a clear error if its SDK isn't installed

## BYOK confirmed across the board

Checked each CRM/SaaS connector's auth method specifically before porting: Salesforce (username/password/token), HubSpot (private-app token), Shopify (admin API token), Google Sheets (service-account JSON), Stripe (secret key). None require a RagLeap-owned OAuth app registration — fully compatible with this project's BYOK, self-hosted model.

## Bug found and fixed (pre-existing, unrelated to this feature)

\`core/api.py\` had a duplicated \`ChatRequest\`/\`ChatResponse\`/\`UploadResponse\` block plus a dangling orphaned type annotation inside \`health()\` — leftover from an earlier edit. Cleaned up while I was in the file.

## Testing

Verified end-to-end against a real public API (JSONPlaceholder): data source creation, connection test, and sync — including confirming correct field-matching behavior (0 records synced with a mismatched identifier field, the real count of 10 once corrected). Confirmed encryption is genuinely applied — checked actual ciphertext in the database, not just assumed — and correctly decrypts back to the original plaintext. Confirmed all 4 tables (2 new) are created correctly via a true fresh-volume \`schema.sql\` init.

## Known scope limits

- 9 of the 18 source types shown in production's UI have real connector implementations. CSV Upload, Snowflake, BigQuery, WooCommerce, Airtable, Notion, Razorpay, Slack, and Gmail are listed as options in production but have no corresponding connector class there either — good-first-issue candidates.
- Sync is on-demand only for now; \`sync_interval_minutes\` is tracked in the schema for a future scheduled-sync feature.
- Synced context isn't yet auto-injected into chat responses — each channel adapter would need to know its own user's identifier first. Reasonable next step, out of scope here.