### PR TITLE
feat: cross-encoder reranking (session-scoped, opt-in)

### DIFF
--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.3.1"
+version = "0.4.0"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"
@@ -36,7 +36,8 @@ dependencies = [
 gemini = ["google-genai>=0.3.0"]
 anthropic = ["anthropic>=0.34.0"]
 openai = ["openai>=1.40.0"]
-all = ["google-genai>=0.3.0", "anthropic>=0.34.0", "openai>=1.40.0"]
+rerank = ["sentence-transformers>=3.0.0"]
+all = ["google-genai>=0.3.0", "anthropic>=0.34.0", "openai>=1.40.0", "sentence-transformers>=3.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/antonyrag/ragleap-core"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -27,11 +27,12 @@ from ragleap.retrieval import VectorRetrievalService
 from ragleap.generation import GenerationService, ProviderConfig
 from ragleap.parsers import extract_text
 from ragleap.memory import ConversationMemory
+from ragleap.reranking import RerankerService
 from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult"]
 
 
@@ -68,6 +69,7 @@ class RagLeap:
         self._embedder = EmbeddingService(embedder)
         self._retriever = VectorRetrievalService(database_url=database_url, embedding_dimensions=embedder.dimensions)
         self._memory = ConversationMemory(database_url=database_url)
+        self._reranker = None  # lazy-loaded on first rerank=True call
         self._generator = GenerationService(
             primary=primary,
             fallbacks=fallbacks,
@@ -145,6 +147,7 @@ class RagLeap:
         max_tokens: Optional[int] = None,
         hybrid: bool = True,
         session_id: Optional[str] = None,
+        rerank: bool = False,
     ) -> Dict:
         """
         Answer a question grounded in previously ingested documents.
@@ -159,10 +162,16 @@ class RagLeap:
             return {"answer": "Sorry, I couldn't process your question (embedding failed).",
                     "sources": [], "provider_used": None, "usage": None, "chunks_sent": 0}
 
+        pool_size = top_k * 4 if rerank else top_k
         if hybrid:
-            chunks = self._retriever.search_hybrid_chunks(query, query_embedding, top_k=top_k)
+            chunks = self._retriever.search_hybrid_chunks(query, query_embedding, top_k=pool_size)
         else:
-            chunks = self._retriever.search_similar_chunks(query_embedding, top_k=top_k)
+            chunks = self._retriever.search_similar_chunks(query_embedding, top_k=pool_size)
+
+        if rerank and chunks:
+            if self._reranker is None:
+                self._reranker = RerankerService()
+            chunks = self._reranker.rerank(query, chunks, top_k=top_k)
 
         history_prefix = self._memory.build_history_prompt(session_id) if session_id else ""
 

--- a/packages/ragleap-rag/src/ragleap/reranking.py
+++ b/packages/ragleap-rag/src/ragleap/reranking.py
@@ -1,0 +1,62 @@
+"""
+Cross-encoder reranking for ragleap-rag.
+Optional — requires the [rerank] extra (sentence-transformers). The
+base package works fully without this; reranking is strictly opt-in.
+"""
+import logging
+from typing import Dict, List
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RERANK_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+
+class RerankerService:
+    """
+    Reorders retrieved chunks by genuine query-document relevance using
+    a cross-encoder, rather than relying solely on the initial retrieval
+    score (cosine similarity / RRF fusion). The cross-encoder scores
+    each (query, chunk) pair jointly, which is slower but more accurate
+    than the bi-encoder scoring used for initial retrieval.
+    """
+
+    def __init__(self, model_name: str = DEFAULT_RERANK_MODEL):
+        self.model_name = model_name
+        self._model = None  # lazy-loaded on first rerank() call
+
+    def _ensure_model_loaded(self):
+        if self._model is not None:
+            return
+        try:
+            from sentence_transformers import CrossEncoder
+        except ImportError:
+            raise ImportError(
+                "Reranking requires the 'rerank' extra. Install it with: "
+                "pip install ragleap-rag[rerank]"
+            )
+        logger.info(f"Loading cross-encoder model '{self.model_name}' (first use only)...")
+        self._model = CrossEncoder(self.model_name)
+        logger.info("Cross-encoder model loaded")
+
+    def rerank(self, query: str, chunks: List[Dict], top_k: int) -> List[Dict]:
+        """
+        Rerank chunks by cross-encoder relevance to query, return the
+        top_k highest-scoring chunks. Adds a 'rerank_score' field to
+        each returned chunk. Chunks list is returned as-is (unranked
+        truncation to top_k) if it's empty or reranking fails.
+        """
+        if not chunks:
+            return chunks
+
+        self._ensure_model_loaded()
+
+        pairs = [(query, c["text"]) for c in chunks]
+        scores = self._model.predict(pairs)
+
+        for chunk, score in zip(chunks, scores):
+            chunk["rerank_score"] = round(float(score), 4)
+
+        reranked = sorted(chunks, key=lambda c: c["rerank_score"], reverse=True)
+
+        logger.info(f"Reranked {len(chunks)} candidates -> top {min(top_k, len(reranked))}")
+        return reranked[:top_k]


### PR DESCRIPTION
Adds rerank=True option to ask() for cross-encoder reranking of retrieved chunks before generation. Off by default — no breaking change, no new dependency unless explicitly opted into.

- New RerankerService (reranking.py), lazy-loads sentence-transformers' CrossEncoder (cross-encoder/ms-marco-MiniLM-L-6-v2 default) only on first rerank=True call, not at RagLeap construction time
- New [rerank] optional extra (pip install ragleap-rag[rerank])
- ask(rerank=True) retrieves a wider candidate pool (top_k * 4) via existing hybrid/dense search, then reranks down to top_k using genuine (query, chunk) joint scoring instead of relying solely on the initial retrieval score
- Adds rerank_score field to returned chunks when reranking is used
- Not wired into ask_stream() yet — reranking's latency (model load + inference) works against streaming's fast-first-token goal; worth a separate design discussion if needed
- Bumped to 0.4.0

Known limitation: sentence-transformers pulls in torch, which on this system pulled in the full CUDA toolkit (2GB+) even though reranking only needs CPU inference for a small cross-encoder model. Worth documenting a CPU-only torch install path, or evaluating an ONNX-runtime-based alternative with no CUDA dependency, in a follow-up.

Verified: rebuilt, installed with [rerank] extra, live test against real Postgres + Gemini — confirmed the model loads lazily (only on first rerank=True call, visible via the weights-loading progress bar), and reranked results genuinely differ from unranked top-k (better source precision in the reranked answer's citation).

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
