### PR TITLE
feat: audio ingestion (Whisper + Deepgram, pluggable)

### DIFF
--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -253,6 +253,29 @@ rag.ingest_image("receipt.png", raw_bytes, mode="ocr")
 rag.ingest_image("product_photo.jpg", raw_bytes, mode="caption")
 ```
 
+## Audio ingestion
+
+ingest_audio(filename, raw_bytes, transcriber=None) transcribes audio and ingests the result. Defaults to OpenAI's hosted Whisper API using OPENAI_API_KEY from the environment; pass a TranscriptionConfig to choose a different provider or add options.
+
+```python
+from ragleap import TranscriptionConfig
+
+# Default: Whisper via OpenAI
+rag.ingest_audio("meeting.mp3", raw_bytes)
+
+# Explicit config, with a vocabulary hint and language
+config = TranscriptionConfig(provider="whisper", language="en", prompt="RagLeap, pgvector, Gemini")
+rag.ingest_audio("meeting.mp3", raw_bytes, transcriber=config)
+
+# Deepgram instead
+config = TranscriptionConfig(provider="deepgram", api_key="...")
+rag.ingest_audio("meeting.mp3", raw_bytes, transcriber=config)
+```
+
+Honest limitation: transcription quality is only as good as the underlying provider. Whisper (the default) is a strong general-purpose baseline, but has no built-in denoising - quiet or noisy audio genuinely degrades accuracy - and no domain-vocabulary biasing by default, so brand names and jargon commonly get mangled unless you pass a prompt hint. Accuracy also varies meaningfully by language. Use provider="deepgram" or pass a prompt hint if these matter for your use case.
+
+Both providers use hosted APIs - no local model weights, no torch/CUDA dependency, consistent with keeping the base install light (the same reasoning behind reranking's optional [rerank] extra). Local/offline Whisper is not currently supported.
+
 ## Performance
 
 Database connections are pooled internally (min 1, max 10 by default) rather than opened fresh on every call. Previously every ingest, ask, and memory operation opened a brand-new Postgres connection and closed it afterward - real, avoidable latency, especially under concurrent load (e.g. a web server handling multiple requests at once). This is automatic and requires no configuration.

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.5.2"
+version = "0.5.3"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -33,12 +33,14 @@ from ragleap.cache import QueryEmbeddingCache
 from ragleap import sanitization as _sanitization
 from ragleap import web as _web
 from ragleap import ocr as _ocr
+from ragleap import transcription as _transcription
+from ragleap.transcription import TranscriptionConfig
 from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.5.2"
-__all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult"]
+__version__ = "0.5.3"
+__all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult", "TranscriptionConfig"]
 
 
 @dataclass
@@ -165,6 +167,32 @@ class RagLeap:
         else:
             raise ValueError(f"Unknown mode '{mode}'. Use 'ocr' or 'caption'.")
 
+        return self.ingest_text(filename, text, metadata=metadata)
+
+    def ingest_audio(
+        self,
+        filename: str,
+        raw_bytes: bytes,
+        transcriber: Optional["TranscriptionConfig"] = None,
+        metadata: Optional[Dict] = None,
+    ) -> IngestResult:
+        """
+        Transcribe audio to text and ingest it. Pass a TranscriptionConfig
+        to choose the provider (whisper or deepgram) and options; if
+        omitted, defaults to OpenAI's hosted Whisper API using
+        OPENAI_API_KEY from the environment.
+
+        Whisper is a strong general-purpose baseline but has real
+        limitations: accuracy varies by language, there is no built-in
+        denoising (quiet/noisy audio genuinely degrades transcription
+        quality), and no domain-vocabulary biasing by default (brand
+        names and jargon commonly get mangled unless you pass a
+        prompt hint via TranscriptionConfig). Use provider='deepgram'
+        if these matter for your use case.
+        """
+        config = transcriber or _transcription.TranscriptionConfig(provider="whisper")
+        service = _transcription.TranscriptionService(config)
+        text = service.transcribe(filename, raw_bytes)
         return self.ingest_text(filename, text, metadata=metadata)
 
     def ingest_text(

--- a/packages/ragleap-rag/src/ragleap/transcription.py
+++ b/packages/ragleap-rag/src/ragleap/transcription.py
@@ -1,0 +1,119 @@
+"""
+Audio transcription for ragleap-rag. Pluggable providers - OpenAI's
+hosted Whisper API by default, or Deepgram - rather than a hardcoded
+single choice. Whisper is a strong general-purpose baseline but has
+real, documented weak spots: accuracy varies significantly by
+language (strongest on English/major European languages), it has no
+built-in denoising (quiet/noisy audio genuinely degrades
+transcription quality - Whisper does not compensate for this), and no
+domain-vocabulary biasing by default (brand names, jargon, and
+proper nouns commonly get mangled unless a prompt hint is supplied).
+Deepgram is offered as an alternative for cases where these
+limitations matter.
+
+Both providers here use hosted APIs (no local model weights, no
+torch/CUDA dependency) - a deliberate choice given ragleap-rag's
+existing experience with the CUDA-bloat problem in the reranking
+feature. Local/offline Whisper (via the openai-whisper package) is
+not currently supported - it would need its own provider option and
+pulls in torch, similar tradeoffs to the reranking dependency.
+"""
+import io
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TranscriptionConfig:
+    """Explicit transcription provider configuration."""
+    provider: str = "whisper"
+    api_key: Optional[str] = None
+    model: Optional[str] = None
+    language: Optional[str] = None  # ISO 639-1 code, e.g. "en" - omit for auto-detect
+    prompt: Optional[str] = None  # optional vocabulary/context hint (Whisper only)
+
+    def __post_init__(self):
+        import os
+        self.provider = self.provider.lower()
+
+        if self.provider == "whisper":
+            self.api_key = self.api_key or os.environ.get("OPENAI_API_KEY")
+            self.model = self.model or "whisper-1"
+        elif self.provider == "deepgram":
+            self.api_key = self.api_key or os.environ.get("DEEPGRAM_API_KEY")
+            self.model = self.model or "nova-2"
+        else:
+            raise ValueError(f"Unknown transcription provider '{self.provider}'. Supported: whisper, deepgram.")
+
+        if not self.api_key:
+            raise ValueError(
+                f"No API key for transcription provider '{self.provider}'. Pass api_key= explicitly, "
+                f"or set {'OPENAI_API_KEY' if self.provider == 'whisper' else 'DEEPGRAM_API_KEY'} in your environment."
+            )
+
+
+class TranscriptionService:
+    """Transcribes audio to text using the configured provider."""
+
+    def __init__(self, config: TranscriptionConfig):
+        self.config = config
+
+    def transcribe(self, filename: str, audio_bytes: bytes) -> str:
+        if self.config.provider == "whisper":
+            return self._transcribe_whisper(filename, audio_bytes)
+        elif self.config.provider == "deepgram":
+            return self._transcribe_deepgram(audio_bytes)
+
+    def _transcribe_whisper(self, filename: str, audio_bytes: bytes) -> str:
+        try:
+            import openai
+        except ImportError as e:
+            raise ValueError("openai package is required for Whisper transcription — pip install ragleap-rag[openai]") from e
+
+        client = openai.OpenAI(api_key=self.config.api_key)
+        audio_file = io.BytesIO(audio_bytes)
+        audio_file.name = filename  # OpenAI's client needs a filename for format detection
+
+        kwargs = {"model": self.config.model, "file": audio_file}
+        if self.config.language:
+            kwargs["language"] = self.config.language
+        if self.config.prompt:
+            kwargs["prompt"] = self.config.prompt
+
+        response = client.audio.transcriptions.create(**kwargs)
+        text = response.text if hasattr(response, "text") else str(response)
+        if not text or not text.strip():
+            raise ValueError("Whisper returned an empty transcription — check the audio has audible speech.")
+        return text
+
+    def _transcribe_deepgram(self, audio_bytes: bytes) -> str:
+        try:
+            import requests
+        except ImportError as e:
+            raise ValueError("requests package is required for Deepgram transcription") from e
+
+        params = {"model": self.config.model, "smart_format": "true"}
+        if self.config.language:
+            params["language"] = self.config.language
+
+        response = requests.post(
+            "https://api.deepgram.com/v1/listen",
+            headers={"Authorization": f"Token {self.config.api_key}", "Content-Type": "audio/*"},
+            params=params,
+            data=audio_bytes,
+            timeout=120,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        try:
+            text = data["results"]["channels"][0]["alternatives"][0]["transcript"]
+        except (KeyError, IndexError) as e:
+            raise ValueError(f"Unexpected Deepgram response shape: {data}") from e
+
+        if not text or not text.strip():
+            raise ValueError("Deepgram returned an empty transcription — check the audio has audible speech.")
+        return text


### PR DESCRIPTION
Fourth part of the multi-modal ingestion milestone. Pluggable transcription providers rather than a hardcoded Whisper-only path, directly addressing a real question raised this session: does Whisper handle multi-language/low-volume/noisy audio correctly, or should users be able to bring their own provider like Deepgram?

Honest answer, documented in both the module docstring and README: Whisper is a strong general-purpose baseline but has real limits - accuracy varies meaningfully by language, no built-in denoising (Whisper does not compensate for quiet/noisy audio), no domain-vocabulary biasing by default (brand names/jargon get mangled without a prompt hint). Deepgram is offered as an alternative for cases where these matter.

- New transcription.py: TranscriptionConfig (mirrors ProviderConfig's pattern - provider/api_key/model, env-var fallback, validation), TranscriptionService dispatches to OpenAI's hosted Whisper API or Deepgram's API
- Both providers are hosted APIs - no local model weights, no torch/ CUDA dependency, consistent with the reasoning behind reranking's optional [rerank] extra staying lean
- RagLeap.ingest_audio(filename, raw_bytes, transcriber=None) - defaults to Whisper via OPENAI_API_KEY if no config is passed
- TranscriptionConfig exported from the top-level package
- New README Audio ingestion section, stating the Whisper limitations directly rather than only in a docstring
- Bumped to 0.5.3 (confirmed in both files before committing)

Verification note - genuinely partial this time, stated honestly: neither an OpenAI nor Deepgram API key was available in this session's environment, so no live transcription call was made. What WAS verified: TranscriptionConfig's validation logic (correct defaults for both providers, correctly raises on missing API key, correctly raises on unknown provider), and a mocked API call confirming the exact request shape sent to OpenAI's client (correct model, correct file object with .name set for format detection). Live end-to-end transcription against a real provider is untested and should be done in a follow-up once a key is available, before this can be considered fully proven the way every other feature this session was.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
