### PR TITLE
feat: connection pooling for all database access

### DIFF
--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -120,6 +120,10 @@ The cross-encoder model (cross-encoder/ms-marco-MiniLM-L-6-v2 by default) loads 
 
 Not currently available on ask_stream().
 
+## Performance
+
+Database connections are pooled internally (min 1, max 10 by default) rather than opened fresh on every call. Previously every ingest, ask, and memory operation opened a brand-new Postgres connection and closed it afterward - real, avoidable latency, especially under concurrent load (e.g. a web server handling multiple requests at once). This is automatic and requires no configuration.
+
 ## How it fits together
              +------------------+
              |   Your text or   |

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.4.0"
+version = "0.4.1"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -28,11 +28,12 @@ from ragleap.generation import GenerationService, ProviderConfig
 from ragleap.parsers import extract_text
 from ragleap.memory import ConversationMemory
 from ragleap.reranking import RerankerService
+from ragleap.db import ConnectionPool
 from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult"]
 
 
@@ -64,11 +65,12 @@ class RagLeap:
     ):
         self.database_url = database_url
         self.embedding_dimensions = embedder.dimensions
+        self._pool = ConnectionPool(database_url)
 
         self._chunker = TextChunker(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
         self._embedder = EmbeddingService(embedder)
-        self._retriever = VectorRetrievalService(database_url=database_url, embedding_dimensions=embedder.dimensions)
-        self._memory = ConversationMemory(database_url=database_url)
+        self._retriever = VectorRetrievalService(pool=self._pool, embedding_dimensions=embedder.dimensions)
+        self._memory = ConversationMemory(pool=self._pool)
         self._reranker = None  # lazy-loaded on first rerank=True call
         self._generator = GenerationService(
             primary=primary,
@@ -81,10 +83,6 @@ class RagLeap:
     def init_schema(self) -> None:
         """Create the required tables/indexes if they don't already exist. Idempotent."""
         _schema.init_schema(self.database_url, dimensions=self.embedding_dimensions)
-
-    def _get_connection(self):
-        import psycopg2
-        return psycopg2.connect(self.database_url)
 
     def ingest(self, filename: str, raw_bytes: bytes) -> IngestResult:
         """
@@ -102,8 +100,8 @@ class RagLeap:
             raise ValueError("No chunks produced from input text — is it empty?")
 
         document_id = str(uuid.uuid4())
-        conn = self._get_connection()
-        try:
+        with self._pool.get_connection() as conn:
+          try:
             cur = conn.cursor()
             cur.execute("INSERT INTO documents (id, filename) VALUES (%s, %s)", (document_id, filename))
 
@@ -132,11 +130,9 @@ class RagLeap:
             cur.close()
             logger.info(f"Ingested '{filename}': {stored}/{len(chunks)} chunks stored")
             return IngestResult(document_id=document_id, chunks_stored=stored)
-        except Exception:
+          except Exception:
             conn.rollback()
             raise
-        finally:
-            conn.close()
 
     def ask(
         self,

--- a/packages/ragleap-rag/src/ragleap/db.py
+++ b/packages/ragleap-rag/src/ragleap/db.py
@@ -1,0 +1,40 @@
+"""
+Shared connection pooling for ragleap-rag.
+Every service class (retrieval, memory) shares one pool instead of
+opening a new psycopg2 connection per call — a fresh TCP handshake +
+Postgres auth on every single method call is a real, avoidable latency
+cost, especially under any concurrent load.
+"""
+import logging
+from contextlib import contextmanager
+
+logger = logging.getLogger(__name__)
+
+
+class ConnectionPool:
+    """Thin wrapper around psycopg2's ThreadedConnectionPool."""
+
+    def __init__(self, database_url: str, min_conn: int = 1, max_conn: int = 10):
+        import psycopg2.pool
+        self.database_url = database_url
+        self._pool = psycopg2.pool.ThreadedConnectionPool(min_conn, max_conn, database_url)
+        logger.info(f"Connection pool created (min={min_conn}, max={max_conn})")
+
+    @contextmanager
+    def get_connection(self):
+        """
+        Usage: with pool.get_connection() as conn: ...
+        Connection is always returned to the pool afterward, even on
+        error. Caller is responsible for conn.commit()/rollback() as
+        needed — the pool does not auto-commit.
+        """
+        conn = self._pool.getconn()
+        try:
+            yield conn
+        finally:
+            self._pool.putconn(conn)
+
+    def close(self):
+        """Close all connections in the pool. Call on shutdown if needed."""
+        self._pool.closeall()
+        logger.info("Connection pool closed")

--- a/packages/ragleap-rag/src/ragleap/memory.py
+++ b/packages/ragleap-rag/src/ragleap/memory.py
@@ -15,13 +15,9 @@ DEFAULT_MAX_HISTORY_MESSAGES = 10
 class ConversationMemory:
     """Stores and retrieves per-session conversation history."""
 
-    def __init__(self, database_url: str, max_history_messages: int = DEFAULT_MAX_HISTORY_MESSAGES):
-        self.database_url = database_url
+    def __init__(self, pool, max_history_messages: int = DEFAULT_MAX_HISTORY_MESSAGES):
+        self.pool = pool
         self.max_history_messages = max_history_messages
-
-    def _get_connection(self):
-        import psycopg2
-        return psycopg2.connect(self.database_url)
 
     def _ensure_session(self, cur, session_id: str) -> None:
         cur.execute(
@@ -34,8 +30,7 @@ class ConversationMemory:
 
     def add_message(self, session_id: str, role: str, content: str) -> None:
         """Store a single message (role: 'user' or 'assistant')."""
-        conn = self._get_connection()
-        try:
+        with self.pool.get_connection() as conn:
             cur = conn.cursor()
             self._ensure_session(cur, session_id)
             cur.execute(
@@ -44,8 +39,6 @@ class ConversationMemory:
             )
             conn.commit()
             cur.close()
-        finally:
-            conn.close()
 
     def get_history(self, session_id: str, limit: int = None) -> List[Dict]:
         """
@@ -53,8 +46,7 @@ class ConversationMemory:
         [{"role": ..., "content": ..., "created_at": ...}, ...].
         """
         limit = limit if limit is not None else self.max_history_messages
-        conn = self._get_connection()
-        try:
+        with self.pool.get_connection() as conn:
             cur = conn.cursor()
             cur.execute(
                 """
@@ -68,20 +60,15 @@ class ConversationMemory:
             rows = cur.fetchall()
             cur.close()
             return [{"role": r[0], "content": r[1], "created_at": r[2]} for r in reversed(rows)]
-        finally:
-            conn.close()
 
     def clear_session(self, session_id: str) -> None:
         """Delete a session and all its messages."""
-        conn = self._get_connection()
-        try:
+        with self.pool.get_connection() as conn:
             cur = conn.cursor()
             cur.execute("DELETE FROM conversations WHERE session_id = %s", (session_id,))
             conn.commit()
             cur.close()
             logger.info(f"Cleared session '{session_id}'")
-        finally:
-            conn.close()
 
     def build_history_prompt(self, session_id: str) -> str:
         """Return prior turns formatted for injection into a prompt. Empty string if no history."""

--- a/packages/ragleap-rag/src/ragleap/retrieval.py
+++ b/packages/ragleap-rag/src/ragleap/retrieval.py
@@ -23,14 +23,10 @@ class VectorRetrievalService:
     'chunks' table (see ragleap.schema for the required DDL).
     """
 
-    def __init__(self, database_url: str, embedding_dimensions: int = 3072, min_similarity: float = 0.05):
-        self.database_url = database_url
+    def __init__(self, pool, embedding_dimensions: int = 3072, min_similarity: float = 0.05):
+        self.pool = pool
         self.embedding_dimensions = embedding_dimensions
         self.min_similarity = min_similarity
-
-    def _get_connection(self):
-        import psycopg2
-        return psycopg2.connect(self.database_url)
 
     def search_similar_chunks(
         self,
@@ -66,12 +62,11 @@ class VectorRetrievalService:
         params.extend([self.embedding_dimensions, literal, self.embedding_dimensions, top_k])
 
         try:
-            conn = self._get_connection()
-            cur = conn.cursor()
-            cur.execute(sql, params)
-            rows = cur.fetchall()
-            cur.close()
-            conn.close()
+            with self.pool.get_connection() as conn:
+                cur = conn.cursor()
+                cur.execute(sql, params)
+                rows = cur.fetchall()
+                cur.close()
 
             results = []
             for row in rows:
@@ -120,12 +115,11 @@ class VectorRetrievalService:
         params.append(top_k)
 
         try:
-            conn = self._get_connection()
-            cur = conn.cursor()
-            cur.execute(sql, params)
-            rows = cur.fetchall()
-            cur.close()
-            conn.close()
+            with self.pool.get_connection() as conn:
+                cur = conn.cursor()
+                cur.execute(sql, params)
+                rows = cur.fetchall()
+                cur.close()
 
             results = []
             for row in rows:


### PR DESCRIPTION
Every DB-touching method (ingest_text, ask via retrieval, memory's add_message/get_history/clear_session) previously opened a brand-new psycopg2 connection per call and closed it immediately after - a fresh TCP handshake + Postgres auth on every single operation, real avoidable latency especially under concurrent load.

- New ConnectionPool (db.py): thin wrapper around psycopg2.pool. ThreadedConnectionPool, exposes a get_connection() context manager that always returns the connection to the pool via try/finally
- RagLeap.__init__() creates one pool (min=1, max=10 by default), passes it to VectorRetrievalService and ConversationMemory instead of raw database_url
- Replaced every _get_connection()/psycopg2.connect() call site in retrieval.py, memory.py, and __init__.py's ingest_text with the pooled context manager
- schema.init_schema() intentionally left as a one-off direct connection - it runs once per process typically, pooling doesn't matter there
- Documented in a new README Performance section
- Bumped to 0.4.1

Verified: rebuilt, force-reinstalled from wheel, live test against real Postgres + Gemini - confirmed pool creation, successful ingest, 5 sequential ask() calls with session memory completing without connection errors, history correctly accumulating and clearing. No functional regressions in retrieval or memory behavior.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
