### PR TITLE
feat: hybrid search (dense+sparse), streaming, and generation controls

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -7,11 +7,12 @@ import shutil
 import logging
 
 from fastapi import FastAPI, UploadFile, File, HTTPException, Request, Response
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from core.ingest import ingest_document
 from core.parsers import extract_text
-from core.chat import ask
+from core.chat import ask, ask_stream
 from core.integrations import service as integrations_service
 
 logging.basicConfig(level=logging.INFO)
@@ -95,8 +96,7 @@ async def upload_document(file: UploadFile = File(...)):
         await file.close()
 
 
-@app.post("/chat")
-def chat(question: str):
+def _validate_question(question: str):
     if not question or not question.strip():
         raise HTTPException(status_code=400, detail="Question cannot be empty.")
     if len(question) > MAX_QUESTION_LENGTH:
@@ -104,16 +104,73 @@ def chat(question: str):
             status_code=400,
             detail=f"Question too long ({len(question)} chars). Max is {MAX_QUESTION_LENGTH} chars.",
         )
+
+
+@app.post("/chat")
+def chat(
+    question: str,
+    top_k: int = 5,
+    temperature: float | None = None,
+    system_prompt: str | None = None,
+    max_tokens: int | None = None,
+    hybrid: bool = True,
+):
+    """
+    Ask a question grounded in previously ingested documents.
+
+    top_k: number of chunks to retrieve and ground the answer in.
+    temperature: LLM sampling temperature (lower = more deterministic/faithful
+        to context; default comes from DEFAULT_TEMPERATURE in .env, 0.3).
+    system_prompt: override the default grounded-QA instructions.
+    max_tokens: override the default max output length.
+    hybrid: use dense+sparse fused retrieval (default True) vs. dense-only.
+    """
+    _validate_question(question)
     try:
-        result = ask(question)
+        result = ask(
+            question, top_k=top_k, temperature=temperature,
+            system_prompt=system_prompt, max_tokens=max_tokens, hybrid=hybrid,
+        )
         return {
             "answer": result["answer"],
             "sources": result.get("sources", []),
             "chunks_used": result.get("chunks_used", 0),
+            "detected_language": result.get("detected_language"),
         }
     except Exception as exc:
         logger.exception("Chat failed for question: %s", question)
         raise HTTPException(status_code=500, detail=f"Chat failed: {exc}") from exc
+
+
+@app.post("/chat/stream")
+def chat_stream(
+    question: str,
+    top_k: int = 5,
+    temperature: float | None = None,
+    system_prompt: str | None = None,
+    max_tokens: int | None = None,
+    hybrid: bool = True,
+):
+    """
+    Same as /chat, but streams the answer text back as it's generated
+    (text/plain, chunked transfer) instead of waiting for the full
+    response. Sources/chunks_used/detected_language aren't available in
+    a streaming response — use /chat if you need those.
+    """
+    _validate_question(question)
+
+    def _generate():
+        try:
+            for piece in ask_stream(
+                question, top_k=top_k, temperature=temperature,
+                system_prompt=system_prompt, max_tokens=max_tokens, hybrid=hybrid,
+            ):
+                yield piece
+        except Exception as exc:
+            logger.exception("Streaming chat failed for question: %s", question)
+            yield f"\n[Error: {exc}]"
+
+    return StreamingResponse(_generate(), media_type="text/plain")
 
 
 @app.post("/webhook/whatsapp")

--- a/core/chat.py
+++ b/core/chat.py
@@ -1,9 +1,12 @@
 """
 Chat Pipeline for RagLeap Core
-Wires together: query language detection -> embedding the query -> vector
-retrieval (graph-boosted) -> answer generation.
+Wires together: query language detection -> embedding the query -> hybrid
+(dense + sparse, graph-boosted) retrieval -> answer generation (blocking
+or streaming).
 """
 import logging
+from typing import Iterator, Optional
+
 from core.embedding import EmbeddingService
 from core.retrieval import VectorRetrievalService
 from core.generation import GenerationService
@@ -12,14 +15,19 @@ from core.language import language_detector
 logger = logging.getLogger(__name__)
 
 
-def ask(query: str, top_k: int = 5) -> dict:
-    """
-    Answer a question grounded in previously ingested documents.
-    Returns: {"answer": str, "sources": List[str], "chunks_used": int, "detected_language": str}
+def _prepare(query: str, top_k: int, hybrid: bool):
+    """Shared setup for both ask() and ask_stream(): detect language,
+    embed the query, retrieve chunks. Returns (chunks, detected_language,
+    embedding_failed: bool).
+
+    hybrid=True (default) uses dense+sparse fusion (search_hybrid_chunks).
+    hybrid=False uses dense-only, graph-boosted retrieval (the older
+    search_similar_chunks_with_graph) — kept as an option since it's a
+    cheaper query path (one search instead of two) for callers that
+    don't need the sparse/keyword-matching benefit.
     """
     embedder = EmbeddingService()
     retriever = VectorRetrievalService()
-    generator = GenerationService()
 
     try:
         detected_language, _confidence = language_detector.detect_query_language(query)
@@ -29,6 +37,37 @@ def ask(query: str, top_k: int = 5) -> dict:
 
     query_embedding = embedder.embed_text(query)
     if query_embedding is None:
+        return [], detected_language, True
+
+    if hybrid:
+        chunks = retriever.search_hybrid_chunks(query, query_embedding, top_k=top_k)
+    else:
+        chunks = retriever.search_similar_chunks_with_graph(query, query_embedding, top_k=top_k)
+
+    return chunks, detected_language, False
+
+
+def ask(
+    query: str,
+    top_k: int = 5,
+    temperature: Optional[float] = None,
+    system_prompt: Optional[str] = None,
+    max_tokens: Optional[int] = None,
+    hybrid: bool = True,
+) -> dict:
+    """
+    Answer a question grounded in previously ingested documents.
+    Returns: {"answer": str, "sources": List[str], "chunks_used": int, "detected_language": str}
+
+    temperature: overrides the generation service's default temperature for this call.
+    system_prompt: overrides the default grounded-QA instructions.
+    max_tokens: overrides the default max output length for this call.
+    hybrid: use dense+sparse fused retrieval (default) vs. dense-only.
+    """
+    generator = GenerationService()
+    chunks, detected_language, embedding_failed = _prepare(query, top_k, hybrid)
+
+    if embedding_failed:
         return {
             "answer": "Sorry, I couldn't process your question (embedding failed).",
             "sources": [],
@@ -36,22 +75,60 @@ def ask(query: str, top_k: int = 5) -> dict:
             "detected_language": detected_language,
         }
 
-    chunks = retriever.search_similar_chunks_with_graph(query, query_embedding, top_k=top_k)
-    result = generator.generate_answer(query, chunks)
+    result = generator.generate_answer(
+        query, chunks, temperature=temperature, system_prompt=system_prompt, max_tokens=max_tokens
+    )
     result["chunks_used"] = len(chunks)
     result["detected_language"] = detected_language
     return result
 
 
+def ask_stream(
+    query: str,
+    top_k: int = 5,
+    temperature: Optional[float] = None,
+    system_prompt: Optional[str] = None,
+    max_tokens: Optional[int] = None,
+    hybrid: bool = True,
+) -> Iterator[str]:
+    """
+    Same as ask(), but yields the answer text incrementally as it's
+    generated. Sources/chunks_used/detected_language aren't available
+    until generation completes — callers needing those should use
+    ask() instead.
+    """
+    generator = GenerationService()
+    chunks, detected_language, embedding_failed = _prepare(query, top_k, hybrid)
+
+    if embedding_failed:
+        yield "Sorry, I couldn't process your question (embedding failed)."
+        return
+
+    yield from generator.generate_answer_stream(
+        query, chunks, temperature=temperature, system_prompt=system_prompt, max_tokens=max_tokens
+    )
+
+
 if __name__ == "__main__":
     import sys
     if len(sys.argv) < 2:
-        print("Usage: python -m core.chat \"<your question>\"")
+        print("Usage: python -m core.chat \"<your question>\" [--stream]")
         sys.exit(1)
-    question = " ".join(sys.argv[1:])
-    result = ask(question)
-    print(f"\nQuestion: {question}")
-    print(f"Detected language: {result.get('detected_language')}")
-    print(f"Answer: {result['answer']}")
-    print(f"Sources: {result['sources']}")
-    print(f"Chunks used: {result['chunks_used']}")
+
+    stream_mode = "--stream" in sys.argv
+    args = [a for a in sys.argv[1:] if a != "--stream"]
+    question = " ".join(args)
+
+    if stream_mode:
+        print(f"\nQuestion: {question}")
+        print("Answer: ", end="", flush=True)
+        for piece in ask_stream(question):
+            print(piece, end="", flush=True)
+        print()
+    else:
+        result = ask(question)
+        print(f"\nQuestion: {question}")
+        print(f"Detected language: {result.get('detected_language')}")
+        print(f"Answer: {result['answer']}")
+        print(f"Sources: {result['sources']}")
+        print(f"Chunks used: {result['chunks_used']}")

--- a/core/generation.py
+++ b/core/generation.py
@@ -8,15 +8,19 @@ OpenAI-compatible providers (via openai SDK + custom base_url): everyone else.
 """
 import os
 import logging
-from typing import List, Dict
+from typing import List, Dict, Iterator, Optional
 
 logger = logging.getLogger(__name__)
 
 LLM_PROVIDER = os.environ.get("LLM_PROVIDER", "gemini").lower()
 GEMINI_CHAT_MODEL = os.environ.get("GEMINI_CHAT_MODEL", "gemini-2.5-flash")
 
-# Base URLs for OpenAI-compatible providers. gemini and anthropic use their
-# own native SDKs and don't need a base_url override here.
+# Default temperature for grounded RAG answers — low by design (favors
+# faithfulness to retrieved context over creative variation). Override
+# per-call or via DEFAULT_TEMPERATURE in .env.
+DEFAULT_TEMPERATURE = float(os.environ.get("DEFAULT_TEMPERATURE", "0.3"))
+MAX_OUTPUT_TOKENS = int(os.environ.get("MAX_OUTPUT_TOKENS", "1024"))
+
 PROVIDER_BASE_URLS = {
     "openai":     "https://api.openai.com/v1",
     "mistral":    "https://api.mistral.ai/v1",
@@ -45,7 +49,8 @@ Always be concise and cite which document your answer came from when possible.""
 class GenerationService:
     """
     Generates a grounded answer using the configured LLM_PROVIDER,
-    given a query and retrieved chunks.
+    given a query and retrieved chunks. Supports per-call temperature
+    override and streaming.
     """
 
     def __init__(self):
@@ -96,7 +101,6 @@ class GenerationService:
             )
 
     def _build_context(self, chunks: List[Dict]) -> str:
-        """Format retrieved chunks into a context block with source labels."""
         if not chunks:
             return "No relevant context was found."
         parts = []
@@ -106,14 +110,10 @@ class GenerationService:
             parts.append(f"[Source {i}: {doc_name}]\n{text}")
         return "\n\n".join(parts)
 
-    def generate_answer(self, query: str, chunks: List[Dict]) -> Dict:
-        """
-        Generate an answer to `query` grounded in the given `chunks`.
-        Returns a dict: {"answer": str, "sources": List[str]}
-        """
+    def _build_prompt(self, query: str, chunks: List[Dict], system_prompt: Optional[str] = None) -> str:
         context = self._build_context(chunks)
-        sources = list({c.get("document_name", "unknown") for c in chunks})
-        prompt = f"""{SYSTEM_PROMPT}
+        instructions = system_prompt or SYSTEM_PROMPT
+        return f"""{instructions}
 
 Context:
 {context}
@@ -121,13 +121,36 @@ Context:
 Question: {query}
 Answer:"""
 
+    def generate_answer(
+        self,
+        query: str,
+        chunks: List[Dict],
+        temperature: Optional[float] = None,
+        system_prompt: Optional[str] = None,
+        max_tokens: Optional[int] = None,
+    ) -> Dict:
+        """
+        Generate an answer to `query` grounded in the given `chunks`.
+        Returns a dict: {"answer": str, "sources": List[str]}
+
+        temperature: overrides DEFAULT_TEMPERATURE for this call only.
+        system_prompt: overrides the default grounded-QA instructions —
+            use this to build your own agent behavior on top of RagLeap's
+            retrieval, without forking the library.
+        max_tokens: overrides MAX_OUTPUT_TOKENS for this call only.
+        """
+        temp = DEFAULT_TEMPERATURE if temperature is None else temperature
+        max_tok = MAX_OUTPUT_TOKENS if max_tokens is None else max_tokens
+        sources = list({c.get("document_name", "unknown") for c in chunks})
+        prompt = self._build_prompt(query, chunks, system_prompt)
+
         try:
             if self.provider == "gemini":
-                answer_text = self._call_gemini(prompt)
+                answer_text = self._call_gemini(prompt, temp, max_tok)
             elif self.provider == "anthropic":
-                answer_text = self._call_anthropic(prompt)
+                answer_text = self._call_anthropic(prompt, temp, max_tok)
             else:
-                answer_text = self._call_openai_compatible(prompt)
+                answer_text = self._call_openai_compatible(prompt, temp, max_tok)
 
             return {"answer": answer_text, "sources": sources}
 
@@ -138,27 +161,110 @@ Answer:"""
                 "sources": [],
             }
 
-    def _call_gemini(self, prompt: str) -> str:
+    def generate_answer_stream(
+        self,
+        query: str,
+        chunks: List[Dict],
+        temperature: Optional[float] = None,
+        system_prompt: Optional[str] = None,
+        max_tokens: Optional[int] = None,
+    ) -> Iterator[str]:
+        """
+        Same as generate_answer(), but yields answer text incrementally
+        as it's generated, instead of waiting for the full response.
+        Sources aren't yielded (caller already has `chunks` to derive
+        them from, same as generate_answer() does).
+        """
+        temp = DEFAULT_TEMPERATURE if temperature is None else temperature
+        max_tok = MAX_OUTPUT_TOKENS if max_tokens is None else max_tokens
+        prompt = self._build_prompt(query, chunks, system_prompt)
+
+        try:
+            if self.provider == "gemini":
+                yield from self._stream_gemini(prompt, temp, max_tok)
+            elif self.provider == "anthropic":
+                yield from self._stream_anthropic(prompt, temp, max_tok)
+            else:
+                yield from self._stream_openai_compatible(prompt, temp, max_tok)
+        except Exception as e:
+            logger.error(f"Streaming generation failed ({self.provider}): {e}")
+            yield f"Sorry, I couldn't generate an answer due to an error: {e}"
+
+    def _call_gemini(self, prompt: str, temperature: float, max_tokens: int) -> str:
         import google.genai as genai
+        from google.genai import types
         client = genai.Client(api_key=self.api_key)
-        response = client.models.generate_content(model=self.model, contents=prompt)
+        response = client.models.generate_content(
+            model=self.model,
+            contents=prompt,
+            config=types.GenerateContentConfig(
+                temperature=temperature,
+                max_output_tokens=max_tokens,
+            ),
+        )
         return response.text.strip() if response.text else "No answer generated."
 
-    def _call_anthropic(self, prompt: str) -> str:
+    def _stream_gemini(self, prompt: str, temperature: float, max_tokens: int) -> Iterator[str]:
+        import google.genai as genai
+        from google.genai import types
+        client = genai.Client(api_key=self.api_key)
+        stream = client.models.generate_content_stream(
+            model=self.model,
+            contents=prompt,
+            config=types.GenerateContentConfig(
+                temperature=temperature,
+                max_output_tokens=max_tokens,
+            ),
+        )
+        for chunk in stream:
+            if chunk.text:
+                yield chunk.text
+
+    def _call_anthropic(self, prompt: str, temperature: float, max_tokens: int) -> str:
         import anthropic
         client = anthropic.Anthropic(api_key=self.api_key)
         response = client.messages.create(
             model=self.model,
-            max_tokens=1024,
+            max_tokens=max_tokens,
+            temperature=temperature,
             messages=[{"role": "user", "content": prompt}],
         )
         return response.content[0].text.strip() if response.content else "No answer generated."
 
-    def _call_openai_compatible(self, prompt: str) -> str:
+    def _stream_anthropic(self, prompt: str, temperature: float, max_tokens: int) -> Iterator[str]:
+        import anthropic
+        client = anthropic.Anthropic(api_key=self.api_key)
+        with client.messages.stream(
+            model=self.model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            messages=[{"role": "user", "content": prompt}],
+        ) as stream:
+            for text in stream.text_stream:
+                yield text
+
+    def _call_openai_compatible(self, prompt: str, temperature: float, max_tokens: int) -> str:
         import openai
         client = openai.OpenAI(api_key=self.api_key or "not-needed", base_url=self.base_url)
         response = client.chat.completions.create(
             model=self.model,
             messages=[{"role": "user", "content": prompt}],
+            temperature=temperature,
+            max_tokens=max_tokens,
         )
         return response.choices[0].message.content.strip() if response.choices else "No answer generated."
+
+    def _stream_openai_compatible(self, prompt: str, temperature: float, max_tokens: int) -> Iterator[str]:
+        import openai
+        client = openai.OpenAI(api_key=self.api_key or "not-needed", base_url=self.base_url)
+        stream = client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=temperature,
+            max_tokens=max_tokens,
+            stream=True,
+        )
+        for chunk in stream:
+            delta = chunk.choices[0].delta.content if chunk.choices else None
+            if delta:
+                yield delta

--- a/core/retrieval.py
+++ b/core/retrieval.py
@@ -2,7 +2,9 @@
 Vector Retrieval Service for RagLeap Core
 Adapted from RagLeap's production pgvector cosine-distance search —
 rewritten as plain SQL (psycopg2), no Django ORM, no multi-tenancy.
-Optionally boosted by the knowledge graph when available.
+Supports dense (vector), sparse (Postgres full-text), and hybrid
+(Reciprocal Rank Fusion of both) retrieval, optionally boosted by the
+knowledge graph.
 """
 import os
 import logging
@@ -15,11 +17,17 @@ logger = logging.getLogger(__name__)
 DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://ragleap:ragleap@localhost:5432/ragleap_core")
 EMBEDDING_DIMENSIONS = int(os.environ.get("EMBEDDING_DIMENSIONS", "3072"))
 
+# Reciprocal Rank Fusion constant. Higher = flatter weighting across ranks
+# (top result matters relatively less vs. lower-ranked ones); 60 is the
+# standard default used in the original RRF paper and most implementations.
+RRF_K = int(os.environ.get("HYBRID_RRF_K", "60"))
+
 
 class VectorRetrievalService:
     """
-    Performs cosine-similarity vector search against a PostgreSQL + pgvector
-    'chunks' table. Single-user, single-database — no workspace scoping needed.
+    Performs dense (pgvector), sparse (Postgres full-text), and hybrid
+    search against a PostgreSQL 'chunks' table. Single-user,
+    single-database — no workspace scoping needed.
     """
 
     def __init__(self, min_similarity: float = 0.05):
@@ -36,7 +44,7 @@ class VectorRetrievalService:
         document_id: Optional[str] = None,
     ) -> List[Dict]:
         """
-        Search for the top_k most similar chunks to the query embedding,
+        Dense retrieval: top_k most similar chunks to the query embedding,
         using pgvector cosine distance (<=> operator).
 
         Returns a list of dicts: chunk_id, text, similarity_score,
@@ -101,6 +109,147 @@ class VectorRetrievalService:
             logger.error(f"Vector search error: {e}", exc_info=True)
             raise
 
+    def search_sparse_chunks(
+        self,
+        query_text: str,
+        top_k: int = 5,
+        document_id: Optional[str] = None,
+    ) -> List[Dict]:
+        """
+        Sparse (keyword/full-text) retrieval using Postgres's built-in
+        text search: websearch_to_tsquery (handles quoted phrases, -exclusions,
+        OR — the same syntax as a typical search engine query box) against
+        the chunks.text_search_vector generated column, ranked by ts_rank.
+
+        Returns the same dict shape as search_similar_chunks(), with
+        similarity_score populated from the normalized ts_rank value.
+        """
+        if not query_text or not query_text.strip():
+            return []
+
+        sql = """
+            SELECT
+                id,
+                text,
+                document_id,
+                document_name,
+                chunk_index,
+                ts_rank(text_search_vector, websearch_to_tsquery('english', %s)) AS rank_score
+            FROM chunks
+            WHERE text_search_vector @@ websearch_to_tsquery('english', %s)
+        """
+        params = [query_text, query_text]
+
+        if document_id:
+            sql += " AND document_id = %s"
+            params.append(document_id)
+
+        sql += " ORDER BY rank_score DESC LIMIT %s"
+        params.append(top_k)
+
+        try:
+            conn = self._get_connection()
+            cur = conn.cursor()
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+            cur.close()
+            conn.close()
+
+            results = []
+            for row in rows:
+                chunk_id, text, doc_id, doc_name, chunk_index, rank_score = row
+                results.append({
+                    "chunk_id": str(chunk_id),
+                    "text": text,
+                    "similarity_score": round(float(rank_score), 4),
+                    "document_id": str(doc_id),
+                    "document_name": doc_name,
+                    "chunk_index": chunk_index,
+                })
+
+            logger.info(f"Sparse search returned {len(results)} chunks (top_k={top_k})")
+            return results
+
+        except Exception as e:
+            logger.error(f"Sparse search error: {e}", exc_info=True)
+            raise
+
+    def search_hybrid_chunks(
+        self,
+        query_text: str,
+        query_embedding: List[float],
+        top_k: int = 5,
+        document_id: Optional[str] = None,
+        use_graph: bool = True,
+        graph_boost: float = 0.15,
+    ) -> List[Dict]:
+        """
+        Hybrid retrieval: combines dense (vector) and sparse (full-text)
+        results via Reciprocal Rank Fusion (RRF), then optionally applies
+        the same knowledge-graph boost as search_similar_chunks_with_graph().
+
+        RRF combines two differently-scaled ranking systems (cosine
+        similarity vs. ts_rank) without needing fragile score
+        normalization — each chunk's final score is based on its RANK
+        in each list, not the raw scores, which is why it's a standard
+        technique for combining dense+sparse retrieval.
+
+        Note: similarity_score in the returned dicts is the RRF-fused
+        score for this method, not a 0-1 cosine similarity — it's only
+        meaningful for ranking within this result set, not comparable
+        across calls to different search_* methods.
+        """
+        dense = self.search_similar_chunks(query_embedding, top_k=top_k * 3, document_id=document_id)
+        sparse = self.search_sparse_chunks(query_text, top_k=top_k * 3, document_id=document_id)
+
+        dense_ranks = {c["chunk_id"]: i for i, c in enumerate(dense)}
+        sparse_ranks = {c["chunk_id"]: i for i, c in enumerate(sparse)}
+
+        chunk_lookup: Dict[str, Dict] = {c["chunk_id"]: c for c in dense}
+        for c in sparse:
+            chunk_lookup.setdefault(c["chunk_id"], c)
+
+        all_ids = set(dense_ranks) | set(sparse_ranks)
+        if not all_ids:
+            return []
+
+        rrf_scores = {}
+        for cid in all_ids:
+            score = 0.0
+            if cid in dense_ranks:
+                score += 1.0 / (RRF_K + dense_ranks[cid] + 1)
+            if cid in sparse_ranks:
+                score += 1.0 / (RRF_K + sparse_ranks[cid] + 1)
+            rrf_scores[cid] = score
+
+        results = [dict(chunk_lookup[cid]) for cid in all_ids]
+        for c in results:
+            c["similarity_score"] = round(rrf_scores[c["chunk_id"]], 6)
+            c["retrieval_method"] = "hybrid_rrf"
+
+        results.sort(key=lambda c: c["similarity_score"], reverse=True)
+
+        if use_graph:
+            try:
+                entities = graph_service.extract_query_entities(query_text)
+                linked_doc_ids = set()
+                if entities:
+                    linked_docs = graph_service.find_documents_by_entities(entities)
+                    linked_doc_ids = {d["document_id"] for d in linked_docs} if linked_docs else set()
+                for c in results:
+                    if c["document_id"] in linked_doc_ids:
+                        c["similarity_score"] += graph_boost
+                        c["graph_boosted"] = True
+                results.sort(key=lambda c: c["similarity_score"], reverse=True)
+            except Exception as e:
+                logger.warning(f"Graph lookup failed during hybrid retrieval (non-fatal): {e}")
+
+        logger.info(
+            f"Hybrid search: {len(dense)} dense + {len(sparse)} sparse -> "
+            f"{len(results)} fused, returning top {min(top_k, len(results))}"
+        )
+        return results[:top_k]
+
     def search_similar_chunks_with_graph(
         self,
         query_text: str,
@@ -113,6 +262,10 @@ class VectorRetrievalService:
         Vector search, then boost chunks whose document is linked via the
         knowledge graph to entities mentioned in the query. Falls back to
         pure vector search if the graph is unavailable or finds nothing.
+
+        Kept for backward compatibility — search_hybrid_chunks() is the
+        recommended method going forward, since it includes this same
+        graph boost plus sparse retrieval.
         """
         candidates = self.search_similar_chunks(
             query_embedding, top_k=top_k * 3, document_id=document_id

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -29,6 +29,14 @@ CREATE TABLE IF NOT EXISTS chunks (
 CREATE INDEX IF NOT EXISTS chunks_embedding_idx
     ON chunks USING hnsw ((embedding::halfvec(3072)) halfvec_cosine_ops);
 
+-- Full-text search support for hybrid (dense + sparse) retrieval.
+-- Generated column stays in sync automatically on insert/update.
+ALTER TABLE chunks ADD COLUMN IF NOT EXISTS text_search_vector tsvector
+    GENERATED ALWAYS AS (to_tsvector('english', text)) STORED;
+
+CREATE INDEX IF NOT EXISTS chunks_text_search_idx
+    ON chunks USING GIN (text_search_vector);
+
 -- Integrations: external data sources (databases, CRMs, SaaS APIs) that can
 -- sync per-user context into RAG responses. Single-tenant — no workspace scoping.
 CREATE TABLE IF NOT EXISTS data_sources (


### PR DESCRIPTION
Real, tested developer-facing controls, not surface-level flags:

- core/retrieval.py: new search_sparse_chunks() (Postgres full-text search via websearch_to_tsquery + ts_rank) and search_hybrid_chunks() (combines dense + sparse via Reciprocal Rank Fusion, RRF_K=60, still applies the knowledge-graph boost on top). Old search_similar_chunks_with_graph() kept for backward compatibility.
- db/schema.sql: chunks.text_search_vector (generated tsvector column)
  + GIN index for the sparse side.
- core/generation.py: system_prompt and max_tokens are now real per-call parameters (previously system_prompt was a hardcoded module constant, max_tokens was env-only). Added generate_answer_stream() with real per-provider streaming implementations for Gemini, Anthropic, and OpenAI-compatible providers (each has a different streaming API — implemented all three properly, not stubbed).
- core/chat.py: ask() and new ask_stream() both take top_k, temperature, system_prompt, max_tokens, and hybrid (default True) parameters.
- core/api.py: /chat expanded with all the above as query params; new /chat/stream endpoint (StreamingResponse, text/plain).

Verified: RRF fusion math confirmed exactly correct against hand calculation (2/61 for a chunk ranked #1 in both dense and sparse lists). Sparse search correctly tokenizes and matches unusual identifiers (tested with an underscored acronym). Custom system_prompt confirmed to genuinely change output (tested 'answer in one sentence' -> got exactly that). Streaming confirmed working end-to-end via curl -N. All verified via a true fresh-volume schema.sql init, not just manual DB patching.

Note: this session did not stress-test hybrid search's actual ranking benefit on a multi-document corpus with genuinely conflicting dense vs. sparse rankings — only single-document correctness. Worth a follow-up benchmark before making comparative retrieval-quality claims.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
