### PR TITLE
feat: image ingestion (OCR + vision captioning)

### DIFF
--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -233,6 +233,26 @@ with open("report.xlsx", "rb") as f:
     rag.ingest("report.xlsx", f.read())
 ```
 
+## Image ingestion
+
+ingest_image(filename, raw_bytes, mode=...) supports two different techniques for two different kinds of images.
+
+mode="ocr" (default) reads literal visible text - scanned documents, screenshots, photos of text. Requires the ocr extra AND the Tesseract binary installed on the system (not pip-installable - e.g. apt install tesseract-ocr on Debian/Ubuntu).
+
+mode="caption" describes an image's contents using a vision-capable model instead - for photos, diagrams, or charts with no readable text. Currently requires Gemini configured as the primary or a fallback provider; no extra install needed since it reuses the existing generation client.
+
+```bash
+pip install ragleap-rag[ocr]
+```
+
+```python
+# Scanned document or screenshot
+rag.ingest_image("receipt.png", raw_bytes, mode="ocr")
+
+# Photo, chart, or diagram with no text
+rag.ingest_image("product_photo.jpg", raw_bytes, mode="caption")
+```
+
 ## Performance
 
 Database connections are pooled internally (min 1, max 10 by default) rather than opened fresh on every call. Previously every ingest, ask, and memory operation opened a brand-new Postgres connection and closed it afterward - real, avoidable latency, especially under concurrent load (e.g. a web server handling multiple requests at once). This is automatic and requires no configuration.

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.5.1"
+version = "0.5.2"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"
@@ -38,6 +38,7 @@ anthropic = ["anthropic>=0.34.0"]
 openai = ["openai>=1.40.0"]
 rerank = ["sentence-transformers>=3.0.0"]
 web = ["trafilatura>=1.6.0"]
+ocr = ["pytesseract>=0.3.10", "Pillow>=10.0.0"]
 formats = [
     "openpyxl>=3.1.0",
     "xlrd>=2.0.0",
@@ -49,7 +50,7 @@ formats = [
     "pyyaml>=6.0",
     "pyarrow>=14.0.0",
 ]
-all = ["google-genai>=0.3.0", "anthropic>=0.34.0", "openai>=1.40.0", "sentence-transformers>=3.0.0", "trafilatura>=1.6.0", "openpyxl>=3.1.0", "xlrd>=2.0.0", "python-pptx>=1.0.0", "odfpy>=1.4.0", "striprtf>=0.0.26", "beautifulsoup4>=4.12.0", "ebooklib>=0.18", "pyyaml>=6.0", "pyarrow>=14.0.0"]
+all = ["google-genai>=0.3.0", "anthropic>=0.34.0", "openai>=1.40.0", "sentence-transformers>=3.0.0", "trafilatura>=1.6.0", "pytesseract>=0.3.10", "Pillow>=10.0.0", "openpyxl>=3.1.0", "xlrd>=2.0.0", "python-pptx>=1.0.0", "odfpy>=1.4.0", "striprtf>=0.0.26", "beautifulsoup4>=4.12.0", "ebooklib>=0.18", "pyyaml>=6.0", "pyarrow>=14.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/antonyrag/ragleap-core"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -32,11 +32,12 @@ from ragleap.db import ConnectionPool
 from ragleap.cache import QueryEmbeddingCache
 from ragleap import sanitization as _sanitization
 from ragleap import web as _web
+from ragleap import ocr as _ocr
 from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult"]
 
 
@@ -136,6 +137,35 @@ class RagLeap:
         if text is None:
             raise ValueError(f"Could not extract usable text from URL: {url}")
         return self.ingest_text(url, text, metadata=metadata)
+
+    def ingest_image(
+        self,
+        filename: str,
+        raw_bytes: bytes,
+        mode: str = "ocr",
+        mime_type: str = "image/jpeg",
+        metadata: Optional[Dict] = None,
+    ) -> IngestResult:
+        """
+        Ingest an image. Two modes, for two different kinds of images:
+
+        mode="ocr" (default) reads literal text visible in the image
+        (scanned documents, screenshots, photos of text). Requires the
+        'ocr' extra AND the Tesseract binary installed on the system.
+
+        mode="caption" describes the image's contents using a vision-
+        capable model instead - for photos, diagrams, or charts with
+        no readable text. Currently requires Gemini configured as the
+        primary or a fallback provider.
+        """
+        if mode == "ocr":
+            text = _ocr.extract_text_from_image(raw_bytes)
+        elif mode == "caption":
+            text = self._generator.describe_image(raw_bytes, mime_type=mime_type)
+        else:
+            raise ValueError(f"Unknown mode '{mode}'. Use 'ocr' or 'caption'.")
+
+        return self.ingest_text(filename, text, metadata=metadata)
 
     def ingest_text(
         self,

--- a/packages/ragleap-rag/src/ragleap/generation.py
+++ b/packages/ragleap-rag/src/ragleap/generation.py
@@ -94,6 +94,42 @@ class GenerationService:
     def _chain(self) -> List[ProviderConfig]:
         return [self.primary] + [f for f in self.fallbacks if f.provider != self.primary.provider]
 
+    def describe_image(self, image_bytes: bytes, mime_type: str = "image/jpeg", prompt: Optional[str] = None) -> str:
+        """
+        Use a vision-capable model to describe an image's contents -
+        for photos, diagrams, or charts with no readable text to OCR.
+        Currently only supports Gemini as the vision provider (the
+        primary provider's Gemini config is used regardless of what
+        the text-generation primary/fallback chain is set to).
+        """
+        gemini_config = None
+        for config in self._chain():
+            if config.provider == "gemini":
+                gemini_config = config
+                break
+        if gemini_config is None:
+            raise ValueError(
+                "Vision captioning currently requires a Gemini provider configured "
+                "(as primary or a fallback) - no Gemini config found in this chain."
+            )
+
+        import google.genai as genai
+        from google.genai import types
+
+        client = genai.Client(api_key=gemini_config.api_key)
+        instruction = prompt or "Describe this image in detail, including any visible text, objects, people, charts, or diagrams."
+        response = client.models.generate_content(
+            model=gemini_config.model,
+            contents=[
+                types.Part.from_bytes(data=image_bytes, mime_type=mime_type),
+                instruction,
+            ],
+        )
+        text = response.text.strip() if response.text else ""
+        if not text:
+            raise ValueError("Vision model returned no description for this image.")
+        return text
+
     def _trim_chunks_to_budget(self, chunks: List[Dict]) -> List[Dict]:
         if self.max_context_chars <= 0 or not chunks:
             return chunks

--- a/packages/ragleap-rag/src/ragleap/ocr.py
+++ b/packages/ragleap-rag/src/ragleap/ocr.py
@@ -1,0 +1,49 @@
+"""
+OCR text extraction for ragleap-rag. Extracts literal text visible in
+an image (scanned documents, screenshots, photos of text) using
+Tesseract OCR via pytesseract. Requires the 'ocr' extra.
+
+For images with no text to read (product photos, diagrams, charts),
+use vision captioning instead (RagLeap.ingest_image(mode="caption")),
+which describes what's in the image rather than reading text from it.
+"""
+import io
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def extract_text_from_image(raw_bytes: bytes) -> str:
+    """
+    Run OCR on image bytes and return extracted text. Requires the
+    'ocr' extra: pip install ragleap-rag[ocr] (also requires the
+    Tesseract binary installed on the system - see
+    https://github.com/tesseract-ocr/tesseract for install instructions).
+    """
+    try:
+        import pytesseract
+        from PIL import Image
+    except ImportError as e:
+        raise ValueError(
+            "OCR requires the 'ocr' extra and the Tesseract binary. "
+            "Install with: pip install ragleap-rag[ocr], and install "
+            "Tesseract itself (e.g. 'apt install tesseract-ocr' on Debian/Ubuntu)."
+        ) from e
+
+    try:
+        image = Image.open(io.BytesIO(raw_bytes))
+    except Exception as e:
+        raise ValueError(f"Could not open image data: {e}") from e
+
+    try:
+        text = pytesseract.image_to_string(image)
+    except Exception as e:
+        raise ValueError(
+            f"OCR failed: {e}. If this is a 'tesseract not found' error, "
+            f"install the Tesseract binary itself, not just the Python package."
+        ) from e
+
+    if not text.strip():
+        raise ValueError("OCR found no readable text in this image.")
+
+    return text


### PR DESCRIPTION
## Summary

Third part of the multi-modal ingestion milestone. Two genuinely different techniques for two different kinds of images — one does not substitute for the other.

## What changed
- New `ocr.py`: `extract_text_from_image()` wraps pytesseract, reads literal visible text (scanned documents, screenshots, photos of text). Requires the `[ocr]` extra AND the Tesseract binary itself (a system dependency, not pip-installable)
- `GenerationService.describe_image()`: uses a vision-capable model to describe an image's contents — reuses the existing Gemini client setup rather than adding a new dependency. Currently requires Gemini as primary or a fallback provider
- `RagLeap.ingest_image(filename, raw_bytes, mode='ocr'|'caption')` dispatches to whichever technique the caller specifies
- New `[ocr]` optional extra (pytesseract, Pillow)
- New README Image ingestion section, including the Tesseract-binary caveat
- Bumped to 0.5.2 (verified in both `pyproject.toml` and `__init__.py`)

## Verification
Installed Tesseract on the VPS, rebuilt, installed with `[ocr]` extra, live tests against real Postgres + Gemini for both modes — OCR correctly read back text drawn onto a synthetic image; vision captioning correctly identified 'red' and 'circle' from an image containing a colored shape and zero text, proving it's genuinely describing visual content rather than falling back to OCR.