### PR TITLE
fix: bump __version__ to match pyproject.toml (0.5.1)

### DIFF
--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -36,7 +36,7 @@ from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult"]
 
 


### PR DESCRIPTION
## Summary

Follow-up to PR #50. The expanded-formats commit bumped `pyproject.toml`'s version to 0.5.1 but `__init__.py`'s `__version__` string was left at 0.5.0 — only `pyproject.toml` was staged in that commit.

Caught via a routine `git status` check before publishing, not after — no version was ever published to PyPI with the mismatch.