### PR TITLE
docs: fix stale embedder_api_key reference, document conversation memory

### DIFF
--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -62,7 +62,7 @@ bad key on your primary provider doesn't mean a failed request:
 ```python
 rag = RagLeap(
     database_url="...",
-    embedder_api_key="...",
+    embedder=EmbeddingConfig(provider="gemini", api_key="..."),
     primary=ProviderConfig(provider="gemini", api_key="..."),
     fallbacks=[ProviderConfig(provider="groq", api_key="...", model="llama-3.3-70b-versatile")],
 )
@@ -81,6 +81,26 @@ for piece in rag.ask_stream("What SDKs are supported?"):
 Real per-provider streaming — Gemini, Anthropic, and any OpenAI-compatible
 endpoint each have different streaming APIs; all three are implemented
 properly, not stubbed.
+
+## Conversation memory
+
+Pass session_id to ask() or ask_stream() to get persistent, multi-turn memory. Prior turns in that session are automatically injected as context. Omit it and every call is fully stateless, exactly as before (no breaking change).
+
+```python
+session = "support-chat-42"
+
+rag.ask("What is the CEO name", session_id=session)
+rag.ask("What country is he based in", session_id=session)
+```
+
+Memory is Postgres-backed (its own conversations/conversation_messages tables, created by init_schema()). It survives restarts and works across processes, not just in-memory for a single script run.
+
+```python
+rag.get_history(session)
+rag.clear_session(session)
+```
+
+By default the last 10 messages are included per call (max_history_messages, no token-aware trimming yet).
 
 ## How it fits together
              +------------------+
@@ -105,7 +125,12 @@ properly, not stubbed.
              |   Generation      |-->| Fallback chain |
              |  (temp/prompt/    |   | (if primary    |
              |   max_tokens)     |   |  fails)        |
-             +-------------------+   +---------------+
+             +--------+---------+   +---------------+
+                      |
+             +--------v---------+
+             |  Conversation     |   optional: session_id ->
+             |  memory (Postgres)|   prior turns injected as context
+             +-------------------+
 
 ## Supported LLM providers
 

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.3.0"
+version = "0.3.1"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -31,7 +31,7 @@ from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult"]
 
 


### PR DESCRIPTION
The Reliability/fallback example in README.md still referenced the pre-0.2.0 embedder_api_key= parameter, which no longer exists on RagLeap.__init__() (replaced by embedder=EmbeddingConfig(...) in PR #36). It was still showing on PyPI as the documented usage for that example even after 0.2.0 shipped.

Also, the 0.3.0 conversation memory feature (PR #37) shipped with zero documentation - no README section, no architecture diagram update.

- Fixed the stale embedder_api_key example
- Added a Conversation memory section: session_id usage, get_history(), clear_session(), and the max_history_messages default
- Added a memory box to the architecture diagram
- Bumped to 0.3.1 (docs-only patch, no API change)

Verified: rebuilt with full 'python3 -m build' (wheel + sdist this time, 0.3.0 was accidentally wheel-only), confirmed via wheel METADATA inspection that embedder_api_key is gone and the new memory docs are present, published to PyPI: https://pypi.org/project/ragleap-rag/0.3.1/

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
