### PR TITLE
feat: URL ingestion (ingest_url)

### DIFF
--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -195,6 +195,21 @@ for c in answer["citations"]:
 
 Each citation includes source_number (matching the [Source N] label the model was given in its prompt), document_name, document_id, chunk_id, chunk_index, and a text_preview of that specific chunk - enough to verify exactly which passage backs a claim, which matters for audit or compliance use cases. The existing sources field (a deduped list of document names) is unchanged for backward compatibility.
 
+## URL ingestion
+
+ingest_url() fetches a web page and extracts clean, readable text - stripping navigation, ads, and other boilerplate via trafilatura - rather than ingesting raw HTML markup. Requires the web extra.
+
+```bash
+pip install ragleap-rag[web]
+```
+
+```python
+result = rag.ingest_url("https://example.com/blog/some-article")
+answer = rag.ask("What does the article say about X?")
+```
+
+The URL itself is stored as the document_name, so citations point back to the original page. Metadata works the same as ingest_text() - pass metadata= to tag the ingested content.
+
 ## Performance
 
 Database connections are pooled internally (min 1, max 10 by default) rather than opened fresh on every call. Previously every ingest, ask, and memory operation opened a brand-new Postgres connection and closed it afterward - real, avoidable latency, especially under concurrent load (e.g. a web server handling multiple requests at once). This is automatic and requires no configuration.

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.4.7"
+version = "0.5.0"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"
@@ -37,7 +37,8 @@ gemini = ["google-genai>=0.3.0"]
 anthropic = ["anthropic>=0.34.0"]
 openai = ["openai>=1.40.0"]
 rerank = ["sentence-transformers>=3.0.0"]
-all = ["google-genai>=0.3.0", "anthropic>=0.34.0", "openai>=1.40.0", "sentence-transformers>=3.0.0"]
+web = ["trafilatura>=1.6.0"]
+all = ["google-genai>=0.3.0", "anthropic>=0.34.0", "openai>=1.40.0", "sentence-transformers>=3.0.0", "trafilatura>=1.6.0"]
 
 [project.urls]
 Homepage = "https://github.com/antonyrag/ragleap-core"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -31,11 +31,12 @@ from ragleap.reranking import RerankerService
 from ragleap.db import ConnectionPool
 from ragleap.cache import QueryEmbeddingCache
 from ragleap import sanitization as _sanitization
+from ragleap import web as _web
 from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.4.7"
+__version__ = "0.5.0"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult"]
 
 
@@ -123,6 +124,18 @@ class RagLeap:
         """
         text = extract_text(filename, raw_bytes)
         return self.ingest_text(filename, text)
+
+    def ingest_url(self, url: str, metadata: Optional[Dict] = None) -> IngestResult:
+        """
+        Fetch a web page, extract clean readable text (stripping nav/
+        ads/footers via trafilatura), and ingest it. Requires the
+        'web' extra: pip install ragleap-rag[web]. The URL itself is
+        used as the stored filename/document_name.
+        """
+        text = _web.fetch_url_text(url)
+        if text is None:
+            raise ValueError(f"Could not extract usable text from URL: {url}")
+        return self.ingest_text(url, text, metadata=metadata)
 
     def ingest_text(
         self,

--- a/packages/ragleap-rag/src/ragleap/web.py
+++ b/packages/ragleap-rag/src/ragleap/web.py
@@ -1,0 +1,40 @@
+"""
+URL ingestion for ragleap-rag. Fetches a web page and extracts clean,
+readable text (stripping navigation, ads, footers, and other
+boilerplate) - requires the [web] extra (trafilatura).
+"""
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_url_text(url: str) -> Optional[str]:
+    """
+    Fetch a URL and return clean extracted text, or None if fetching
+    or extraction failed. Requires the 'web' extra.
+    """
+    try:
+        import trafilatura
+    except ImportError:
+        raise ImportError(
+            "URL ingestion requires the 'web' extra. Install it with: "
+            "pip install ragleap-rag[web]"
+        )
+
+    try:
+        downloaded = trafilatura.fetch_url(url)
+    except Exception as e:
+        logger.error(f"Failed to fetch URL '{url}': {e}")
+        return None
+
+    if downloaded is None:
+        logger.warning(f"No content downloaded from '{url}'")
+        return None
+
+    text = trafilatura.extract(downloaded, include_comments=False, include_tables=True)
+    if not text or not text.strip():
+        logger.warning(f"No extractable text found at '{url}'")
+        return None
+
+    return text


### PR DESCRIPTION
First of the multi-modal ingestion additions - directly closes part of the 'document loader breadth' gap flagged against LangChain, which has 100+ loaders vs ragleap-rag's previous txt/pdf/docx-only support.

- New web.py: fetch_url_text() wraps trafilatura, extracting clean readable text (stripping nav/ads/footers) rather than raw HTML
- New [web] optional extra (pip install ragleap-rag[web])
- RagLeap.ingest_url(url, metadata=None) fetches, extracts, and ingests in one call - the URL itself is stored as document_name, so citations point back to the original page
- New README URL ingestion section
- Bumped to 0.5.0 (minor version - begins the multi-modal ingestion milestone, a real capability expansion, not just a patch)

Real bug caught and fixed during verification: the initial implementation assumed trafilatura.fetch_url() accepted a timeout= kwarg based on outdated API knowledge. The installed version (2.1.0) does not - confirmed via inspect.signature() against the actual installed package rather than assuming, then fixed to match the real API rather than guessing again.

Verified: rebuilt, installed with [web] extra, live test - ingested the actual Wikipedia article on retrieval-augmented generation (5 chunks), then asked 'What is retrieval-augmented generation?' and got a genuinely accurate, well-grounded answer with correct citations showing the URL as document_name across 3 distinct chunks.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
