### PR TITLE
feat: citation clarity (chunk-level, structured citations)

### DIFF
--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -181,6 +181,20 @@ Sanitization strips null bytes, control characters, and invisible/zero-width Uni
 
 Injection-risk detection is heuristic pattern matching against a fixed list of common trigger phrases ("ignore previous instructions", "reveal your system prompt", etc). It logs a warning and does NOT block ingestion. Honest limitation: this is pattern matching, not semantic understanding - prompt injection via retrieved content is an open research problem, and a sufficiently motivated attacker can rephrase around any fixed pattern list. Treat a warning as a signal to review, not a guarantee of safety, and treat the absence of a warning as "nothing matched", not "this content is safe."
 
+## Citations
+
+Every ask() response includes a citations field - a structured, chunk-level breakdown that resolves a real ambiguity: a citation like "(Source 1)" in an answer could mean a whole document or one specific passage within it. It always means the latter.
+
+```python
+answer = rag.ask("What is our refund policy?")
+print(answer["answer"])
+
+for c in answer["citations"]:
+    print(c["source_number"], c["document_name"], "chunk", c["chunk_index"], "-", c["text_preview"])
+```
+
+Each citation includes source_number (matching the [Source N] label the model was given in its prompt), document_name, document_id, chunk_id, chunk_index, and a text_preview of that specific chunk - enough to verify exactly which passage backs a claim, which matters for audit or compliance use cases. The existing sources field (a deduped list of document names) is unchanged for backward compatibility.
+
 ## Performance
 
 Database connections are pooled internally (min 1, max 10 by default) rather than opened fresh on every call. Previously every ingest, ask, and memory operation opened a brand-new Postgres connection and closed it afterward - real, avoidable latency, especially under concurrent load (e.g. a web server handling multiple requests at once). This is automatic and requires no configuration.

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.4.6"
+version = "0.4.7"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -35,7 +35,7 @@ from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.4.6"
+__version__ = "0.4.7"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult"]
 
 
@@ -220,7 +220,7 @@ class RagLeap:
         query_embedding = self._embed_query_cached(query)
         if query_embedding is None:
             return {"answer": "Sorry, I couldn't process your question (embedding failed).",
-                    "sources": [], "provider_used": None, "usage": None, "chunks_sent": 0}
+                    "sources": [], "citations": [], "provider_used": None, "usage": None, "chunks_sent": 0}
 
         pool_size = top_k * 4 if rerank else top_k
         if hybrid:

--- a/packages/ragleap-rag/src/ragleap/generation.py
+++ b/packages/ragleap-rag/src/ragleap/generation.py
@@ -114,8 +114,30 @@ class GenerationService:
         parts = []
         for i, chunk in enumerate(chunks, start=1):
             doc_name = chunk.get("document_name", "unknown document")
-            parts.append(f"[Source {i}: {doc_name}]\n{chunk.get('text', '')}")
+            chunk_index = chunk.get("chunk_index", "?")
+            parts.append(f"[Source {i}: {doc_name}, chunk {chunk_index}]\n{chunk.get('text', '')}")
         return "\n\n".join(parts)
+
+    def _build_citations(self, chunks: List[Dict]) -> List[Dict]:
+        """
+        Structured citation list mapping each [Source N] label used in
+        the prompt to the specific chunk it refers to - resolves the
+        ambiguity of whether a citation like "(Source 1)" in an answer
+        means a whole document or a specific passage. It is always the
+        latter: chunk-level, not document-level.
+        """
+        citations = []
+        for i, chunk in enumerate(chunks, start=1):
+            text = chunk.get("text", "")
+            citations.append({
+                "source_number": i,
+                "document_name": chunk.get("document_name", "unknown document"),
+                "document_id": chunk.get("document_id"),
+                "chunk_id": chunk.get("chunk_id"),
+                "chunk_index": chunk.get("chunk_index"),
+                "text_preview": text[:150] + ("..." if len(text) > 150 else ""),
+            })
+        return citations
 
     def _build_prompt(self, query: str, chunks: List[Dict], system_prompt: Optional[str], history_prefix: str = "") -> str:
         context = self._build_context(chunks)
@@ -140,6 +162,7 @@ class GenerationService:
 
         trimmed = self._trim_chunks_to_budget(chunks)
         sources = list({c.get("document_name", "unknown") for c in trimmed})
+        citations = self._build_citations(trimmed)
         prompt = self._build_prompt(query, trimmed, system_prompt, history_prefix)
 
         last_error = None
@@ -149,7 +172,7 @@ class GenerationService:
                 if i > 0:
                     logger.info(f"Answer generated via fallback provider '{config.provider}'")
                 return {
-                    "answer": answer_text, "sources": sources,
+                    "answer": answer_text, "sources": sources, "citations": citations,
                     "provider_used": config.provider, "usage": usage,
                     "chunks_sent": len(trimmed),
                 }
@@ -160,7 +183,7 @@ class GenerationService:
 
         return {
             "answer": f"Sorry, all configured providers failed. Last error: {last_error}",
-            "sources": [], "provider_used": None, "usage": None, "chunks_sent": 0,
+            "sources": [], "citations": [], "provider_used": None, "usage": None, "chunks_sent": 0,
         }
 
     def generate_answer_stream(


### PR DESCRIPTION
Resolves a real ambiguity flagged in the gap analysis: a citation like "(Source 1)" in an answer previously gave no way to tell whether it referred to a whole document or one specific passage within it. It was always chunk-level internally, but this was never documented or exposed - a real gap for audit/compliance use cases.

- _build_context()'s [Source N] labels now explicitly include the chunk index (e.g. "[Source 1: handbook.txt, chunk 3]"), not just the filename - the model itself now cites chunks explicitly in its answers, confirmed in a live test
- New citations field on generate_answer()'s return dict: a structured list mapping each source_number to its document_name, document_id, chunk_id, chunk_index, and a text_preview
- Existing sources field (deduped document names) is unchanged - this is additive, not a breaking change
- citations: [] added consistently to every failure-path return (provider failure, embedding failure) so the field is always present
- New README Citations section
- Bumped to 0.4.7

Verified: rebuilt, force-reinstalled from wheel, live test against real Postgres + Gemini - the model's actual answer text cited sources using the new explicit chunk-level format, and the returned citations list correctly mapped each source_number to the right document_name, chunk_index, and a verifiable text_preview matching what was actually retrieved.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
