### PR TITLE
feat: query embedding caching (in-memory LRU, opt-out)

### DIFF
--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -124,6 +124,8 @@ Not currently available on ask_stream().
 
 Database connections are pooled internally (min 1, max 10 by default) rather than opened fresh on every call. Previously every ingest, ask, and memory operation opened a brand-new Postgres connection and closed it afterward - real, avoidable latency, especially under concurrent load (e.g. a web server handling multiple requests at once). This is automatic and requires no configuration.
 
+Query embeddings are also cached in memory (LRU, 1000 entries by default) - repeated identical questions skip a redundant embedding call. This caches embeddings only, never full answers, since with conversation memory the same question can legitimately produce different answers depending on session history. Check cache effectiveness with rag.cache_stats(), or disable with cache_enabled=False.
+
 ## How it fits together
              +------------------+
              |   Your text or   |

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.4.1"
+version = "0.4.2"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -29,11 +29,12 @@ from ragleap.parsers import extract_text
 from ragleap.memory import ConversationMemory
 from ragleap.reranking import RerankerService
 from ragleap.db import ConnectionPool
+from ragleap.cache import QueryEmbeddingCache
 from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult"]
 
 
@@ -62,6 +63,8 @@ class RagLeap:
         max_context_chars: int = 12000,
         chunk_size: Optional[int] = None,
         chunk_overlap: Optional[int] = None,
+        cache_enabled: bool = True,
+        cache_max_size: int = 1000,
     ):
         self.database_url = database_url
         self.embedding_dimensions = embedder.dimensions
@@ -72,6 +75,8 @@ class RagLeap:
         self._retriever = VectorRetrievalService(pool=self._pool, embedding_dimensions=embedder.dimensions)
         self._memory = ConversationMemory(pool=self._pool)
         self._reranker = None  # lazy-loaded on first rerank=True call
+        self._cache_enabled = cache_enabled
+        self._query_cache = QueryEmbeddingCache(max_size=cache_max_size) if cache_enabled else None
         self._generator = GenerationService(
             primary=primary,
             fallbacks=fallbacks,
@@ -83,6 +88,31 @@ class RagLeap:
     def init_schema(self) -> None:
         """Create the required tables/indexes if they don't already exist. Idempotent."""
         _schema.init_schema(self.database_url, dimensions=self.embedding_dimensions)
+
+    def _embed_query_cached(self, query: str) -> Optional[List[float]]:
+        """Embed a query, using the cache if enabled. Cache key is
+        (query text, embedding model) - safe across different queries
+        and different embedder configs on the same instance."""
+        if self._cache_enabled:
+            cached = self._query_cache.get(query, self._embedder.model)
+            if cached is not None:
+                return cached
+
+        embedding = self._embedder.embed_text(query)
+
+        if self._cache_enabled and embedding is not None:
+            self._query_cache.set(query, self._embedder.model, embedding)
+
+        return embedding
+
+    def cache_stats(self) -> dict:
+        """Return query embedding cache stats: hits, misses, hit_rate, size.
+        Returns all zeros if caching is disabled."""
+        if not self._cache_enabled:
+            return {"hits": 0, "misses": 0, "hit_rate": 0.0, "size": 0, "enabled": False}
+        stats = self._query_cache.stats()
+        stats["enabled"] = True
+        return stats
 
     def ingest(self, filename: str, raw_bytes: bytes) -> IngestResult:
         """
@@ -153,7 +183,7 @@ class RagLeap:
         Returns: {"answer": str, "sources": List[str], "provider_used": str,
                   "usage": dict|None, "chunks_sent": int}
         """
-        query_embedding = self._embedder.embed_text(query)
+        query_embedding = self._embed_query_cached(query)
         if query_embedding is None:
             return {"answer": "Sorry, I couldn't process your question (embedding failed).",
                     "sources": [], "provider_used": None, "usage": None, "chunks_sent": 0}
@@ -195,7 +225,7 @@ class RagLeap:
         """Same as ask(), but yields the answer incrementally as it's
         generated. If session_id is set, the full assembled answer is
         stored to memory once streaming completes."""
-        query_embedding = self._embedder.embed_text(query)
+        query_embedding = self._embed_query_cached(query)
         if query_embedding is None:
             yield "Sorry, I couldn't process your question (embedding failed)."
             return

--- a/packages/ragleap-rag/src/ragleap/cache.py
+++ b/packages/ragleap-rag/src/ragleap/cache.py
@@ -1,0 +1,58 @@
+"""
+Query embedding cache for ragleap-rag.
+Caches embeddings for repeated identical queries (e.g. an FAQ-style
+bot getting the same question multiple times) to avoid a redundant
+embedding API call. In-memory only, per RagLeap instance - no new
+dependency, no external cache service required.
+
+Deliberately does NOT cache full answers: with conversation memory,
+identical questions can legitimately produce different answers
+depending on session history, so answer-level caching risks returning
+stale or wrong responses. Caching the embedding step is always safe,
+since an embedding is a pure function of (text, model).
+"""
+import logging
+from collections import OrderedDict
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class QueryEmbeddingCache:
+    """Simple in-memory LRU cache for query embeddings."""
+
+    def __init__(self, max_size: int = 1000):
+        self.max_size = max_size
+        self._store: OrderedDict[str, List[float]] = OrderedDict()
+        self.hits = 0
+        self.misses = 0
+
+    def _key(self, query: str, model: str) -> str:
+        return f"{model}:{query}"
+
+    def get(self, query: str, model: str) -> Optional[List[float]]:
+        key = self._key(query, model)
+        if key in self._store:
+            self._store.move_to_end(key)  # mark as recently used
+            self.hits += 1
+            return self._store[key]
+        self.misses += 1
+        return None
+
+    def set(self, query: str, model: str, embedding: List[float]) -> None:
+        key = self._key(query, model)
+        self._store[key] = embedding
+        self._store.move_to_end(key)
+        if len(self._store) > self.max_size:
+            evicted_key, _ = self._store.popitem(last=False)  # evict least recently used
+            logger.debug(f"Cache full, evicted: {evicted_key[:50]}...")
+
+    def clear(self) -> None:
+        self._store.clear()
+        self.hits = 0
+        self.misses = 0
+
+    def stats(self) -> dict:
+        total = self.hits + self.misses
+        hit_rate = round(self.hits / total, 4) if total > 0 else 0.0
+        return {"hits": self.hits, "misses": self.misses, "hit_rate": hit_rate, "size": len(self._store)}


### PR DESCRIPTION
## Summary

Repeated identical queries were re-embedding from scratch every time. Adds an in-memory LRU cache (1000 entries by default) keyed on (query text, embedding model).

## What changed
- New `QueryEmbeddingCache` (`cache.py`): simple `OrderedDict`-based LRU, no external dependency, per-`RagLeap`-instance
- Deliberately does NOT cache full answers — with conversation memory, identical questions can legitimately produce different answers depending on session history, so answer-level caching would risk returning stale or wrong responses. Caching stops at the embedding step, which has no such risk (embeddings are a pure function of their inputs).
- New `cache_enabled` (default `True`) and `cache_max_size` (default `1000`) `RagLeap.__init__()` params
- New `_embed_query_cached()` internal helper, used by both `ask()` and `ask_stream()` — chunk embedding in `ingest_text()` is intentionally untouched
- New `rag.cache_stats()` — hits/misses/hit_rate/size
- Documented in the existing Performance README section
- Bumped to 0.4.2

## Verification
Rebuilt, force-reinstalled from wheel, live test against real Postgres + Gemini — three calls (unique query, repeat of same query, then a different query) produced exactly the expected `hits=1, misses=2`, with the cache-hit call measurably faster than the cache-miss calls.