### PR TITLE
feat: metadata filtering (multi-tenant, date-range, arbitrary JSON tags)

### DIFF
--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -149,6 +149,22 @@ rag.delete_document(docs[0]["document_id"])
 result = rag.update_document(some_document_id, "new content here")
 ```
 
+## Metadata & filtering
+
+Attach arbitrary JSON metadata to a document at ingest time, then restrict retrieval to matching chunks with metadata_filter on ask() - the basis for multi-tenant isolation, date-range filtering, or any other tagging scheme.
+
+```python
+rag.ingest_text("acme_handbook.txt", "...", metadata={"tenant": "acme"})
+rag.ingest_text("globex_handbook.txt", "...", metadata={"tenant": "globex"})
+
+# Only retrieves chunks whose metadata contains {"tenant": "acme"}
+answer = rag.ask("What is our PTO policy?", metadata_filter={"tenant": "acme"})
+```
+
+Filtering uses Postgres JSONB containment (metadata @> filter), backed by a GIN index - so it scales, and metadata can hold any JSON-serializable structure, not just flat tenant IDs. metadata is also returned by list_documents().
+
+Known limitation: update_document() does not currently preserve the original document's metadata - re-ingesting content via update_document() resets metadata to empty unless you pass it again yourself. Worth fixing in a follow-up if this trips anyone up.
+
 ## Performance
 
 Database connections are pooled internally (min 1, max 10 by default) rather than opened fresh on every call. Previously every ingest, ask, and memory operation opened a brand-new Postgres connection and closed it afterward - real, avoidable latency, especially under concurrent load (e.g. a web server handling multiple requests at once). This is automatic and requires no configuration.

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.4.4"
+version = "0.4.5"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -34,7 +34,7 @@ from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.4.4"
+__version__ = "0.4.5"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult"]
 
 
@@ -123,7 +123,7 @@ class RagLeap:
         text = extract_text(filename, raw_bytes)
         return self.ingest_text(filename, text)
 
-    def ingest_text(self, filename: str, text: str) -> IngestResult:
+    def ingest_text(self, filename: str, text: str, metadata: Optional[Dict] = None) -> IngestResult:
         """Same as ingest(), but for text you've already extracted yourself."""
         chunks = self._chunker.chunk_text(text)
         if not chunks:
@@ -133,7 +133,11 @@ class RagLeap:
         with self._pool.get_connection() as conn:
           try:
             cur = conn.cursor()
-            cur.execute("INSERT INTO documents (id, filename) VALUES (%s, %s)", (document_id, filename))
+            import json as _json
+            cur.execute(
+                "INSERT INTO documents (id, filename, metadata) VALUES (%s, %s, %s::jsonb)",
+                (document_id, filename, _json.dumps(metadata or {})),
+            )
 
             stored = 0
             for chunk in chunks:
@@ -145,10 +149,10 @@ class RagLeap:
                 embedding_literal = "[" + ",".join(str(float(x)) for x in embedding) + "]"
                 cur.execute(
                     """
-                    INSERT INTO chunks (document_id, document_name, chunk_index, text, token_count, embedding)
-                    VALUES (%s, %s, %s, %s, %s, %s::vector)
+                    INSERT INTO chunks (document_id, document_name, chunk_index, text, token_count, embedding, metadata)
+                    VALUES (%s, %s, %s, %s, %s, %s::vector, %s::jsonb)
                     """,
-                    (document_id, filename, chunk["chunk_index"], chunk["text"], chunk["token_count"], embedding_literal),
+                    (document_id, filename, chunk["chunk_index"], chunk["text"], chunk["token_count"], embedding_literal, _json.dumps(metadata or {})),
                 )
                 stored += 1
 
@@ -174,6 +178,7 @@ class RagLeap:
         hybrid: bool = True,
         session_id: Optional[str] = None,
         rerank: bool = False,
+        metadata_filter: Optional[Dict] = None,
     ) -> Dict:
         """
         Answer a question grounded in previously ingested documents.
@@ -190,9 +195,9 @@ class RagLeap:
 
         pool_size = top_k * 4 if rerank else top_k
         if hybrid:
-            chunks = self._retriever.search_hybrid_chunks(query, query_embedding, top_k=pool_size)
+            chunks = self._retriever.search_hybrid_chunks(query, query_embedding, top_k=pool_size, metadata_filter=metadata_filter)
         else:
-            chunks = self._retriever.search_similar_chunks(query_embedding, top_k=pool_size)
+            chunks = self._retriever.search_similar_chunks(query_embedding, top_k=pool_size, metadata_filter=metadata_filter)
 
         if rerank and chunks:
             if self._reranker is None:
@@ -267,10 +272,10 @@ class RagLeap:
             cur = conn.cursor()
             cur.execute(
                 """
-                SELECT d.id, d.filename, d.uploaded_at, COUNT(c.id) AS chunk_count
+                SELECT d.id, d.filename, d.uploaded_at, d.metadata, COUNT(c.id) AS chunk_count
                 FROM documents d
                 LEFT JOIN chunks c ON c.document_id = d.id
-                GROUP BY d.id, d.filename, d.uploaded_at
+                GROUP BY d.id, d.filename, d.uploaded_at, d.metadata
                 ORDER BY d.uploaded_at DESC
                 LIMIT %s OFFSET %s
                 """,
@@ -280,7 +285,7 @@ class RagLeap:
             cur.close()
 
         return [
-            {"document_id": str(r[0]), "filename": r[1], "uploaded_at": r[2], "chunk_count": r[3]}
+            {"document_id": str(r[0]), "filename": r[1], "uploaded_at": r[2], "metadata": r[3], "chunk_count": r[4]}
             for r in rows
         ]
 

--- a/packages/ragleap-rag/src/ragleap/retrieval.py
+++ b/packages/ragleap-rag/src/ragleap/retrieval.py
@@ -9,6 +9,7 @@ schema — see that module for the exact DDL).
 No knowledge-graph coupling here by design — ragleap-graph (a separate
 package) extends retrieval with graph-boosted ranking on top of this.
 """
+import json
 import logging
 from typing import List, Dict, Optional
 
@@ -33,6 +34,7 @@ class VectorRetrievalService:
         query_embedding: List[float],
         top_k: int = 5,
         document_id: Optional[str] = None,
+        metadata_filter: Optional[Dict] = None,
     ) -> List[Dict]:
         """Dense retrieval via pgvector cosine distance."""
         if not query_embedding:
@@ -54,9 +56,15 @@ class VectorRetrievalService:
         """
         params = [self.embedding_dimensions, literal, self.embedding_dimensions]
 
+        where_clauses = []
         if document_id:
-            sql += " WHERE document_id = %s"
+            where_clauses.append("document_id = %s")
             params.append(document_id)
+        if metadata_filter:
+            where_clauses.append("metadata @> %s::jsonb")
+            params.append(json.dumps(metadata_filter))
+        if where_clauses:
+            sql += " WHERE " + " AND ".join(where_clauses)
 
         sql += " ORDER BY embedding::halfvec(%s) <=> %s::halfvec(%s) LIMIT %s"
         params.extend([self.embedding_dimensions, literal, self.embedding_dimensions, top_k])
@@ -94,6 +102,7 @@ class VectorRetrievalService:
         query_text: str,
         top_k: int = 5,
         document_id: Optional[str] = None,
+        metadata_filter: Optional[Dict] = None,
     ) -> List[Dict]:
         """Sparse (keyword/full-text) retrieval via Postgres text search."""
         if not query_text or not query_text.strip():
@@ -110,6 +119,9 @@ class VectorRetrievalService:
         if document_id:
             sql += " AND document_id = %s"
             params.append(document_id)
+        if metadata_filter:
+            sql += " AND metadata @> %s::jsonb"
+            params.append(json.dumps(metadata_filter))
 
         sql += " ORDER BY rank_score DESC LIMIT %s"
         params.append(top_k)
@@ -146,14 +158,15 @@ class VectorRetrievalService:
         query_embedding: List[float],
         top_k: int = 5,
         document_id: Optional[str] = None,
+        metadata_filter: Optional[Dict] = None,
     ) -> List[Dict]:
         """
         Combines dense + sparse via Reciprocal Rank Fusion. similarity_score
         in the returned dicts is the RRF-fused score, meaningful only for
         ranking within this result set (not a 0-1 cosine similarity).
         """
-        dense = self.search_similar_chunks(query_embedding, top_k=top_k * 3, document_id=document_id)
-        sparse = self.search_sparse_chunks(query_text, top_k=top_k * 3, document_id=document_id)
+        dense = self.search_similar_chunks(query_embedding, top_k=top_k * 3, document_id=document_id, metadata_filter=metadata_filter)
+        sparse = self.search_sparse_chunks(query_text, top_k=top_k * 3, document_id=document_id, metadata_filter=metadata_filter)
 
         dense_ranks = {c["chunk_id"]: i for i, c in enumerate(dense)}
         sparse_ranks = {c["chunk_id"]: i for i, c in enumerate(sparse)}

--- a/packages/ragleap-rag/src/ragleap/schema.py
+++ b/packages/ragleap-rag/src/ragleap/schema.py
@@ -11,6 +11,7 @@ CREATE EXTENSION IF NOT EXISTS vector;
 CREATE TABLE IF NOT EXISTS documents (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     filename TEXT NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{{}}'::jsonb,
     uploaded_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
@@ -22,15 +23,25 @@ CREATE TABLE IF NOT EXISTS chunks (
     text TEXT NOT NULL,
     token_count INTEGER,
     embedding vector({dimensions}),
+    metadata JSONB NOT NULL DEFAULT '{{}}'::jsonb,
     text_search_vector tsvector GENERATED ALWAYS AS (to_tsvector('english', text)) STORED,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+
+ALTER TABLE documents ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{{}}'::jsonb;
+ALTER TABLE chunks ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{{}}'::jsonb;
 
 CREATE INDEX IF NOT EXISTS chunks_embedding_idx
     ON chunks USING hnsw ((embedding::halfvec({dimensions})) halfvec_cosine_ops);
 
 CREATE INDEX IF NOT EXISTS chunks_text_search_idx
     ON chunks USING GIN (text_search_vector);
+
+CREATE INDEX IF NOT EXISTS chunks_metadata_idx
+    ON chunks USING GIN (metadata);
+
+CREATE INDEX IF NOT EXISTS documents_metadata_idx
+    ON documents USING GIN (metadata);
 
 CREATE TABLE IF NOT EXISTS conversations (
     session_id TEXT PRIMARY KEY,


### PR DESCRIPTION
Adds JSONB metadata storage and Postgres-native containment filtering, the basis for multi-tenant isolation - a real gap flagged directly against the resume's claimed workspace-scoped multi-tenant work, which had no equivalent in the public API until now.

- New metadata JSONB column on documents and chunks, GIN-indexed
- Schema migration is ALTER TABLE ADD COLUMN IF NOT EXISTS, not just part of CREATE TABLE - CREATE TABLE IF NOT EXISTS is a no-op against an already-existing table, so a plain column addition in the template alone would never reach a database from an earlier version. Caught this via a real failure against this session's own test database before it could ship broken.
- ingest_text(filename, text, metadata=None) stores metadata on both the document and every one of its chunks
- search_similar_chunks/search_sparse_chunks/search_hybrid_chunks all accept metadata_filter, using JSONB containment (metadata @> filter)
- ask(..., metadata_filter=...) wires this through to retrieval
- list_documents() now returns each document's metadata
- New README Metadata & filtering section, including an honest known limitation: update_document() does not currently preserve metadata across a content replacement
- Bumped to 0.4.5

Verified: rebuilt, force-reinstalled from wheel, live test against real Postgres + Gemini - ingested two documents with different tenant metadata, each containing a distinct secret value. Unfiltered ask() correctly saw both secrets. metadata_filter={tenant: acme} answer mentioned ONLY the acme secret, never the globex one, and vice versa - concrete proof the JSONB filter genuinely restricts retrieval rather than being silently accepted as a no-op.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
