### PR TITLE
docs: document reranking

### DIFF
--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -102,6 +102,24 @@ rag.clear_session(session)
 
 By default the last 10 messages are included per call (max_history_messages, no token-aware trimming yet).
 
+## Reranking
+
+Pass rerank=True to ask() for cross-encoder reranking. The initial hybrid search retrieves a wider candidate pool, then a cross-encoder scores each (query, chunk) pair jointly, reordering results by genuine relevance rather than the initial retrieval score alone. Off by default (extra latency, extra dependency).
+
+```python
+answer = rag.ask("What is the exact pricing?", rerank=True)
+```
+
+Requires the rerank extra:
+
+```bash
+pip install ragleap-rag[rerank]
+```
+
+The cross-encoder model (cross-encoder/ms-marco-MiniLM-L-6-v2 by default) loads lazily on the first rerank=True call, not at RagLeap construction time. Note: sentence-transformers depends on torch, which may pull in CUDA libraries even for CPU-only use — if you only need CPU inference, consider installing a CPU-only torch build first.
+
+Not currently available on ask_stream().
+
 ## How it fits together
              +------------------+
              |   Your text or   |


### PR DESCRIPTION
## Summary

PR #39 shipped cross-encoder reranking but the README wasn't updated - same gap the conversation memory feature had before (PR #38 fixed that one).

## What changed

New Reranking section: `rerank=True` usage, the `[rerank]` extra install, lazy model loading behavior, the CPU-only torch caveat, and the current `ask_stream()` limitation.

## Verification

Rebuilt with full `python3 -m build`, confirmed via wheel METADATA inspection that the Reranking section and `rerank=True` usage are present, published as part of 0.4.0: https://pypi.org/project/ragleap-rag/0.4.0/