### PR TITLE
feat: content sanitization and injection-risk detection

### DIFF
--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -165,6 +165,22 @@ Filtering uses Postgres JSONB containment (metadata @> filter), backed by a GIN 
 
 Known limitation: update_document() does not currently preserve the original document's metadata - re-ingesting content via update_document() resets metadata to empty unless you pass it again yourself. Worth fixing in a follow-up if this trips anyone up.
 
+## Content sanitization
+
+ingest_text() sanitizes and screens content by default (sanitize=True, warn_on_injection_risk=True) - both can be disabled per call if you are already sanitizing upstream.
+
+```python
+# Default: sanitizes control characters and warns on suspicious patterns
+rag.ingest_text("doc.txt", text)
+
+# Opt out if you handle this yourself
+rag.ingest_text("doc.txt", text, sanitize=False, warn_on_injection_risk=False)
+```
+
+Sanitization strips null bytes, control characters, and invisible/zero-width Unicode characters - a documented technique for hiding instructions inside text that looks normal to a human reviewer.
+
+Injection-risk detection is heuristic pattern matching against a fixed list of common trigger phrases ("ignore previous instructions", "reveal your system prompt", etc). It logs a warning and does NOT block ingestion. Honest limitation: this is pattern matching, not semantic understanding - prompt injection via retrieved content is an open research problem, and a sufficiently motivated attacker can rephrase around any fixed pattern list. Treat a warning as a signal to review, not a guarantee of safety, and treat the absence of a warning as "nothing matched", not "this content is safe."
+
 ## Performance
 
 Database connections are pooled internally (min 1, max 10 by default) rather than opened fresh on every call. Previously every ingest, ask, and memory operation opened a brand-new Postgres connection and closed it afterward - real, avoidable latency, especially under concurrent load (e.g. a web server handling multiple requests at once). This is automatic and requires no configuration.

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.4.5"
+version = "0.4.6"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -30,11 +30,12 @@ from ragleap.memory import ConversationMemory
 from ragleap.reranking import RerankerService
 from ragleap.db import ConnectionPool
 from ragleap.cache import QueryEmbeddingCache
+from ragleap import sanitization as _sanitization
 from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.4.5"
+__version__ = "0.4.6"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult"]
 
 
@@ -123,8 +124,36 @@ class RagLeap:
         text = extract_text(filename, raw_bytes)
         return self.ingest_text(filename, text)
 
-    def ingest_text(self, filename: str, text: str, metadata: Optional[Dict] = None) -> IngestResult:
-        """Same as ingest(), but for text you've already extracted yourself."""
+    def ingest_text(
+        self,
+        filename: str,
+        text: str,
+        metadata: Optional[Dict] = None,
+        sanitize: bool = True,
+        warn_on_injection_risk: bool = True,
+    ) -> IngestResult:
+        """
+        Same as ingest(), but for text you've already extracted yourself.
+
+        sanitize=True (default) strips null bytes, control characters,
+        and invisible/zero-width Unicode from the text before chunking.
+        warn_on_injection_risk=True (default) logs a warning if common
+        prompt-injection trigger phrases are found - this is a heuristic
+        signal for review, not a guarantee the content is safe, and
+        nothing is blocked automatically.
+        """
+        if sanitize:
+            text = _sanitization.sanitize_text(text)
+
+        if warn_on_injection_risk:
+            risk_matches = _sanitization.detect_injection_risk(text)
+            if risk_matches:
+                logger.warning(
+                    f"Possible prompt-injection content in '{filename}': "
+                    f"matched phrase(s) {risk_matches}. This is a heuristic "
+                    f"signal, not a block - review the content if unexpected."
+                )
+
         chunks = self._chunker.chunk_text(text)
         if not chunks:
             raise ValueError("No chunks produced from input text — is it empty?")

--- a/packages/ragleap-rag/src/ragleap/sanitization.py
+++ b/packages/ragleap-rag/src/ragleap/sanitization.py
@@ -1,0 +1,83 @@
+"""
+Content sanitization and injection-risk detection for ragleap-rag.
+
+Honest scope: this reduces risk, it does not eliminate it. Prompt
+injection via retrieved content is an open research problem with no
+complete solution at the library level - a sufficiently motivated
+attacker can still craft content that evades pattern-based detection.
+What this module does provide:
+
+1. Character-level sanitization - strips null bytes, control
+   characters, and invisible/zero-width Unicode characters, a
+   documented technique for hiding instructions inside text that
+   looks normal to a human reviewer.
+2. Heuristic injection-pattern detection - flags common trigger
+   phrases at ingest time. This is pattern matching, not semantic
+   understanding, and will miss novel or obfuscated attempts. Treat
+   flagged content as a signal to review, not a guarantee of safety.
+3. A basic length guard against abuse via extremely long single chunks.
+"""
+import logging
+import re
+import unicodedata
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_CHUNK_LENGTH = 50_000
+
+# Common prompt-injection trigger phrases. Heuristic, not exhaustive -
+# a determined attacker can rephrase around any fixed list.
+INJECTION_PATTERNS = [
+    r"ignore (all )?(previous|prior|above) instructions",
+    r"disregard (all )?(previous|prior|above) instructions",
+    r"you are now",
+    r"new instructions:",
+    r"system prompt:",
+    r"\bsystem:\s",
+    r"forget (everything|all) (you|that)",
+    r"reveal your (system prompt|instructions)",
+    r"act as if",
+    r"do not (follow|obey) (your|the) (previous|original) instructions",
+]
+
+_COMPILED_PATTERNS = [re.compile(p, re.IGNORECASE) for p in INJECTION_PATTERNS]
+
+
+def sanitize_text(text: str) -> str:
+    """
+    Strip null bytes, control characters (except newline/tab), and
+    invisible/zero-width Unicode characters. Safe to call on any text -
+    normal content is unaffected.
+    """
+    if not text:
+        return text
+
+    # Remove null bytes and most control characters, but keep \n and \t
+    cleaned = "".join(
+        ch for ch in text
+        if ch in ("\n", "\t") or unicodedata.category(ch) not in ("Cc", "Cf")
+    )
+    return cleaned
+
+
+def detect_injection_risk(text: str) -> List[str]:
+    """
+    Return a list of matched suspicious phrases, if any. Empty list
+    means no known pattern matched - not a guarantee the content is
+    safe, just that it didn't match this heuristic list.
+    """
+    if not text:
+        return []
+
+    matches = []
+    for pattern in _COMPILED_PATTERNS:
+        found = pattern.search(text)
+        if found:
+            matches.append(found.group(0))
+    return matches
+
+
+def check_length(text: str, max_length: int = DEFAULT_MAX_CHUNK_LENGTH) -> bool:
+    """Return True if text is within the allowed length."""
+    return len(text) <= max_length


### PR DESCRIPTION
Adds defensive measures at ingest time, a real gap flagged directly against RAG's known attack surface - malicious content embedded and later surfaced to an LLM via retrieval.

Honest scope, stated explicitly in the module docstring and README: this reduces risk, it does not eliminate it. Prompt injection via retrieved content is an open research problem with no complete solution at the library level.

- New sanitization.py: sanitize_text() strips null bytes, control characters, and invisible/zero-width Unicode - a documented technique for hiding instructions inside text that looks normal to a human reviewer
- detect_injection_risk() does heuristic pattern matching against a fixed list of common trigger phrases ("ignore previous instructions", "reveal your system prompt", etc) - pattern matching, not semantic understanding, will miss novel or obfuscated attempts
- ingest_text() gets sanitize=True and warn_on_injection_risk=True as defaults - sanitization is applied automatically, injection risk is logged as a WARNING but never blocks ingestion (a library should not silently drop content the caller explicitly asked to ingest)
- Both are opt-out per call for callers who sanitize upstream
- New README Content sanitization section with the honest limitation spelled out directly, not buried in a docstring only
- Bumped to 0.4.6

Verified: rebuilt, force-reinstalled from wheel, live test - confirmed sanitize_text() actually removes a null byte and zero-width Unicode spaces while preserving normal visible text; confirmed detect_injection_risk() matches two distinct patterns in a crafted injection attempt and zero patterns in ordinary business text (no false positive); confirmed ingest_text() logs the expected WARNING for suspicious content but still successfully ingests it, proving this is a signal, not a block, as documented.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
