### PR TITLE
feat: custom transcription provider support (provider='custom')

### DIFF
--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -276,6 +276,17 @@ Honest limitation: transcription quality is only as good as the underlying provi
 
 Both providers use hosted APIs - no local model weights, no torch/CUDA dependency, consistent with keeping the base install light (the same reasoning behind reranking's optional [rerank] extra). Local/offline Whisper is not currently supported.
 
+Not limited to Whisper and Deepgram - provider="custom" accepts any transcription function you supply, so you can use AssemblyAI, Speechmatics, Azure Speech, AWS Transcribe, or anything else without waiting on ragleap-rag to add native support.
+
+```python
+def my_transcriber(filename: str, audio_bytes: bytes) -> str:
+    # call whatever provider/SDK you prefer
+    return transcript_text
+
+config = TranscriptionConfig(provider="custom", transcribe_fn=my_transcriber)
+rag.ingest_audio("call.mp3", raw_bytes, transcriber=config)
+```
+
 Verified live: a real Deepgram API call against synthesized speech correctly transcribed the audio and produced an accurate, grounded answer referencing what was actually said. Whisper's API shape was verified via a mocked call (no OpenAI key was available in this session), confirming the correct request structure without a live network round-trip.
 
 ## Video ingestion

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.5.4"
+version = "0.5.5"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -40,7 +40,7 @@ from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.5.4"
+__version__ = "0.5.5"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult", "TranscriptionConfig"]
 
 

--- a/packages/ragleap-rag/src/ragleap/transcription.py
+++ b/packages/ragleap-rag/src/ragleap/transcription.py
@@ -28,12 +28,24 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class TranscriptionConfig:
-    """Explicit transcription provider configuration."""
+    """
+    Explicit transcription provider configuration.
+
+    provider="whisper" and provider="deepgram" are built-in. For any
+    other provider (AssemblyAI, Speechmatics, Azure Speech, AWS
+    Transcribe, or anything else), use provider="custom" and pass
+    transcribe_fn - a callable of (filename: str, audio_bytes: bytes) -> str
+    that does the transcription however you like. This makes the
+    library provider-agnostic rather than limited to the two built-in
+    options - you are not blocked on ragleap-rag adding native support
+    for a provider you already trust more.
+    """
     provider: str = "whisper"
     api_key: Optional[str] = None
     model: Optional[str] = None
     language: Optional[str] = None  # ISO 639-1 code, e.g. "en" - omit for auto-detect
     prompt: Optional[str] = None  # optional vocabulary/context hint (Whisper only)
+    transcribe_fn: Optional[object] = None  # callable(filename, audio_bytes) -> str, required if provider="custom"
 
     def __post_init__(self):
         import os
@@ -45,8 +57,14 @@ class TranscriptionConfig:
         elif self.provider == "deepgram":
             self.api_key = self.api_key or os.environ.get("DEEPGRAM_API_KEY")
             self.model = self.model or "nova-2"
+        elif self.provider == "custom":
+            if not callable(self.transcribe_fn):
+                raise ValueError(
+                    "provider='custom' requires transcribe_fn=<callable(filename, audio_bytes) -> str>."
+                )
+            return  # custom provider handles its own auth, no api_key check needed
         else:
-            raise ValueError(f"Unknown transcription provider '{self.provider}'. Supported: whisper, deepgram.")
+            raise ValueError(f"Unknown transcription provider '{self.provider}'. Supported: whisper, deepgram, custom.")
 
         if not self.api_key:
             raise ValueError(
@@ -66,6 +84,8 @@ class TranscriptionService:
             return self._transcribe_whisper(filename, audio_bytes)
         elif self.config.provider == "deepgram":
             return self._transcribe_deepgram(audio_bytes)
+        elif self.config.provider == "custom":
+            return self.config.transcribe_fn(filename, audio_bytes)
 
     def _transcribe_whisper(self, filename: str, audio_bytes: bytes) -> str:
         try:


### PR DESCRIPTION
## Summary

Directly answers a question raised this session: should users be locked into just Whisper/Deepgram, or able to bring any provider they judge better (AssemblyAI, Speechmatics, Azure Speech, AWS Transcribe, etc.)? Previously the answer was 'wait for ragleap-rag to add it' — now it isn't.

## What changed
- `TranscriptionConfig` gains `provider='custom'` + `transcribe_fn` — a callable of `(filename: str, audio_bytes: bytes) -> str` the caller supplies. `TranscriptionService.transcribe()` dispatches to it directly.
- Validates `transcribe_fn` is actually callable when `provider='custom'` is set, raising a clear error otherwise.
- No `api_key` requirement for `provider='custom'` — the custom function handles its own auth.
- New README subsection under Audio ingestion.
- Bumped to 0.5.5

## Verification
Rebuilt, live test — a real custom transcriber function was correctly called with the right filename and byte count, its return value was correctly ingested and retrievable via a grounded `ask()` answer that accurately quoted the custom function's output, and validation correctly rejected `provider='custom'` with no `transcribe_fn` supplied.