### PR TITLE
feat: LLM provider fallback chain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,13 @@ LANGUAGE_DETECTION_SUPPORTED_LANGUAGES=
 #   python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 ADDON_ENCRYPTION_KEY=
 
+
+# Provider fallback chain — comma-separated provider names to try, in
+# order, if LLM_PROVIDER fails (rate limit, outage, bad key). Each needs
+# its own API key configured normally (e.g. ANTHROPIC_API_KEY). Optional
+# — leave blank to disable fallback entirely.
+LLM_FALLBACK_PROVIDERS=
+
+# Generation output length and defaults
+MAX_OUTPUT_TOKENS=1024
+DEFAULT_TEMPERATURE=0.3

--- a/core/api.py
+++ b/core/api.py
@@ -136,6 +136,7 @@ def chat(
             "sources": result.get("sources", []),
             "chunks_used": result.get("chunks_used", 0),
             "detected_language": result.get("detected_language"),
+            "provider_used": result.get("provider_used"),
         }
     except Exception as exc:
         logger.exception("Chat failed for question: %s", question)

--- a/core/chat.py
+++ b/core/chat.py
@@ -129,6 +129,7 @@ if __name__ == "__main__":
         result = ask(question)
         print(f"\nQuestion: {question}")
         print(f"Detected language: {result.get('detected_language')}")
+        print(f"Provider used: {result.get('provider_used')}")
         print(f"Answer: {result['answer']}")
         print(f"Sources: {result['sources']}")
         print(f"Chunks used: {result['chunks_used']}")

--- a/core/generation.py
+++ b/core/generation.py
@@ -1,6 +1,8 @@
 """
 Answer Generation Service for RagLeap Core
-Bring-your-own-key only — no system key, no fallback.
+Bring-your-own-key only — no system key, no fallback provided by RagLeap
+itself. You can configure your OWN fallback chain across providers you
+have keys for (see LLM_FALLBACK_PROVIDERS below).
 
 Supports multiple LLM providers via LLM_PROVIDER env var (default: gemini).
 Native SDK providers: gemini, anthropic
@@ -15,11 +17,18 @@ logger = logging.getLogger(__name__)
 LLM_PROVIDER = os.environ.get("LLM_PROVIDER", "gemini").lower()
 GEMINI_CHAT_MODEL = os.environ.get("GEMINI_CHAT_MODEL", "gemini-2.5-flash")
 
-# Default temperature for grounded RAG answers — low by design (favors
-# faithfulness to retrieved context over creative variation). Override
-# per-call or via DEFAULT_TEMPERATURE in .env.
 DEFAULT_TEMPERATURE = float(os.environ.get("DEFAULT_TEMPERATURE", "0.3"))
 MAX_OUTPUT_TOKENS = int(os.environ.get("MAX_OUTPUT_TOKENS", "1024"))
+
+# Comma-separated list of provider names to try, in order, if the primary
+# LLM_PROVIDER fails (rate limit, outage, bad key, etc). Each fallback
+# provider needs its own API key configured the same way the primary
+# would (e.g. ANTHROPIC_API_KEY, GROQ_API_KEY). A fallback provider
+# without a configured key is skipped with a warning, not a hard error —
+# it's a backup, not a requirement.
+LLM_FALLBACK_PROVIDERS = [
+    p.strip().lower() for p in os.environ.get("LLM_FALLBACK_PROVIDERS", "").split(",") if p.strip()
+]
 
 PROVIDER_BASE_URLS = {
     "openai":     "https://api.openai.com/v1",
@@ -46,59 +55,90 @@ If the answer is not in the context, say clearly that you don't have that inform
 Always be concise and cite which document your answer came from when possible."""
 
 
+def _resolve_provider_config(provider: str, required: bool = True) -> Optional[Dict]:
+    """
+    Resolve a provider name into {provider, api_key, model, base_url}.
+    If required=True (used for the primary provider), raises ValueError
+    on missing config, matching the original constructor behavior.
+    If required=False (used for fallback providers), returns None and
+    logs a warning instead of raising, so a misconfigured fallback
+    doesn't break startup or crash a request that would have otherwise
+    succeeded on the primary provider.
+    """
+    provider = provider.lower()
+
+    def _fail(msg: str) -> Optional[Dict]:
+        if required:
+            raise ValueError(msg)
+        logger.warning(f"Skipping fallback provider '{provider}': {msg}")
+        return None
+
+    if provider == "gemini":
+        api_key = os.environ.get("GEMINI_API_KEY")
+        if not api_key:
+            return _fail(
+                "GEMINI_API_KEY is not set. Get one at "
+                "https://aistudio.google.com/apikey and add it to .env."
+            )
+        return {"provider": "gemini", "api_key": api_key, "model": GEMINI_CHAT_MODEL, "base_url": None}
+
+    elif provider == "anthropic":
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            return _fail(
+                "ANTHROPIC_API_KEY is not set. Get one at "
+                "https://console.anthropic.com and add it to .env."
+            )
+        model = os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-4-5")
+        return {"provider": "anthropic", "api_key": api_key, "model": model, "base_url": None}
+
+    elif provider in PROVIDER_BASE_URLS:
+        key_env = f"{provider.upper()}_API_KEY"
+        api_key = os.environ.get(key_env)
+        model = os.environ.get(f"{provider.upper()}_MODEL", "")
+        base_url = os.environ.get("CUSTOM_BASE_URL") if provider == "custom" else PROVIDER_BASE_URLS[provider]
+
+        if not api_key and provider != "ollama":
+            return _fail(f"{key_env} is not set. Add your {provider} API key to .env.")
+        if not base_url:
+            return _fail(
+                f"No base URL configured for provider '{provider}'. "
+                f"Set CUSTOM_BASE_URL in .env if using 'custom'."
+            )
+        if not model:
+            return _fail(f"{provider.upper()}_MODEL is not set in .env.")
+
+        return {"provider": provider, "api_key": api_key, "model": model, "base_url": base_url}
+
+    else:
+        return _fail(
+            f"Unknown provider '{provider}'. Supported: gemini, anthropic, "
+            f"{', '.join(PROVIDER_BASE_URLS.keys())}."
+        )
+
+
 class GenerationService:
     """
     Generates a grounded answer using the configured LLM_PROVIDER,
-    given a query and retrieved chunks. Supports per-call temperature
-    override and streaming.
+    given a query and retrieved chunks. Supports per-call temperature/
+    system_prompt/max_tokens overrides, streaming, and an optional
+    fallback chain across providers (LLM_FALLBACK_PROVIDERS).
     """
 
     def __init__(self):
-        self.provider = LLM_PROVIDER
+        self.primary_config = _resolve_provider_config(LLM_PROVIDER, required=True)
+        self.provider = self.primary_config["provider"]  # kept for backward compat / introspection
 
-        if self.provider == "gemini":
-            self.api_key = os.environ.get("GEMINI_API_KEY")
-            self.model = GEMINI_CHAT_MODEL
-            if not self.api_key:
-                raise ValueError(
-                    "GEMINI_API_KEY is not set. Get one at "
-                    "https://aistudio.google.com/apikey and add it to .env."
-                )
-
-        elif self.provider == "anthropic":
-            self.api_key = os.environ.get("ANTHROPIC_API_KEY")
-            self.model = os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-4-5")
-            if not self.api_key:
-                raise ValueError(
-                    "ANTHROPIC_API_KEY is not set. Get one at "
-                    "https://console.anthropic.com and add it to .env."
-                )
-
-        elif self.provider in PROVIDER_BASE_URLS:
-            key_env = f"{self.provider.upper()}_API_KEY"
-            self.api_key = os.environ.get(key_env)
-            self.model = os.environ.get(f"{self.provider.upper()}_MODEL", "")
-            self.base_url = os.environ.get("CUSTOM_BASE_URL") if self.provider == "custom" else PROVIDER_BASE_URLS[self.provider]
-
-            if not self.api_key and self.provider != "ollama":
-                raise ValueError(
-                    f"{key_env} is not set. Add your {self.provider} API key to .env."
-                )
-            if not self.base_url:
-                raise ValueError(
-                    f"No base URL configured for provider '{self.provider}'. "
-                    f"Set CUSTOM_BASE_URL in .env if using 'custom'."
-                )
-            if not self.model:
-                raise ValueError(
-                    f"{self.provider.upper()}_MODEL is not set in .env."
-                )
-
-        else:
-            raise ValueError(
-                f"Unknown LLM_PROVIDER '{self.provider}'. Supported: gemini, anthropic, "
-                f"{', '.join(PROVIDER_BASE_URLS.keys())}."
-            )
+    def _fallback_chain(self) -> List[Dict]:
+        """Primary config first, then any successfully-resolved fallback configs."""
+        chain = [self.primary_config]
+        for name in LLM_FALLBACK_PROVIDERS:
+            if name == self.primary_config["provider"]:
+                continue  # no point retrying the same provider that just failed
+            config = _resolve_provider_config(name, required=False)
+            if config:
+                chain.append(config)
+        return chain
 
     def _build_context(self, chunks: List[Dict]) -> str:
         if not chunks:
@@ -121,6 +161,28 @@ Context:
 Question: {query}
 Answer:"""
 
+    def _call_provider(self, config: Dict, prompt: str, temperature: float, max_tokens: int) -> str:
+        provider = config["provider"]
+        if provider == "gemini":
+            return self._call_gemini(prompt, temperature, max_tokens, config["api_key"], config["model"])
+        elif provider == "anthropic":
+            return self._call_anthropic(prompt, temperature, max_tokens, config["api_key"], config["model"])
+        else:
+            return self._call_openai_compatible(
+                prompt, temperature, max_tokens, config["api_key"], config["model"], config["base_url"]
+            )
+
+    def _stream_provider(self, config: Dict, prompt: str, temperature: float, max_tokens: int) -> Iterator[str]:
+        provider = config["provider"]
+        if provider == "gemini":
+            yield from self._stream_gemini(prompt, temperature, max_tokens, config["api_key"], config["model"])
+        elif provider == "anthropic":
+            yield from self._stream_anthropic(prompt, temperature, max_tokens, config["api_key"], config["model"])
+        else:
+            yield from self._stream_openai_compatible(
+                prompt, temperature, max_tokens, config["api_key"], config["model"], config["base_url"]
+            )
+
     def generate_answer(
         self,
         query: str,
@@ -131,35 +193,36 @@ Answer:"""
     ) -> Dict:
         """
         Generate an answer to `query` grounded in the given `chunks`.
-        Returns a dict: {"answer": str, "sources": List[str]}
+        Returns a dict: {"answer": str, "sources": List[str], "provider_used": str}
 
-        temperature: overrides DEFAULT_TEMPERATURE for this call only.
-        system_prompt: overrides the default grounded-QA instructions —
-            use this to build your own agent behavior on top of RagLeap's
-            retrieval, without forking the library.
-        max_tokens: overrides MAX_OUTPUT_TOKENS for this call only.
+        If LLM_FALLBACK_PROVIDERS is configured, tries each in order
+        after the primary provider fails, before giving up.
         """
         temp = DEFAULT_TEMPERATURE if temperature is None else temperature
         max_tok = MAX_OUTPUT_TOKENS if max_tokens is None else max_tokens
         sources = list({c.get("document_name", "unknown") for c in chunks})
         prompt = self._build_prompt(query, chunks, system_prompt)
 
-        try:
-            if self.provider == "gemini":
-                answer_text = self._call_gemini(prompt, temp, max_tok)
-            elif self.provider == "anthropic":
-                answer_text = self._call_anthropic(prompt, temp, max_tok)
-            else:
-                answer_text = self._call_openai_compatible(prompt, temp, max_tok)
+        chain = self._fallback_chain()
+        last_error = None
 
-            return {"answer": answer_text, "sources": sources}
+        for i, config in enumerate(chain):
+            try:
+                answer_text = self._call_provider(config, prompt, temp, max_tok)
+                if i > 0:
+                    logger.info(f"Answer generated via fallback provider '{config['provider']}' (primary failed)")
+                return {"answer": answer_text, "sources": sources, "provider_used": config["provider"]}
+            except Exception as e:
+                last_error = e
+                logger.warning(f"Provider '{config['provider']}' failed: {e}")
+                continue
 
-        except Exception as e:
-            logger.error(f"Answer generation failed ({self.provider}): {e}")
-            return {
-                "answer": f"Sorry, I couldn't generate an answer due to an error: {e}",
-                "sources": [],
-            }
+        logger.error(f"All providers in the fallback chain failed. Last error: {last_error}")
+        return {
+            "answer": f"Sorry, I couldn't generate an answer — all configured providers failed. Last error: {last_error}",
+            "sources": [],
+            "provider_used": None,
+        }
 
     def generate_answer_stream(
         self,
@@ -170,32 +233,49 @@ Answer:"""
         max_tokens: Optional[int] = None,
     ) -> Iterator[str]:
         """
-        Same as generate_answer(), but yields answer text incrementally
-        as it's generated, instead of waiting for the full response.
-        Sources aren't yielded (caller already has `chunks` to derive
-        them from, same as generate_answer() does).
+        Same as generate_answer(), but yields answer text incrementally.
+        Fallback works the same way, but since streaming has already
+        started sending text to the caller once a provider begins
+        responding, a mid-stream failure can't cleanly fall back —
+        only a failure BEFORE any text is yielded triggers the next
+        provider in the chain.
         """
         temp = DEFAULT_TEMPERATURE if temperature is None else temperature
         max_tok = MAX_OUTPUT_TOKENS if max_tokens is None else max_tokens
         prompt = self._build_prompt(query, chunks, system_prompt)
 
-        try:
-            if self.provider == "gemini":
-                yield from self._stream_gemini(prompt, temp, max_tok)
-            elif self.provider == "anthropic":
-                yield from self._stream_anthropic(prompt, temp, max_tok)
-            else:
-                yield from self._stream_openai_compatible(prompt, temp, max_tok)
-        except Exception as e:
-            logger.error(f"Streaming generation failed ({self.provider}): {e}")
-            yield f"Sorry, I couldn't generate an answer due to an error: {e}"
+        chain = self._fallback_chain()
+        last_error = None
 
-    def _call_gemini(self, prompt: str, temperature: float, max_tokens: int) -> str:
+        for i, config in enumerate(chain):
+            yielded_anything = False
+            try:
+                for piece in self._stream_provider(config, prompt, temp, max_tok):
+                    yielded_anything = True
+                    yield piece
+                if i > 0:
+                    logger.info(f"Streamed via fallback provider '{config['provider']}' (primary failed)")
+                return
+            except Exception as e:
+                last_error = e
+                logger.warning(f"Provider '{config['provider']}' failed during streaming: {e}")
+                if yielded_anything:
+                    # Already sent partial output to the caller — can't silently
+                    # switch providers mid-stream without confusing/duplicating
+                    # output, so surface the failure instead of retrying.
+                    yield f"\n[Error: generation interrupted — {e}]"
+                    return
+                continue
+
+        logger.error(f"All providers in the fallback chain failed during streaming. Last error: {last_error}")
+        yield f"Sorry, I couldn't generate an answer — all configured providers failed. Last error: {last_error}"
+
+    def _call_gemini(self, prompt: str, temperature: float, max_tokens: int, api_key: str, model: str) -> str:
         import google.genai as genai
         from google.genai import types
-        client = genai.Client(api_key=self.api_key)
+        client = genai.Client(api_key=api_key)
         response = client.models.generate_content(
-            model=self.model,
+            model=model,
             contents=prompt,
             config=types.GenerateContentConfig(
                 temperature=temperature,
@@ -204,12 +284,12 @@ Answer:"""
         )
         return response.text.strip() if response.text else "No answer generated."
 
-    def _stream_gemini(self, prompt: str, temperature: float, max_tokens: int) -> Iterator[str]:
+    def _stream_gemini(self, prompt: str, temperature: float, max_tokens: int, api_key: str, model: str) -> Iterator[str]:
         import google.genai as genai
         from google.genai import types
-        client = genai.Client(api_key=self.api_key)
+        client = genai.Client(api_key=api_key)
         stream = client.models.generate_content_stream(
-            model=self.model,
+            model=model,
             contents=prompt,
             config=types.GenerateContentConfig(
                 temperature=temperature,
@@ -220,22 +300,22 @@ Answer:"""
             if chunk.text:
                 yield chunk.text
 
-    def _call_anthropic(self, prompt: str, temperature: float, max_tokens: int) -> str:
+    def _call_anthropic(self, prompt: str, temperature: float, max_tokens: int, api_key: str, model: str) -> str:
         import anthropic
-        client = anthropic.Anthropic(api_key=self.api_key)
+        client = anthropic.Anthropic(api_key=api_key)
         response = client.messages.create(
-            model=self.model,
+            model=model,
             max_tokens=max_tokens,
             temperature=temperature,
             messages=[{"role": "user", "content": prompt}],
         )
         return response.content[0].text.strip() if response.content else "No answer generated."
 
-    def _stream_anthropic(self, prompt: str, temperature: float, max_tokens: int) -> Iterator[str]:
+    def _stream_anthropic(self, prompt: str, temperature: float, max_tokens: int, api_key: str, model: str) -> Iterator[str]:
         import anthropic
-        client = anthropic.Anthropic(api_key=self.api_key)
+        client = anthropic.Anthropic(api_key=api_key)
         with client.messages.stream(
-            model=self.model,
+            model=model,
             max_tokens=max_tokens,
             temperature=temperature,
             messages=[{"role": "user", "content": prompt}],
@@ -243,22 +323,22 @@ Answer:"""
             for text in stream.text_stream:
                 yield text
 
-    def _call_openai_compatible(self, prompt: str, temperature: float, max_tokens: int) -> str:
+    def _call_openai_compatible(self, prompt: str, temperature: float, max_tokens: int, api_key: str, model: str, base_url: str) -> str:
         import openai
-        client = openai.OpenAI(api_key=self.api_key or "not-needed", base_url=self.base_url)
+        client = openai.OpenAI(api_key=api_key or "not-needed", base_url=base_url)
         response = client.chat.completions.create(
-            model=self.model,
+            model=model,
             messages=[{"role": "user", "content": prompt}],
             temperature=temperature,
             max_tokens=max_tokens,
         )
         return response.choices[0].message.content.strip() if response.choices else "No answer generated."
 
-    def _stream_openai_compatible(self, prompt: str, temperature: float, max_tokens: int) -> Iterator[str]:
+    def _stream_openai_compatible(self, prompt: str, temperature: float, max_tokens: int, api_key: str, model: str, base_url: str) -> Iterator[str]:
         import openai
-        client = openai.OpenAI(api_key=self.api_key or "not-needed", base_url=self.base_url)
+        client = openai.OpenAI(api_key=api_key or "not-needed", base_url=base_url)
         stream = client.chat.completions.create(
-            model=self.model,
+            model=model,
             messages=[{"role": "user", "content": prompt}],
             temperature=temperature,
             max_tokens=max_tokens,


### PR DESCRIPTION
If the primary LLM_PROVIDER fails (rate limit, outage, bad key), retry with each provider in LLM_FALLBACK_PROVIDERS (comma-separated), in order, before giving up.

- core/generation.py: refactored provider resolution into a standalone _resolve_provider_config() function (required=True for the primary provider — raises on missing config, matching prior behavior; required=False for fallbacks — logs a warning and skips instead of crashing startup or a request that would've succeeded on the primary). All _call_*/_stream_* methods now take explicit (api_key, model, base_url) params instead of reading self state, so the same methods work for any provider in the chain, not just the one bound at __init__.
- generate_answer() and generate_answer_stream() now try each config in the chain in order, returning/yielding on the first success. Streaming can only fall back BEFORE any text has been yielded to the caller — a mid-stream failure surfaces as an error instead of silently switching providers, to avoid confusing partial/duplicated output.
- Both now include provider_used in their result, surfaced through core/chat.py's ask()/ask_stream() and core/api.py's /chat endpoint.
- LLM_FALLBACK_PROVIDERS, MAX_OUTPUT_TOKENS, DEFAULT_TEMPERATURE documented in .env.example.

Verified with a real broken-primary test: deliberately corrupted GEMINI_API_KEY (in-process only, never written to .env), confirmed the request failed on Gemini, correctly fell through to Groq, and returned a correct, properly-grounded answer with provider_used: 'groq'. Tested both generate_answer() and generate_answer_stream(). Confirmed provider_used flows correctly through the full HTTP /chat endpoint under normal (non-fallback) operation, returning provider_used: 'gemini'.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
