### PR TITLE
feat: persistent conversation memory (session-scoped, Postgres-backed)

### DIFF
--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.2.0"
+version = "0.3.0"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -26,11 +26,12 @@ from ragleap.embedding import EmbeddingService, EmbeddingConfig
 from ragleap.retrieval import VectorRetrievalService
 from ragleap.generation import GenerationService, ProviderConfig
 from ragleap.parsers import extract_text
+from ragleap.memory import ConversationMemory
 from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult"]
 
 
@@ -66,6 +67,7 @@ class RagLeap:
         self._chunker = TextChunker(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
         self._embedder = EmbeddingService(embedder)
         self._retriever = VectorRetrievalService(database_url=database_url, embedding_dimensions=embedder.dimensions)
+        self._memory = ConversationMemory(database_url=database_url)
         self._generator = GenerationService(
             primary=primary,
             fallbacks=fallbacks,
@@ -142,9 +144,13 @@ class RagLeap:
         system_prompt: Optional[str] = None,
         max_tokens: Optional[int] = None,
         hybrid: bool = True,
+        session_id: Optional[str] = None,
     ) -> Dict:
         """
         Answer a question grounded in previously ingested documents.
+        Pass session_id to enable persistent, multi-turn conversation
+        memory (Postgres-backed) — prior turns in that session are
+        injected as context. Omit it for a fully stateless call.
         Returns: {"answer": str, "sources": List[str], "provider_used": str,
                   "usage": dict|None, "chunks_sent": int}
         """
@@ -158,9 +164,18 @@ class RagLeap:
         else:
             chunks = self._retriever.search_similar_chunks(query_embedding, top_k=top_k)
 
-        return self._generator.generate_answer(
-            query, chunks, temperature=temperature, system_prompt=system_prompt, max_tokens=max_tokens
+        history_prefix = self._memory.build_history_prompt(session_id) if session_id else ""
+
+        result = self._generator.generate_answer(
+            query, chunks, temperature=temperature, system_prompt=system_prompt,
+            max_tokens=max_tokens, history_prefix=history_prefix,
         )
+
+        if session_id:
+            self._memory.add_message(session_id, "user", query)
+            self._memory.add_message(session_id, "assistant", result["answer"])
+
+        return result
 
     def ask_stream(
         self,
@@ -170,8 +185,11 @@ class RagLeap:
         system_prompt: Optional[str] = None,
         max_tokens: Optional[int] = None,
         hybrid: bool = True,
+        session_id: Optional[str] = None,
     ) -> Iterator[str]:
-        """Same as ask(), but yields the answer incrementally as it's generated."""
+        """Same as ask(), but yields the answer incrementally as it's
+        generated. If session_id is set, the full assembled answer is
+        stored to memory once streaming completes."""
         query_embedding = self._embedder.embed_text(query)
         if query_embedding is None:
             yield "Sorry, I couldn't process your question (embedding failed)."
@@ -182,6 +200,24 @@ class RagLeap:
         else:
             chunks = self._retriever.search_similar_chunks(query_embedding, top_k=top_k)
 
-        yield from self._generator.generate_answer_stream(
-            query, chunks, temperature=temperature, system_prompt=system_prompt, max_tokens=max_tokens
-        )
+        history_prefix = self._memory.build_history_prompt(session_id) if session_id else ""
+
+        pieces = []
+        for piece in self._generator.generate_answer_stream(
+            query, chunks, temperature=temperature, system_prompt=system_prompt,
+            max_tokens=max_tokens, history_prefix=history_prefix,
+        ):
+            pieces.append(piece)
+            yield piece
+
+        if session_id:
+            self._memory.add_message(session_id, "user", query)
+            self._memory.add_message(session_id, "assistant", "".join(pieces))
+
+    def get_history(self, session_id: str) -> List[Dict]:
+        """Return the stored conversation history for a session, oldest first."""
+        return self._memory.get_history(session_id)
+
+    def clear_session(self, session_id: str) -> None:
+        """Delete a session and its full message history."""
+        self._memory.clear_session(session_id)

--- a/packages/ragleap-rag/src/ragleap/generation.py
+++ b/packages/ragleap-rag/src/ragleap/generation.py
@@ -117,10 +117,10 @@ class GenerationService:
             parts.append(f"[Source {i}: {doc_name}]\n{chunk.get('text', '')}")
         return "\n\n".join(parts)
 
-    def _build_prompt(self, query: str, chunks: List[Dict], system_prompt: Optional[str]) -> str:
+    def _build_prompt(self, query: str, chunks: List[Dict], system_prompt: Optional[str], history_prefix: str = "") -> str:
         context = self._build_context(chunks)
         instructions = system_prompt or self.system_prompt
-        return f"{instructions}\n\nContext:\n{context}\n\nQuestion: {query}\nAnswer:"
+        return f"{instructions}\n\n{history_prefix}Context:\n{context}\n\nQuestion: {query}\nAnswer:"
 
     def generate_answer(
         self,
@@ -129,6 +129,7 @@ class GenerationService:
         temperature: Optional[float] = None,
         system_prompt: Optional[str] = None,
         max_tokens: Optional[int] = None,
+        history_prefix: str = "",
     ) -> Dict:
         """
         Returns: {"answer": str, "sources": List[str], "provider_used": str,
@@ -139,7 +140,7 @@ class GenerationService:
 
         trimmed = self._trim_chunks_to_budget(chunks)
         sources = list({c.get("document_name", "unknown") for c in trimmed})
-        prompt = self._build_prompt(query, trimmed, system_prompt)
+        prompt = self._build_prompt(query, trimmed, system_prompt, history_prefix)
 
         last_error = None
         for i, config in enumerate(self._chain()):
@@ -169,6 +170,7 @@ class GenerationService:
         temperature: Optional[float] = None,
         system_prompt: Optional[str] = None,
         max_tokens: Optional[int] = None,
+        history_prefix: str = "",
     ) -> Iterator[str]:
         """Streams the answer incrementally. Usage reporting isn't
         available for streaming (each provider handles it differently)."""
@@ -176,7 +178,7 @@ class GenerationService:
         max_tok = self.default_max_tokens if max_tokens is None else max_tokens
 
         trimmed = self._trim_chunks_to_budget(chunks)
-        prompt = self._build_prompt(query, trimmed, system_prompt)
+        prompt = self._build_prompt(query, trimmed, system_prompt, history_prefix)
 
         last_error = None
         for i, config in enumerate(self._chain()):

--- a/packages/ragleap-rag/src/ragleap/memory.py
+++ b/packages/ragleap-rag/src/ragleap/memory.py
@@ -1,0 +1,92 @@
+"""
+Persistent conversation memory for ragleap-rag.
+Session-scoped, Postgres-backed. Opt-in per call — pass session_id to
+ask()/ask_stream() to get multi-turn context; omit it and behavior is
+identical to a stateless call.
+"""
+import logging
+from typing import Dict, List
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_HISTORY_MESSAGES = 10
+
+
+class ConversationMemory:
+    """Stores and retrieves per-session conversation history."""
+
+    def __init__(self, database_url: str, max_history_messages: int = DEFAULT_MAX_HISTORY_MESSAGES):
+        self.database_url = database_url
+        self.max_history_messages = max_history_messages
+
+    def _get_connection(self):
+        import psycopg2
+        return psycopg2.connect(self.database_url)
+
+    def _ensure_session(self, cur, session_id: str) -> None:
+        cur.execute(
+            """
+            INSERT INTO conversations (session_id) VALUES (%s)
+            ON CONFLICT (session_id) DO UPDATE SET updated_at = now()
+            """,
+            (session_id,),
+        )
+
+    def add_message(self, session_id: str, role: str, content: str) -> None:
+        """Store a single message (role: 'user' or 'assistant')."""
+        conn = self._get_connection()
+        try:
+            cur = conn.cursor()
+            self._ensure_session(cur, session_id)
+            cur.execute(
+                "INSERT INTO conversation_messages (session_id, role, content) VALUES (%s, %s, %s)",
+                (session_id, role, content),
+            )
+            conn.commit()
+            cur.close()
+        finally:
+            conn.close()
+
+    def get_history(self, session_id: str, limit: int = None) -> List[Dict]:
+        """
+        Return recent messages for a session, oldest first, as
+        [{"role": ..., "content": ..., "created_at": ...}, ...].
+        """
+        limit = limit if limit is not None else self.max_history_messages
+        conn = self._get_connection()
+        try:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                SELECT role, content, created_at FROM conversation_messages
+                WHERE session_id = %s
+                ORDER BY created_at DESC
+                LIMIT %s
+                """,
+                (session_id, limit),
+            )
+            rows = cur.fetchall()
+            cur.close()
+            return [{"role": r[0], "content": r[1], "created_at": r[2]} for r in reversed(rows)]
+        finally:
+            conn.close()
+
+    def clear_session(self, session_id: str) -> None:
+        """Delete a session and all its messages."""
+        conn = self._get_connection()
+        try:
+            cur = conn.cursor()
+            cur.execute("DELETE FROM conversations WHERE session_id = %s", (session_id,))
+            conn.commit()
+            cur.close()
+            logger.info(f"Cleared session '{session_id}'")
+        finally:
+            conn.close()
+
+    def build_history_prompt(self, session_id: str) -> str:
+        """Return prior turns formatted for injection into a prompt. Empty string if no history."""
+        history = self.get_history(session_id)
+        if not history:
+            return ""
+        lines = [f"{m['role'].capitalize()}: {m['content']}" for m in history]
+        return "Previous conversation:\n" + "\n".join(lines) + "\n\n"

--- a/packages/ragleap-rag/src/ragleap/schema.py
+++ b/packages/ragleap-rag/src/ragleap/schema.py
@@ -31,6 +31,23 @@ CREATE INDEX IF NOT EXISTS chunks_embedding_idx
 
 CREATE INDEX IF NOT EXISTS chunks_text_search_idx
     ON chunks USING GIN (text_search_vector);
+
+CREATE TABLE IF NOT EXISTS conversations (
+    session_id TEXT PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS conversation_messages (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    session_id TEXT NOT NULL REFERENCES conversations(session_id) ON DELETE CASCADE,
+    role TEXT NOT NULL CHECK (role IN ('user', 'assistant')),
+    content TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS conversation_messages_session_idx
+    ON conversation_messages (session_id, created_at);
 """
 
 


### PR DESCRIPTION
## Summary

Adds multi-turn conversation memory to `ask()`/`ask_stream()` via an opt-in `session_id` parameter. Omitting `session_id` preserves fully stateless behavior — no breaking change.

## What changed
- New `ConversationMemory` class (`memory.py`): `add_message`, `get_history`, `clear_session`, `build_history_prompt`
- New `conversations` / `conversation_messages` tables (idempotent, indexed on `(session_id, created_at)`)
- `generation.py`: prompt builders accept an optional `history_prefix`, injected before retrieval context
- `RagLeap.ask()`/`ask_stream()` accept `session_id`; when set, prior history is injected and both the query + answer are stored after
- New `RagLeap.get_history(session_id)` and `clear_session(session_id)` methods
- Bumped to 0.3.0

## Verification
- Fresh rebuild + reinstall from wheel — confirmed new methods present via `hasattr`
- Real live 3-turn test against Postgres + Gemini: turn 2 ("what country is *he* based in") and turn 3 ("what is *his* name again") both resolved pronoun-only references correctly using only stored session context
- `get_history()` confirmed returning correct ordered messages
- `clear_session()` confirmed to fully wipe history (verified empty `[]` after clearing)

## Known limitation
History window is capped at `max_history_messages` (default 10) with no token-aware trimming yet — long sessions could still push close to context limits. Worth a follow-up alongside the existing `max_context_chars` budget trimming for retrieval chunks.