### PR TITLE
feat: expanded document format support (28 formats)

### DIFF
--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -210,6 +210,29 @@ answer = rag.ask("What does the article say about X?")
 
 The URL itself is stored as the document_name, so citations point back to the original page. Metadata works the same as ingest_text() - pass metadata= to tag the ingested content.
 
+## Supported file formats
+
+rag.ingest(filename, raw_bytes) supports 28 formats via file extension, dispatched automatically. Core formats (txt, pdf, docx, md) work with the base install; everything else requires the formats extra.
+
+```bash
+pip install ragleap-rag[formats]
+```
+
+**Office & documents**: pdf, docx, pptx, odt, ods, odp, rtf
+**Spreadsheets & tabular**: xlsx, xls, csv, tsv, parquet
+**Structured data**: json, yaml, xml, xsl, xslt
+**Markup & web**: html, htm, md
+**Archives & email**: zip (recurses into supported files inside), eml
+**Books & media metadata**: epub, vtt, srt (subtitle cue numbers and timestamps are stripped, spoken text kept)
+**Plain text**: txt, sql
+
+**Not supported**: legacy binary .doc and .ppt (pre-2007 Office formats) - no reliable pure-Python parser exists for these. Convert to the modern equivalent first, e.g. via LibreOffice headless: soffice --headless --convert-to docx yourfile.doc
+
+```python
+with open("report.xlsx", "rb") as f:
+    rag.ingest("report.xlsx", f.read())
+```
+
 ## Performance
 
 Database connections are pooled internally (min 1, max 10 by default) rather than opened fresh on every call. Previously every ingest, ask, and memory operation opened a brand-new Postgres connection and closed it afterward - real, avoidable latency, especially under concurrent load (e.g. a web server handling multiple requests at once). This is automatic and requires no configuration.

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.5.0"
+version = "0.5.1"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"
@@ -38,7 +38,18 @@ anthropic = ["anthropic>=0.34.0"]
 openai = ["openai>=1.40.0"]
 rerank = ["sentence-transformers>=3.0.0"]
 web = ["trafilatura>=1.6.0"]
-all = ["google-genai>=0.3.0", "anthropic>=0.34.0", "openai>=1.40.0", "sentence-transformers>=3.0.0", "trafilatura>=1.6.0"]
+formats = [
+    "openpyxl>=3.1.0",
+    "xlrd>=2.0.0",
+    "python-pptx>=1.0.0",
+    "odfpy>=1.4.0",
+    "striprtf>=0.0.26",
+    "beautifulsoup4>=4.12.0",
+    "ebooklib>=0.18",
+    "pyyaml>=6.0",
+    "pyarrow>=14.0.0",
+]
+all = ["google-genai>=0.3.0", "anthropic>=0.34.0", "openai>=1.40.0", "sentence-transformers>=3.0.0", "trafilatura>=1.6.0", "openpyxl>=3.1.0", "xlrd>=2.0.0", "python-pptx>=1.0.0", "odfpy>=1.4.0", "striprtf>=0.0.26", "beautifulsoup4>=4.12.0", "ebooklib>=0.18", "pyyaml>=6.0", "pyarrow>=14.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/antonyrag/ragleap-core"

--- a/packages/ragleap-rag/src/ragleap/parsers.py
+++ b/packages/ragleap-rag/src/ragleap/parsers.py
@@ -1,27 +1,91 @@
 """
 Document text extraction for ragleap-rag.
-Supports .txt, .pdf, .docx.
+
+Core formats (txt, pdf, docx) work with the base install. Everything
+else requires the 'formats' extra: pip install ragleap-rag[formats]
+
+Not supported: legacy binary .doc and .ppt (pre-2007 Office formats).
+No reliable pure-Python parser exists for these - convert to .docx/
+.pptx first (e.g. via LibreOffice headless, or Microsoft Office
+"Save As"), or use a dedicated conversion service.
 """
+import csv
 import io
+import json
 import logging
+import zipfile
 
 logger = logging.getLogger(__name__)
 
-SUPPORTED_EXTENSIONS = {".txt", ".pdf", ".docx"}
+CORE_EXTENSIONS = {".txt", ".pdf", ".docx", ".md"}
+EXTENDED_EXTENSIONS = {
+    ".xlsx", ".xls", ".csv", ".tsv", ".xsl", ".xslt", ".pptx", ".html", ".htm",
+    ".json", ".xml", ".rtf", ".odt", ".ods", ".odp", ".eml", ".zip", ".sql",
+    ".epub", ".yaml", ".yml", ".parquet", ".vtt", ".srt",
+}
+SUPPORTED_EXTENSIONS = CORE_EXTENSIONS | EXTENDED_EXTENSIONS
+UNSUPPORTED_LEGACY = {".doc", ".ppt"}
+
+
+def _require(module_name: str, extra_hint: str = "formats"):
+    try:
+        return __import__(module_name)
+    except ImportError as e:
+        raise ValueError(
+            f"'{module_name}' is required for this file type — "
+            f"pip install ragleap-rag[{extra_hint}]"
+        ) from e
 
 
 def extract_text(filename: str, raw_bytes: bytes) -> str:
     """Extract plain text from raw file bytes, dispatching on file extension."""
     ext = filename.lower().rsplit(".", 1)[-1] if "." in filename else ""
     ext = f".{ext}"
-    if ext == ".txt":
-        return _extract_txt(raw_bytes)
-    elif ext == ".pdf":
-        return _extract_pdf(raw_bytes)
-    elif ext == ".docx":
-        return _extract_docx(raw_bytes)
-    else:
+
+    if ext in UNSUPPORTED_LEGACY:
+        raise ValueError(
+            f"'{ext}' (legacy binary Office format) is not supported — no reliable "
+            f"pure-Python parser exists. Convert to the modern equivalent first "
+            f"(.docx/.pptx), e.g. via LibreOffice headless: "
+            f"'soffice --headless --convert-to docx yourfile.doc'"
+        )
+
+    dispatch = {
+        ".txt": _extract_txt,
+        ".md": _extract_txt,
+        ".pdf": _extract_pdf,
+        ".docx": _extract_docx,
+        ".xlsx": _extract_xlsx,
+        ".xls": _extract_xls,
+        ".csv": _extract_csv,
+        ".tsv": lambda b: _extract_csv(b, delimiter="\t"),
+        ".xsl": _extract_xml,
+        ".xslt": _extract_xml,
+        ".pptx": _extract_pptx,
+        ".html": _extract_html,
+        ".htm": _extract_html,
+        ".json": _extract_json,
+        ".xml": _extract_xml,
+        ".rtf": _extract_rtf,
+        ".odt": _extract_odt,
+        ".ods": _extract_ods,
+        ".odp": _extract_odp,
+        ".eml": _extract_eml,
+        ".zip": _extract_zip,
+        ".sql": _extract_txt,
+        ".epub": _extract_epub,
+        ".yaml": _extract_yaml,
+        ".yml": _extract_yaml,
+        ".parquet": _extract_parquet,
+        ".vtt": _extract_subtitle,
+        ".srt": _extract_subtitle,
+    }
+
+    handler = dispatch.get(ext)
+    if handler is None:
         raise ValueError(f"Unsupported file type '{ext}'. Supported: {', '.join(sorted(SUPPORTED_EXTENSIONS))}.")
+
+    return handler(raw_bytes)
 
 
 def _extract_txt(raw_bytes: bytes) -> str:
@@ -67,3 +131,200 @@ def _extract_docx(raw_bytes: bytes) -> str:
     if not full_text.strip():
         raise ValueError("No text could be extracted from this DOCX file — it may be empty.")
     return full_text
+
+
+def _extract_xlsx(raw_bytes: bytes) -> str:
+    openpyxl = _require("openpyxl")
+    wb = openpyxl.load_workbook(io.BytesIO(raw_bytes), data_only=True)
+    parts = []
+    for sheet in wb.worksheets:
+        parts.append(f"[Sheet: {sheet.title}]")
+        for row in sheet.iter_rows(values_only=True):
+            row_text = "\t".join(str(c) for c in row if c is not None)
+            if row_text.strip():
+                parts.append(row_text)
+    return "\n".join(parts)
+
+
+def _extract_xls(raw_bytes: bytes) -> str:
+    xlrd = _require("xlrd")
+    wb = xlrd.open_workbook(file_contents=raw_bytes)
+    parts = []
+    for sheet in wb.sheets():
+        parts.append(f"[Sheet: {sheet.name}]")
+        for row_idx in range(sheet.nrows):
+            row = sheet.row_values(row_idx)
+            row_text = "\t".join(str(c) for c in row if c != "")
+            if row_text.strip():
+                parts.append(row_text)
+    return "\n".join(parts)
+
+
+def _extract_csv(raw_bytes: bytes, delimiter: str = ",") -> str:
+    text = _extract_txt(raw_bytes)
+    reader = csv.reader(io.StringIO(text), delimiter=delimiter)
+    return "\n".join("\t".join(row) for row in reader)
+
+
+def _extract_pptx(raw_bytes: bytes) -> str:
+    pptx = _require("pptx", extra_hint="formats")
+    prs = pptx.Presentation(io.BytesIO(raw_bytes))
+    parts = []
+    for i, slide in enumerate(prs.slides, start=1):
+        slide_text = []
+        for shape in slide.shapes:
+            if shape.has_text_frame:
+                for para in shape.text_frame.paragraphs:
+                    text = "".join(run.text for run in para.runs)
+                    if text.strip():
+                        slide_text.append(text)
+        if slide.has_notes_slide and slide.notes_slide.notes_text_frame:
+            notes = slide.notes_slide.notes_text_frame.text
+            if notes.strip():
+                slide_text.append(f"[Speaker notes: {notes}]")
+        if slide_text:
+            parts.append(f"[Slide {i}]\n" + "\n".join(slide_text))
+    return "\n\n".join(parts)
+
+
+def _extract_html(raw_bytes: bytes) -> str:
+    bs4 = _require("bs4")
+    soup = bs4.BeautifulSoup(raw_bytes, "html.parser")
+    for tag in soup(["script", "style"]):
+        tag.decompose()
+    return soup.get_text(separator="\n", strip=True)
+
+
+def _extract_json(raw_bytes: bytes) -> str:
+    data = json.loads(_extract_txt(raw_bytes))
+    return json.dumps(data, indent=2, ensure_ascii=False)
+
+
+def _extract_xml(raw_bytes: bytes) -> str:
+    bs4 = _require("bs4")
+    soup = bs4.BeautifulSoup(raw_bytes, "xml")
+    return soup.get_text(separator="\n", strip=True)
+
+
+def _extract_rtf(raw_bytes: bytes) -> str:
+    striprtf = _require("striprtf")
+    from striprtf.striprtf import rtf_to_text
+    return rtf_to_text(_extract_txt(raw_bytes))
+
+
+def _extract_odt(raw_bytes: bytes) -> str:
+    odf_opendoc = _require("odf.opendocument", extra_hint="formats")
+    from odf import text as odf_text
+    from odf.opendocument import load
+    doc = load(io.BytesIO(raw_bytes))
+    paragraphs = doc.getElementsByType(odf_text.P)
+    return "\n".join(str(p) for p in paragraphs)
+
+
+def _extract_ods(raw_bytes: bytes) -> str:
+    from odf.opendocument import load
+    from odf.table import Table, TableRow, TableCell
+    doc = load(io.BytesIO(raw_bytes))
+    parts = []
+    for table in doc.getElementsByType(Table):
+        for row in table.getElementsByType(TableRow):
+            cells = row.getElementsByType(TableCell)
+            row_text = "\t".join(str(c) for c in cells)
+            if row_text.strip():
+                parts.append(row_text)
+    return "\n".join(parts)
+
+
+def _extract_odp(raw_bytes: bytes) -> str:
+    from odf import text as odf_text
+    from odf.opendocument import load
+    doc = load(io.BytesIO(raw_bytes))
+    paragraphs = doc.getElementsByType(odf_text.P)
+    return "\n".join(str(p) for p in paragraphs)
+
+
+def _extract_eml(raw_bytes: bytes) -> str:
+    import email
+    from email import policy
+    msg = email.message_from_bytes(raw_bytes, policy=policy.default)
+    parts = [f"From: {msg.get('From', '')}", f"To: {msg.get('To', '')}", f"Subject: {msg.get('Subject', '')}"]
+    body = msg.get_body(preferencelist=("plain", "html"))
+    if body:
+        content = body.get_content()
+        if body.get_content_type() == "text/html":
+            content = _extract_html(content.encode("utf-8"))
+        parts.append(content)
+    return "\n".join(parts)
+
+
+def _extract_zip(raw_bytes: bytes) -> str:
+    """Extracts and concatenates text from every supported file inside the zip."""
+    parts = []
+    with zipfile.ZipFile(io.BytesIO(raw_bytes)) as z:
+        for name in z.namelist():
+            if name.endswith("/"):
+                continue
+            ext = f".{name.lower().rsplit('.', 1)[-1]}" if "." in name else ""
+            if ext not in SUPPORTED_EXTENSIONS or ext == ".zip":
+                continue
+            try:
+                inner_bytes = z.read(name)
+                inner_text = extract_text(name, inner_bytes)
+                if inner_text.strip():
+                    parts.append(f"[File: {name}]\n{inner_text}")
+            except Exception as e:
+                logger.warning(f"Skipping '{name}' inside zip — extraction failed: {e}")
+    if not parts:
+        raise ValueError("No extractable text found in any file inside this zip.")
+    return "\n\n".join(parts)
+
+
+def _extract_epub(raw_bytes: bytes) -> str:
+    ebooklib = _require("ebooklib")
+    import ebooklib as _eb
+    from ebooklib import epub
+    import tempfile, os as _os
+    with tempfile.NamedTemporaryFile(suffix=".epub", delete=False) as f:
+        f.write(raw_bytes)
+        tmp_path = f.name
+    try:
+        book = epub.read_epub(tmp_path)
+        parts = []
+        for item in book.get_items_of_type(_eb.ITEM_DOCUMENT):
+            html_text = _extract_html(item.get_content())
+            if html_text.strip():
+                parts.append(html_text)
+        return "\n\n".join(parts)
+    finally:
+        _os.unlink(tmp_path)
+
+
+def _extract_yaml(raw_bytes: bytes) -> str:
+    yaml = _require("yaml", extra_hint="formats")
+    data = yaml.safe_load(_extract_txt(raw_bytes))
+    return json.dumps(data, indent=2, ensure_ascii=False, default=str)
+
+
+def _extract_parquet(raw_bytes: bytes) -> str:
+    pyarrow = _require("pyarrow")
+    import pyarrow.parquet as pq
+    table = pq.read_table(io.BytesIO(raw_bytes))
+    df = table.to_pandas()
+    return df.to_csv(index=False, sep="\t")
+
+
+def _extract_subtitle(raw_bytes: bytes) -> str:
+    """Strips timestamps/cue numbers from .vtt/.srt subtitle files, keeping spoken text."""
+    text = _extract_txt(raw_bytes)
+    lines = text.splitlines()
+    kept = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped == "WEBVTT":
+            continue
+        if stripped.isdigit():
+            continue
+        if "-->" in stripped:
+            continue
+        kept.append(stripped)
+    return "\n".join(kept)


### PR DESCRIPTION
Second part of the multi-modal ingestion milestone. Previously ingest()/ingest_text() supported only txt/pdf/docx - a real gap against LangChain's 100+ document loaders. This adds 25 more format handlers across office documents, spreadsheets, structured data, markup, archives, and subtitle files.

- New [formats] optional extra bundling openpyxl, xlrd, python-pptx, odfpy, striprtf, beautifulsoup4, ebooklib, pyyaml, pyarrow
- Office & documents: pptx (including speaker notes), odt, ods, odp, rtf
- Spreadsheets & tabular: xlsx, xls, csv, tsv, parquet
- Structured data: json, yaml, xml, xsl, xslt (normalized to readable text/JSON rather than raw markup)
- Markup & web: html, htm, md
- Archives & email: zip (recurses into every supported file inside the archive and concatenates their extracted text), eml
- Books & subtitles: epub, vtt, srt (cue numbers and timestamps stripped, spoken text kept - directly useful ahead of the planned audio/video ingestion work, since transcripts often already exist as subtitle files)
- Explicitly NOT supported: legacy binary .doc and .ppt (pre-2007 Office formats) - no reliable pure-Python parser exists. Raises a clear error with a concrete LibreOffice conversion command rather than failing silently or half-working
- New README Supported file formats section
- Bumped to 0.5.1

Verified: rebuilt, installed with [formats] extra, live tests across representative format families - CSV (correct row parsing), JSON (correct round-trip), YAML (correctly parsed and normalized, proving real yaml.safe_load rather than passthrough), HTML (script tags genuinely stripped while real content preserved), XLSX (correct sheet/row extraction via a real openpyxl workbook), ZIP (correctly recursed into and extracted both a nested .txt and .json file), and SRT (cue numbers and timestamps correctly stripped, spoken lines preserved).

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
