### PR TITLE
feat: Redis-backed distributed query cache + ingest_batch() (0.5.6)

### DIFF
--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -301,11 +301,47 @@ If the video already has a matching subtitle file (.vtt/.srt), ingesting that di
 
 Verification note: both the ffmpeg audio-extraction step and the transcription step are now fully verified live. ffprobe independently confirmed a real 3-second test video is extracted to a valid, playable audio stream of the correct duration. Separately, a real Deepgram API call against synthesized speech (via espeak) correctly transcribed the audio and produced an accurate, grounded answer referencing what was actually said - closing the gap noted in Audio ingestion, where live-provider testing was initially unavailable.
 
+## Batch ingestion
+
+`rag.ingest_batch(items)` ingests a list of mixed-type items concurrently, and returns a per-item result rather than raising on the first failure - one bad item never blocks or rolls back the others.
+
+```python
+results = await rag.ingest_batch([
+    {"type": "file", "filename": "notes.txt", "raw_bytes": b"..."},
+    {"type": "url", "url": "https://example.com/article"},
+    {"type": "image", "filename": "scan.png", "raw_bytes": b"...", "mode": "ocr"},
+    {"type": "audio", "filename": "call.mp3", "raw_bytes": b"..."},
+])
+
+for r in results:
+    if r["success"]:
+        print(r["result"])
+    else:
+        print("failed:", r["error"])
+```
+
+Each item dict needs a `"type"` key (`"file"`, `"url"`, `"image"`, `"audio"`, or `"video"`) plus whatever kwargs that type's `ingest_*` method normally needs. Verification note: tested with a real 4-item mixed batch (a .txt file, a live URL fetch, a deliberately corrupt fake PDF, and a .json file) - 3 of 4 succeeded exactly as expected, and the corrupt PDF failed cleanly with a clear logged error rather than crashing the batch or silently affecting the other results.
+
 ## Performance
 
 Database connections are pooled internally (min 1, max 10 by default) rather than opened fresh on every call. Previously every ingest, ask, and memory operation opened a brand-new Postgres connection and closed it afterward - real, avoidable latency, especially under concurrent load (e.g. a web server handling multiple requests at once). This is automatic and requires no configuration.
 
 Query embeddings are also cached in memory (LRU, 1000 entries by default) - repeated identical questions skip a redundant embedding call. This caches embeddings only, never full answers, since with conversation memory the same question can legitimately produce different answers depending on session history. Check cache effectiveness with rag.cache_stats(), or disable with cache_enabled=False.
+
+For multi-process deployments (multiple Gunicorn or Celery workers), the in-memory cache doesn't help across processes - each worker has its own separate cache, so a hit in one worker is invisible to the others. Setting `cache_backend="redis"` (with the `[redis]` extra and a `redis_url`) shares the query embedding cache across all worker processes via Redis, with a configurable `cache_ttl_seconds` (default 86400 = 24h).
+
+```python
+rag = RagLeap(
+    database_url="...",
+    embedder=EmbeddingConfig(...),
+    primary=ProviderConfig(...),
+    cache_backend="redis",
+    redis_url="redis://localhost:6379/0",
+    cache_ttl_seconds=86400,
+)
+```
+
+Verification note: proven with two separate `RagLeap` instances (simulating two separate worker processes) pointed at the same Redis - the first instance's cache miss and resulting embedding write was correctly picked up as a cache hit on the second, completely separate instance's first call, confirming the embedding is genuinely shared across process boundaries and not just cached within one Python object.
 
 ## How it fits together
              +------------------+

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.5.5"
+version = "0.5.6"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"
@@ -39,6 +39,7 @@ openai = ["openai>=1.40.0"]
 rerank = ["sentence-transformers>=3.0.0"]
 web = ["trafilatura>=1.6.0"]
 ocr = ["pytesseract>=0.3.10", "Pillow>=10.0.0"]
+redis = ["redis>=5.0.0"]
 formats = [
     "openpyxl>=3.1.0",
     "xlrd>=2.0.0",
@@ -50,7 +51,7 @@ formats = [
     "pyyaml>=6.0",
     "pyarrow>=14.0.0",
 ]
-all = ["google-genai>=0.3.0", "anthropic>=0.34.0", "openai>=1.40.0", "sentence-transformers>=3.0.0", "trafilatura>=1.6.0", "pytesseract>=0.3.10", "Pillow>=10.0.0", "openpyxl>=3.1.0", "xlrd>=2.0.0", "python-pptx>=1.0.0", "odfpy>=1.4.0", "striprtf>=0.0.26", "beautifulsoup4>=4.12.0", "ebooklib>=0.18", "pyyaml>=6.0", "pyarrow>=14.0.0"]
+all = ["google-genai>=0.3.0", "anthropic>=0.34.0", "openai>=1.40.0", "sentence-transformers>=3.0.0", "trafilatura>=1.6.0", "pytesseract>=0.3.10", "Pillow>=10.0.0", "redis>=5.0.0", "openpyxl>=3.1.0", "xlrd>=2.0.0", "python-pptx>=1.0.0", "odfpy>=1.4.0", "striprtf>=0.0.26", "beautifulsoup4>=4.12.0", "ebooklib>=0.18", "pyyaml>=6.0", "pyarrow>=14.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/antonyrag/ragleap-core"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -29,7 +29,7 @@ from ragleap.parsers import extract_text
 from ragleap.memory import ConversationMemory
 from ragleap.reranking import RerankerService
 from ragleap.db import ConnectionPool
-from ragleap.cache import QueryEmbeddingCache
+from ragleap.cache import QueryEmbeddingCache, RedisQueryEmbeddingCache
 from ragleap import sanitization as _sanitization
 from ragleap import web as _web
 from ragleap import ocr as _ocr
@@ -40,7 +40,7 @@ from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.5.5"
+__version__ = "0.5.6"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult", "TranscriptionConfig"]
 
 
@@ -71,6 +71,9 @@ class RagLeap:
         chunk_overlap: Optional[int] = None,
         cache_enabled: bool = True,
         cache_max_size: int = 1000,
+        cache_backend: str = "memory",
+        redis_url: Optional[str] = None,
+        cache_ttl_seconds: int = 86400,
     ):
         self.database_url = database_url
         self.embedding_dimensions = embedder.dimensions
@@ -82,7 +85,16 @@ class RagLeap:
         self._memory = ConversationMemory(pool=self._pool)
         self._reranker = None  # lazy-loaded on first rerank=True call
         self._cache_enabled = cache_enabled
-        self._query_cache = QueryEmbeddingCache(max_size=cache_max_size) if cache_enabled else None
+        if not cache_enabled:
+            self._query_cache = None
+        elif cache_backend == "redis":
+            if not redis_url:
+                raise ValueError("cache_backend='redis' requires redis_url= to be set.")
+            self._query_cache = RedisQueryEmbeddingCache(redis_url, max_size=cache_max_size, ttl_seconds=cache_ttl_seconds)
+        elif cache_backend == "memory":
+            self._query_cache = QueryEmbeddingCache(max_size=cache_max_size)
+        else:
+            raise ValueError(f"Unknown cache_backend '{cache_backend}'. Use 'memory' or 'redis'.")
         self._generator = GenerationService(
             primary=primary,
             fallbacks=fallbacks,
@@ -469,6 +481,109 @@ class RagLeap:
         """Async version of ingest_text(). See aingest() for details."""
         import asyncio
         return await asyncio.to_thread(self.ingest_text, filename, text)
+
+    async def aingest_url(self, url: str, metadata: Optional[Dict] = None) -> IngestResult:
+        """Async version of ingest_url(). See aingest() for details."""
+        import asyncio
+        return await asyncio.to_thread(self.ingest_url, url, metadata)
+
+    async def aingest_image(
+        self,
+        filename: str,
+        raw_bytes: bytes,
+        mode: str = "ocr",
+        mime_type: str = "image/jpeg",
+        metadata: Optional[Dict] = None,
+    ) -> IngestResult:
+        """Async version of ingest_image(). See aingest() for details."""
+        import asyncio
+        return await asyncio.to_thread(self.ingest_image, filename, raw_bytes, mode, mime_type, metadata)
+
+    async def aingest_audio(
+        self,
+        filename: str,
+        raw_bytes: bytes,
+        transcriber: Optional["TranscriptionConfig"] = None,
+        metadata: Optional[Dict] = None,
+    ) -> IngestResult:
+        """Async version of ingest_audio(). See aingest() for details."""
+        import asyncio
+        return await asyncio.to_thread(self.ingest_audio, filename, raw_bytes, transcriber, metadata)
+
+    async def aingest_video(
+        self,
+        filename: str,
+        raw_bytes: bytes,
+        transcriber: Optional["TranscriptionConfig"] = None,
+        metadata: Optional[Dict] = None,
+    ) -> IngestResult:
+        """Async version of ingest_video(). See aingest() for details."""
+        import asyncio
+        return await asyncio.to_thread(self.ingest_video, filename, raw_bytes, transcriber, metadata)
+
+    async def ingest_batch(self, items: List[Dict]) -> List[Dict]:
+        """
+        Ingest a mixed batch of documents concurrently - any
+        combination of types, e.g. a PDF, a video, an image, and a
+        URL all in one call. Each item runs independently: one
+        item's failure does not stop or roll back the others, and
+        each successfully ingested item is committed on its own (the
+        same as calling each ingest_*() method separately, just
+        concurrent instead of sequential).
+
+        items: list of dicts, each with:
+          - "type": one of "file", "url", "image", "audio", "video"
+            ("file" covers ingest()'s full format range - pdf, docx,
+            xlsx, etc. - dispatched by filename extension)
+          - "filename": required for file/image/audio/video
+          - "raw_bytes": required for file/image/audio/video
+          - "url": required for type="url"
+          - "mode": optional, image only ("ocr" or "caption")
+          - "transcriber": optional, audio/video only (TranscriptionConfig)
+          - "metadata": optional, any type
+
+        Returns a list of dicts, one per input item, in the same
+        order: {"success": bool, "result": IngestResult | None,
+                "error": str | None}. Check "success" per item rather
+        than assuming the whole batch succeeded - a batch of 10 with
+        3 failures still stores the other 7.
+        """
+        async def _run_one(item: Dict) -> Dict:
+            try:
+                item_type = item.get("type")
+                metadata = item.get("metadata")
+
+                if item_type == "file":
+                    result = await self.aingest(item["filename"], item["raw_bytes"])
+                elif item_type == "url":
+                    result = await self.aingest_url(item["url"], metadata=metadata)
+                elif item_type == "image":
+                    result = await self.aingest_image(
+                        item["filename"], item["raw_bytes"],
+                        mode=item.get("mode", "ocr"),
+                        mime_type=item.get("mime_type", "image/jpeg"),
+                        metadata=metadata,
+                    )
+                elif item_type == "audio":
+                    result = await self.aingest_audio(
+                        item["filename"], item["raw_bytes"],
+                        transcriber=item.get("transcriber"), metadata=metadata,
+                    )
+                elif item_type == "video":
+                    result = await self.aingest_video(
+                        item["filename"], item["raw_bytes"],
+                        transcriber=item.get("transcriber"), metadata=metadata,
+                    )
+                else:
+                    raise ValueError(f"Unknown batch item type '{item_type}'. Use file, url, image, audio, or video.")
+
+                return {"success": True, "result": result, "error": None}
+            except Exception as e:
+                logger.warning(f"ingest_batch item failed (type={item.get('type')}, filename={item.get('filename') or item.get('url')}): {e}")
+                return {"success": False, "result": None, "error": str(e)}
+
+        import asyncio
+        return await asyncio.gather(*[_run_one(item) for item in items])
 
     async def aask(
         self,

--- a/packages/ragleap-rag/src/ragleap/cache.py
+++ b/packages/ragleap-rag/src/ragleap/cache.py
@@ -56,3 +56,78 @@ class QueryEmbeddingCache:
         total = self.hits + self.misses
         hit_rate = round(self.hits / total, 4) if total > 0 else 0.0
         return {"hits": self.hits, "misses": self.misses, "hit_rate": hit_rate, "size": len(self._store)}
+
+
+class RedisQueryEmbeddingCache:
+    """
+    Redis-backed query embedding cache - same interface as
+    QueryEmbeddingCache (get/set/clear/stats), so RagLeap can use
+    either interchangeably. Unlike the in-memory cache, this survives
+    process restarts and is shared across multiple worker processes
+    or Celery workers, which was a real, named limitation of the
+    in-memory-only cache. Requires the 'redis' extra:
+    pip install ragleap-rag[redis]
+
+    Note on stats: hits/misses are tracked per-instance (in-process
+    counters), not shared across processes via Redis itself - each
+    worker sees only its own hit/miss counts, even though the
+    underlying cached embeddings ARE shared. This is a deliberate
+    simplification, not an oversight - a fully distributed hit-rate
+    counter would need its own Redis key with atomic increments,
+    which adds complexity for a metric that is mainly useful for
+    local debugging anyway.
+    """
+
+    def __init__(self, redis_url: str, max_size: int = 1000, ttl_seconds: int = 86400, key_prefix: str = "ragleap:embcache:"):
+        try:
+            import redis
+        except ImportError as e:
+            raise ValueError("Redis caching requires the 'redis' extra — pip install ragleap-rag[redis]") from e
+
+        self.max_size = max_size
+        self.ttl_seconds = ttl_seconds
+        self.key_prefix = key_prefix
+        self._client = redis.Redis.from_url(redis_url, decode_responses=False)
+        self.hits = 0
+        self.misses = 0
+
+    def _key(self, query: str, model: str) -> str:
+        return f"{self.key_prefix}{model}:{query}"
+
+    def get(self, query: str, model: str) -> Optional[List[float]]:
+        import json
+        key = self._key(query, model)
+        raw = self._client.get(key)
+        if raw is not None:
+            self.hits += 1
+            return json.loads(raw)
+        self.misses += 1
+        return None
+
+    def set(self, query: str, model: str, embedding: List[float]) -> None:
+        import json
+        key = self._key(query, model)
+        self._client.set(key, json.dumps(embedding), ex=self.ttl_seconds)
+
+    def clear(self) -> None:
+        cursor = 0
+        while True:
+            cursor, keys = self._client.scan(cursor=cursor, match=f"{self.key_prefix}*", count=500)
+            if keys:
+                self._client.delete(*keys)
+            if cursor == 0:
+                break
+        self.hits = 0
+        self.misses = 0
+
+    def stats(self) -> dict:
+        total = self.hits + self.misses
+        hit_rate = round(self.hits / total, 4) if total > 0 else 0.0
+        size = 0
+        cursor = 0
+        while True:
+            cursor, keys = self._client.scan(cursor=cursor, match=f"{self.key_prefix}*", count=500)
+            size += len(keys)
+            if cursor == 0:
+                break
+        return {"hits": self.hits, "misses": self.misses, "hit_rate": hit_rate, "size": size}


### PR DESCRIPTION
Redis query embedding cache:
- New RedisQueryEmbeddingCache class (src/ragleap/cache.py), same get/set/clear/stats interface as the existing in-memory cache
- RagLeap.__init__() gains cache_backend, redis_url, cache_ttl_seconds
- Verified across process boundaries: two separate RagLeap instances pointed at the same Redis - instance 1's cache miss/write was correctly hit by instance 2's first call, confirming the cache is genuinely shared across workers, not just within one process
- Requires [redis] extra (redis>=5.0.0), already added to pyproject.toml

ingest_batch():
- New async ingest_batch(items) - concurrent mixed-type ingestion (file/url/image/audio/video) via asyncio.gather
- Returns per-item {success, result, error} - one failure never blocks or rolls back the rest
- Verified with a real 4-item mixed batch (txt, live URL, corrupt fake PDF, json): 3/4 succeeded as expected, corrupt PDF failed cleanly with a logged error

Also adds missing async ingest wrappers (aingest_url, aingest_image, aingest_audio, aingest_video) - all 6 ingest methods now have async twins, closing a gap where only 2 of 6 previously did.

Version bumped 0.5.5 -> 0.5.6 in both pyproject.toml and __init__.py. README documents both features in this same commit.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
