### PR TITLE
feat: document lifecycle (list_documents, delete_document, update_doc…

### DIFF
--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -133,6 +133,22 @@ The cross-encoder model (cross-encoder/ms-marco-MiniLM-L-6-v2 by default) loads 
 
 Not currently available on ask_stream().
 
+## Document lifecycle
+
+list_documents(), delete_document(), and update_document() manage previously ingested content.
+
+```python
+docs = rag.list_documents(limit=20)
+for d in docs:
+    print(d["filename"], d["chunk_count"], "chunks")
+
+rag.delete_document(docs[0]["document_id"])
+
+# update_document is delete + re-ingest under the hood - the document
+# gets a new document_id, old chunks and embeddings are not preserved
+result = rag.update_document(some_document_id, "new content here")
+```
+
 ## Performance
 
 Database connections are pooled internally (min 1, max 10 by default) rather than opened fresh on every call. Previously every ingest, ask, and memory operation opened a brand-new Postgres connection and closed it afterward - real, avoidable latency, especially under concurrent load (e.g. a web server handling multiple requests at once). This is automatic and requires no configuration.

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.4.3"
+version = "0.4.4"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -34,7 +34,7 @@ from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult"]
 
 
@@ -256,6 +256,74 @@ class RagLeap:
     def clear_session(self, session_id: str) -> None:
         """Delete a session and its full message history."""
         self._memory.clear_session(session_id)
+
+    def list_documents(self, limit: int = 100, offset: int = 0) -> List[Dict]:
+        """
+        List previously ingested documents, most recently uploaded first.
+        Returns: [{"document_id": str, "filename": str, "uploaded_at": ...,
+                   "chunk_count": int}, ...]
+        """
+        with self._pool.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                SELECT d.id, d.filename, d.uploaded_at, COUNT(c.id) AS chunk_count
+                FROM documents d
+                LEFT JOIN chunks c ON c.document_id = d.id
+                GROUP BY d.id, d.filename, d.uploaded_at
+                ORDER BY d.uploaded_at DESC
+                LIMIT %s OFFSET %s
+                """,
+                (limit, offset),
+            )
+            rows = cur.fetchall()
+            cur.close()
+
+        return [
+            {"document_id": str(r[0]), "filename": r[1], "uploaded_at": r[2], "chunk_count": r[3]}
+            for r in rows
+        ]
+
+    def delete_document(self, document_id: str) -> bool:
+        """
+        Delete a document and all its chunks (cascades automatically via
+        the chunks.document_id foreign key). Returns True if a document
+        was actually deleted, False if document_id did not exist.
+        """
+        with self._pool.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute("DELETE FROM documents WHERE id = %s", (document_id,))
+            deleted = cur.rowcount > 0
+            conn.commit()
+            cur.close()
+
+        if deleted:
+            logger.info(f"Deleted document {document_id}")
+        else:
+            logger.warning(f"delete_document: no document found with id {document_id}")
+        return deleted
+
+    def update_document(self, document_id: str, text: str, filename: Optional[str] = None) -> IngestResult:
+        """
+        Replace a document's content. This is implemented as delete +
+        re-ingest under the hood, not an in-place edit - chunk boundaries
+        and embeddings for the old content are not preserved, and the
+        document gets a new document_id. Use filename= to also rename it;
+        omit to keep the existing filename.
+        """
+        existing_filename = filename
+        if existing_filename is None:
+            with self._pool.get_connection() as conn:
+                cur = conn.cursor()
+                cur.execute("SELECT filename FROM documents WHERE id = %s", (document_id,))
+                row = cur.fetchone()
+                cur.close()
+            if row is None:
+                raise ValueError(f"No document found with id {document_id}")
+            existing_filename = row[0]
+
+        self.delete_document(document_id)
+        return self.ingest_text(existing_filename, text)
 
     async def aingest(self, filename: str, raw_bytes: bytes) -> IngestResult:
         """


### PR DESCRIPTION
…ument)

Adds methods to manage previously ingested content, which was previously missing entirely - a real production gap since content inevitably needs removing or refreshing over time.

- list_documents(limit, offset): documents newest-first, joined with a live chunk count via GROUP BY, not a cached/stale count
- delete_document(document_id): deletes the documents row, chunks cascade automatically via the existing chunks.document_id foreign key. Returns True/False based on whether a row was actually deleted, so callers can detect a not-found case rather than silently no-op-ing
- update_document(document_id, text, filename=None): implemented as delete + re-ingest, not an in-place edit - documented clearly as such, since the document gets a new document_id and old chunks/ embeddings for the previous content are not preserved. Looks up the existing filename automatically if filename= is omitted.
- New README Document lifecycle section
- Bumped to 0.4.4

Verified: rebuilt, force-reinstalled from wheel, live test against real Postgres + Gemini - ingested two documents, confirmed list_documents returns accurate chunk counts, confirmed update_document's old document_id is gone and the new one exists, confirmed ask() reflects the updated content (not the original) after update, confirmed delete_document removes a real document and correctly returns False (not an exception) for a nonexistent id.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
