### PR TITLE
docs: Celery integration guide + example

### DIFF
--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -343,6 +343,73 @@ rag = RagLeap(
 
 Verification note: proven with two separate `RagLeap` instances (simulating two separate worker processes) pointed at the same Redis - the first instance's cache miss and resulting embedding write was correctly picked up as a cache hit on the second, completely separate instance's first call, confirming the embedding is genuinely shared across process boundaries and not just cached within one Python object.
 
+## Celery integration
+
+Running ingestion or asking as background tasks (so a web request doesn't block on an LLM call) is a common pattern. The one thing that matters: **RagLeap's connection pool is per-instance and not fork-safe across processes.** Create one global `RagLeap` object before Celery's default "prefork" pool forks workers, and every worker inherits the same pool and file descriptors - this shows up later as hung queries or connection errors under concurrent load, not as an obvious startup crash.
+
+The fix: each worker process builds its own `RagLeap` instance, once, after it forks - not at module import time.
+
+```python
+from celery import Celery
+from celery.signals import worker_process_init
+from ragleap import RagLeap, ProviderConfig, EmbeddingConfig
+
+app = Celery("ragleap_tasks", broker="redis://localhost:6379/0", backend="redis://localhost:6379/0")
+
+_rag_instance = None
+
+def get_rag() -> RagLeap:
+    global _rag_instance
+    if _rag_instance is None:
+        _rag_instance = RagLeap(
+            database_url="postgresql://...",
+            embedder=EmbeddingConfig(provider="gemini", api_key="..."),
+            primary=ProviderConfig(provider="gemini", api_key="..."),
+            # Same Redis server as the broker above is fine - a different
+            # db index keeps the query cache and the task queue from colliding.
+            cache_backend="redis",
+            redis_url="redis://localhost:6379/1",
+        )
+        _rag_instance.init_schema()
+    return _rag_instance
+
+@worker_process_init.connect
+def init_worker(**kwargs):
+    get_rag()  # built right after fork, not before
+
+@app.task(name="ragleap.ingest_text")
+def ingest_text_task(filename: str, text: str, metadata: dict | None = None):
+    result = get_rag().ingest_text(filename=filename, text=text, metadata=metadata)
+    return {"document_id": result.document_id, "chunks_stored": result.chunks_stored}
+
+@app.task(name="ragleap.ask")
+def ask_task(query: str, session_id: str | None = None):
+    answer = get_rag().ask(query, session_id=session_id)
+    return {"answer": answer["answer"], "sources": answer["sources"]}
+```
+
+Architecture:
+
+```
+                    +-----------+
+  Web request  ---> |   Redis   | ---> worker process 1 (own RagLeap + pool)
+  (non-blocking)    |  broker   | ---> worker process 2 (own RagLeap + pool)
+                    +-----------+                |
+                                                  v
+                                          +---------------+
+                                          |   PostgreSQL   |
+                                          |   + pgvector   |
+                                          +---------------+
+                                                  ^
+                                                  |
+                                   (optional) Redis query cache,
+                                   shared across all worker processes
+```
+
+Each worker process talks to the same Postgres database and, optionally, shares the Redis query cache (a separate concern from the Celery broker/backend, even if it's the same Redis server). Run `celery -A your_module worker --loglevel=info` to start a worker, then call `.delay(...)` from your web app to enqueue tasks without blocking the request.
+
+See `examples/05_celery_background_tasks.py` for the full runnable version.
+
 ## How it fits together
              +------------------+
              |   Your text or   |
@@ -389,6 +456,7 @@ in the source repo:
 - `02_streaming.py` — streaming responses
 - `03_fallback_and_hybrid_search.py` — provider fallback + hybrid toggle
 - `04_flask_web_api.py` — drop-in web API (works identically in FastAPI)
+- `05_celery_background_tasks.py` — background ingestion/asking via Celery + Redis
 
 ## Why this exists
 

--- a/packages/ragleap-rag/examples/05_celery_background_tasks.py
+++ b/packages/ragleap-rag/examples/05_celery_background_tasks.py
@@ -1,0 +1,109 @@
+"""
+ragleap-rag — Background ingestion and asking with Celery.
+
+The constraint that matters here: RagLeap's connection pool is created
+per-instance and is NOT fork-safe or shareable across processes. If you
+create one global RagLeap object and Celery forks worker processes from
+it (the default "prefork" pool), every forked worker inherits the same
+pool object and file descriptors — this breaks in ways that are easy to
+misdiagnose (hung queries, connection errors under load, or workers that
+seem fine until concurrent tasks land).
+
+The fix: each worker process creates its OWN RagLeap instance, once,
+via Celery's worker_process_init signal — not at module import time.
+
+Setup:
+    pip install ragleap-rag celery redis
+    # or: uv add ragleap-rag celery redis
+
+    You'll need:
+    1. A PostgreSQL database with pgvector (see 01_basic_ingest_and_ask.py)
+    2. Redis running locally, used here as both the Celery broker and
+       result backend: docker run -d -p 6379:6379 redis:7
+    3. A free Gemini API key: https://aistudio.google.com/apikey
+
+Run:
+    # Terminal 1 — start a worker:
+    celery -A 05_celery_background_tasks worker --loglevel=info
+
+    # Terminal 2 — enqueue tasks:
+    python 05_celery_background_tasks.py
+"""
+from celery import Celery
+from celery.signals import worker_process_init
+from ragleap import RagLeap, ProviderConfig, EmbeddingConfig
+
+GEMINI_API_KEY = "your-gemini-api-key-here"
+DATABASE_URL = "postgresql://postgres:postgres@localhost:5432/postgres"
+REDIS_URL = "redis://localhost:6379/0"
+
+app = Celery("ragleap_tasks", broker=REDIS_URL, backend=REDIS_URL)
+
+# WRONG — do not do this:
+#   rag = RagLeap(database_url=DATABASE_URL, ...)   # created at import time
+#   @app.task
+#   def ingest_task(text): rag.ingest_text(...)     # every forked worker
+#                                                     # shares this one pool
+#
+# Every worker process gets its own RagLeap instance instead, built lazily
+# the first time a task in that process needs it.
+
+_rag_instance = None
+
+
+def get_rag() -> RagLeap:
+    """Return this worker process's own RagLeap instance, creating it once."""
+    global _rag_instance
+    if _rag_instance is None:
+        _rag_instance = RagLeap(
+            database_url=DATABASE_URL,
+            embedder=EmbeddingConfig(provider="gemini", api_key=GEMINI_API_KEY),
+            primary=ProviderConfig(provider="gemini", api_key=GEMINI_API_KEY),
+            # Redis-backed cache is a *separate* concern from the Celery
+            # broker above — same Redis server is fine, different db index
+            # keeps them from colliding.
+            cache_backend="redis",
+            redis_url="redis://localhost:6379/1",
+        )
+        _rag_instance.init_schema()
+    return _rag_instance
+
+
+@worker_process_init.connect
+def init_worker(**kwargs):
+    """Build this worker's RagLeap instance right after the process forks,
+    not before — this is what makes the pool safe per-process."""
+    get_rag()
+
+
+@app.task(name="ragleap.ingest_text")
+def ingest_text_task(filename: str, text: str, metadata: dict | None = None):
+    rag = get_rag()
+    result = rag.ingest_text(filename=filename, text=text, metadata=metadata)
+    return {"document_id": result.document_id, "chunks_stored": result.chunks_stored}
+
+
+@app.task(name="ragleap.ask")
+def ask_task(query: str, session_id: str | None = None):
+    rag = get_rag()
+    answer = rag.ask(query, session_id=session_id)
+    return {
+        "answer": answer["answer"],
+        "sources": answer["sources"],
+        "provider_used": answer["provider_used"],
+    }
+
+
+if __name__ == "__main__":
+    # Enqueue a couple of tasks — run this while a worker (see docstring) is up.
+    r1 = ingest_text_task.delay(
+        filename="company_handbook.txt",
+        text="Our company offers unlimited PTO, a fully remote work policy, "
+             "and a $500/year learning budget for courses and books.",
+    )
+    print("Enqueued ingest task:", r1.id)
+    print("Result (blocks until worker finishes):", r1.get(timeout=30))
+
+    r2 = ask_task.delay("How much PTO do employees get?")
+    print("Enqueued ask task:", r2.id)
+    print("Result:", r2.get(timeout=30))


### PR DESCRIPTION
Documents the one constraint that actually matters for background task usage: RagLeap's connection pool is per-instance and not fork-safe across processes. Covers the correct pattern (build RagLeap inside worker_process_init, not at module import time), a full Redis-broker code example, and an architecture diagram showing worker/pool/Postgres/ cache relationships.

Adds examples/05_celery_background_tasks.py - a runnable end-to-end example (ingest task + ask task, enqueue + retrieve results).

Note: the architecture diagram was originally corrupted by terminal paste mangling (lost code fence + collapsed whitespace/alignment) on first attempt - caught via the standard bracket-view verification step, fixed by base64-round-tripping the diagram content rather than pasting raw ASCII art again.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
