### PR TITLE
feat: pluggable vector storage backends (0.6.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
         working-directory: packages/ragleap-rag
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[test,gemini]"
+          pip install -e ".[test,gemini,faiss]"
       - name: Run ragleap-rag test suite
         working-directory: packages/ragleap-rag
         env:

--- a/packages/ragleap-rag/CHANGELOG.md
+++ b/packages/ragleap-rag/CHANGELOG.md
@@ -8,6 +8,18 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `docs`: Celery integration guide + runnable example ([#57](https://github.com/antonyrag/ragleap-core/pull/57))
 - `test`: comprehensive pytest suite (67 tests) + CI integration — first automated testing this package has had ([#58](https://github.com/antonyrag/ragleap-core/pull/58))
 
+## [0.6.0]
+
+### Added
+- Pluggable vector storage backends via `vector_backend=` on `RagLeap.__init__()`. Vector storage is now decoupled from conversation memory (which always uses Postgres regardless of vector backend choice, since memory is a separate concern).
+- `ragleap.vectorstores.VectorBackend` — the abstract interface any backend implements (`init_schema`, `insert_document`, `insert_chunk`, `search_dense`, `list_documents`, `delete_document`, `get_document_filename`, optionally `search_sparse`/`search_hybrid`/`supports_sparse`).
+- `PgVectorBackend` — the default, a refactor (not a rewrite) of the existing proven Postgres/pgvector logic. Zero behavior change for existing users; verified via the full existing test suite passing unmodified (73/73) after the refactor.
+- `FAISSBackend` — new, local, in-process, no API key required. Requires the `[faiss]` extra. No native full-text search (`supports_sparse()` returns `False`; `ask(hybrid=True)` gracefully degrades to dense-only). Metadata filtering is a post-filter over a SQLite sidecar, not an indexed query. Optional `persist_directory=` for data that survives process restarts — verified live across separate backend instances pointed at the same directory, not just in-process. 10 new tests, all live against a real FAISS index (no mocking of the backend itself).
+
+### Changed
+- Internal: `RagLeap._retriever` (the old `VectorRetrievalService`) removed in favor of `RagLeap._vector_backend`. This is a private-attribute rename — anyone reaching into `rag._retriever` directly (not part of the public API) needs to update to `rag._vector_backend` with its new method names (`search_dense`/`search_sparse`/`search_hybrid` instead of `search_similar_chunks`/`search_sparse_chunks`/`search_hybrid_chunks`).
+- `schema.py` split into independent core schema (documents/chunks, backend-specific) and memory schema (conversations/conversation_messages, always Postgres) - `init_schema()`/`get_schema_sql()` remain as backward-compatible combined wrappers for anyone calling the module directly.
+
 ## [0.5.8]
 
 ### Changed

--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -37,6 +37,34 @@ Employees get unlimited PTO. (Source 1)
 That's the whole loop: ingest text (or a `.txt`/`.pdf`/`.docx` file via
 `rag.ingest(filename, raw_bytes)`), then ask questions grounded in it.
 
+## Vector backends
+
+By default, `RagLeap` stores vectors in Postgres/pgvector - the `database_url` you already pass in. Conversation memory always uses this same Postgres connection regardless of which vector backend you choose, since memory (session history) is a separate concern from vector storage.
+
+You can swap the vector backend via `vector_backend=`:
+
+```python
+from ragleap import RagLeap, ProviderConfig, EmbeddingConfig
+from ragleap.vectorstores import FAISSBackend
+
+rag = RagLeap(
+    database_url="postgresql://user:pass@localhost/mydb",  # still required, for conversation memory
+    vector_backend=FAISSBackend(persist_directory="./my_faiss_data"),  # vectors go here instead
+    embedder=EmbeddingConfig(provider="gemini", api_key="..."),
+    primary=ProviderConfig(provider="gemini", api_key="..."),
+)
+rag.init_schema()
+```
+
+Currently available:
+
+| Backend | Extra | Sparse/hybrid search | Notes |
+|---|---|---|---|
+| `PgVectorBackend` (default) | none needed | Yes - real Postgres full-text search | Battle-tested, the original implementation |
+| `FAISSBackend` | `pip install ragleap-rag[faiss]` | No - `ask(hybrid=True)` gracefully degrades to dense-only | Local, in-process, no API key. Pass `persist_directory=` for data that survives restarts - without it, everything is in-memory and lost on process exit. Metadata filtering is a post-filter (over-fetch then filter), not an indexed query - fine for small-to-medium datasets, less efficient than pgvector's JSONB GIN index at large scale. |
+
+More backends (Pinecone, Weaviate, Qdrant, Milvus) are planned - see the project roadmap. Building your own is straightforward: implement the `ragleap.vectorstores.VectorBackend` abstract interface (`init_schema`, `insert_document`, `insert_chunk`, `search_dense`, `list_documents`, `delete_document`, `get_document_filename`, and optionally `search_sparse`/`search_hybrid`/`supports_sparse` if your backend can do keyword search).
+
 ## The three things that matter
 
 **Retrieval** is hybrid by default — dense (pgvector cosine similarity)

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.5.8"
+version = "0.6.0"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"
@@ -38,6 +38,7 @@ test = ["pytest>=8.0.0", "pytest-asyncio>=0.24.0", "psycopg2-binary>=2.9.0"]
 anthropic = ["anthropic>=0.34.0"]
 openai = ["openai>=1.40.0"]
 rerank = ["onnxruntime>=1.17.0", "tokenizers>=0.19.0", "huggingface_hub>=0.20.0"]
+faiss = ["faiss-cpu>=1.8.0"]
 web = ["trafilatura>=1.6.0"]
 ocr = ["pytesseract>=0.3.10", "Pillow>=10.0.0"]
 redis = ["redis>=5.0.0"]
@@ -52,7 +53,7 @@ formats = [
     "pyyaml>=6.0",
     "pyarrow>=14.0.0",
 ]
-all = ["google-genai>=0.3.0", "anthropic>=0.34.0", "openai>=1.40.0", "onnxruntime>=1.17.0", "tokenizers>=0.19.0", "huggingface_hub>=0.20.0", "trafilatura>=1.6.0", "pytesseract>=0.3.10", "Pillow>=10.0.0", "redis>=5.0.0", "openpyxl>=3.1.0", "xlrd>=2.0.0", "python-pptx>=1.0.0", "odfpy>=1.4.0", "striprtf>=0.0.26", "beautifulsoup4>=4.12.0", "ebooklib>=0.18", "pyyaml>=6.0", "pyarrow>=14.0.0"]
+all = ["google-genai>=0.3.0", "anthropic>=0.34.0", "openai>=1.40.0", "onnxruntime>=1.17.0", "tokenizers>=0.19.0", "huggingface_hub>=0.20.0", "faiss-cpu>=1.8.0", "trafilatura>=1.6.0", "pytesseract>=0.3.10", "Pillow>=10.0.0", "redis>=5.0.0", "openpyxl>=3.1.0", "xlrd>=2.0.0", "python-pptx>=1.0.0", "odfpy>=1.4.0", "striprtf>=0.0.26", "beautifulsoup4>=4.12.0", "ebooklib>=0.18", "pyyaml>=6.0", "pyarrow>=14.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/antonyrag/ragleap-core"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -23,7 +23,7 @@ from typing import Dict, Iterator, List, Optional
 
 from ragleap.chunker import TextChunker
 from ragleap.embedding import EmbeddingService, EmbeddingConfig
-from ragleap.retrieval import VectorRetrievalService
+from ragleap.vectorstores import VectorBackend, PgVectorBackend
 from ragleap.generation import GenerationService, ProviderConfig
 from ragleap.parsers import extract_text
 from ragleap.memory import ConversationMemory
@@ -40,8 +40,8 @@ from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.5.8"
-__all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult", "TranscriptionConfig"]
+__version__ = "0.6.0"
+__all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult", "TranscriptionConfig", "VectorBackend", "PgVectorBackend"]
 
 
 @dataclass
@@ -54,8 +54,10 @@ class RagLeap:
     """
     The main entry point for ragleap-rag. Wires together chunking,
     embedding, hybrid retrieval, and generation (with fallback,
-    streaming, and token usage reporting) over a PostgreSQL + pgvector
-    database you control.
+    streaming, and token usage reporting) over a pluggable vector
+    backend (Postgres/pgvector by default) plus Postgres-backed
+    conversation memory, which is always required regardless of
+    which vector backend is chosen.
     """
 
     def __init__(
@@ -63,6 +65,7 @@ class RagLeap:
         database_url: str,
         primary: ProviderConfig,
         embedder: EmbeddingConfig,
+        vector_backend: Optional[VectorBackend] = None,
         fallbacks: Optional[List[ProviderConfig]] = None,
         default_temperature: float = 0.3,
         default_max_tokens: int = 1024,
@@ -75,13 +78,21 @@ class RagLeap:
         redis_url: Optional[str] = None,
         cache_ttl_seconds: int = 86400,
     ):
+        """
+        database_url is always required - conversation memory is
+        always Postgres-backed regardless of which vector_backend is
+        chosen (FAISS/Pinecone/etc. only store vectors, not chat
+        history). Pass vector_backend= to swap vector storage away
+        from the default PgVectorBackend (pip install ragleap-rag[faiss]
+        etc. for the optional backend-specific dependencies).
+        """
         self.database_url = database_url
         self.embedding_dimensions = embedder.dimensions
         self._pool = ConnectionPool(database_url)
+        self._vector_backend = vector_backend or PgVectorBackend(database_url)
 
         self._chunker = TextChunker(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
         self._embedder = EmbeddingService(embedder)
-        self._retriever = VectorRetrievalService(pool=self._pool, embedding_dimensions=embedder.dimensions)
         self._memory = ConversationMemory(pool=self._pool)
         self._reranker = None  # lazy-loaded on first rerank=True call
         self._cache_enabled = cache_enabled
@@ -104,8 +115,13 @@ class RagLeap:
         )
 
     def init_schema(self) -> None:
-        """Create the required tables/indexes if they don't already exist. Idempotent."""
-        _schema.init_schema(self.database_url, dimensions=self.embedding_dimensions)
+        """
+        Create the required storage structures if they don't already
+        exist. Idempotent. Initializes both the vector backend's
+        schema and the (always-Postgres) conversation memory schema.
+        """
+        self._vector_backend.init_schema(self.embedding_dimensions)
+        _schema.init_memory_schema(self.database_url)
 
     def _embed_query_cached(self, query: str) -> Optional[List[float]]:
         """Embed a query, using the cache if enabled. Cache key is
@@ -194,14 +210,6 @@ class RagLeap:
         to choose the provider (whisper or deepgram) and options; if
         omitted, defaults to OpenAI's hosted Whisper API using
         OPENAI_API_KEY from the environment.
-
-        Whisper is a strong general-purpose baseline but has real
-        limitations: accuracy varies by language, there is no built-in
-        denoising (quiet/noisy audio genuinely degrades transcription
-        quality), and no domain-vocabulary biasing by default (brand
-        names and jargon commonly get mangled unless you pass a
-        prompt hint via TranscriptionConfig). Use provider='deepgram'
-        if these matter for your use case.
         """
         config = transcriber or _transcription.TranscriptionConfig(provider="whisper")
         service = _transcription.TranscriptionService(config)
@@ -265,43 +273,27 @@ class RagLeap:
             raise ValueError("No chunks produced from input text — is it empty?")
 
         document_id = str(uuid.uuid4())
-        with self._pool.get_connection() as conn:
-          try:
-            cur = conn.cursor()
-            import json as _json
-            cur.execute(
-                "INSERT INTO documents (id, filename, metadata) VALUES (%s, %s, %s::jsonb)",
-                (document_id, filename, _json.dumps(metadata or {})),
+        self._vector_backend.insert_document(document_id, filename, metadata or {})
+
+        stored = 0
+        for chunk in chunks:
+            embedding = self._embedder.embed_text(chunk["text"])
+            if embedding is None:
+                logger.warning(f"Skipping chunk {chunk['chunk_index']} — embedding failed")
+                continue
+
+            self._vector_backend.insert_chunk(
+                document_id=document_id, document_name=filename, chunk_index=chunk["chunk_index"],
+                text=chunk["text"], token_count=chunk["token_count"], embedding=embedding, metadata=metadata or {},
             )
+            stored += 1
 
-            stored = 0
-            for chunk in chunks:
-                embedding = self._embedder.embed_text(chunk["text"])
-                if embedding is None:
-                    logger.warning(f"Skipping chunk {chunk['chunk_index']} — embedding failed")
-                    continue
+        if stored == 0:
+            self._vector_backend.delete_document(document_id)
+            raise ValueError(f"All {len(chunks)} chunk(s) failed to embed — nothing was stored.")
 
-                embedding_literal = "[" + ",".join(str(float(x)) for x in embedding) + "]"
-                cur.execute(
-                    """
-                    INSERT INTO chunks (document_id, document_name, chunk_index, text, token_count, embedding, metadata)
-                    VALUES (%s, %s, %s, %s, %s, %s::vector, %s::jsonb)
-                    """,
-                    (document_id, filename, chunk["chunk_index"], chunk["text"], chunk["token_count"], embedding_literal, _json.dumps(metadata or {})),
-                )
-                stored += 1
-
-            if stored == 0:
-                conn.rollback()
-                raise ValueError(f"All {len(chunks)} chunk(s) failed to embed — nothing was stored.")
-
-            conn.commit()
-            cur.close()
-            logger.info(f"Ingested '{filename}': {stored}/{len(chunks)} chunks stored")
-            return IngestResult(document_id=document_id, chunks_stored=stored)
-          except Exception:
-            conn.rollback()
-            raise
+        logger.info(f"Ingested '{filename}': {stored}/{len(chunks)} chunks stored")
+        return IngestResult(document_id=document_id, chunks_stored=stored)
 
     def ask(
         self,
@@ -320,6 +312,12 @@ class RagLeap:
         Pass session_id to enable persistent, multi-turn conversation
         memory (Postgres-backed) — prior turns in that session are
         injected as context. Omit it for a fully stateless call.
+
+        hybrid=True requests dense+sparse fusion, but gracefully
+        degrades to dense-only if the active vector backend doesn't
+        support sparse search (see VectorBackend.supports_sparse()) -
+        not every backend can do full-text search.
+
         Returns: {"answer": str, "sources": List[str], "provider_used": str,
                   "usage": dict|None, "chunks_sent": int}
         """
@@ -330,9 +328,9 @@ class RagLeap:
 
         pool_size = top_k * 4 if rerank else top_k
         if hybrid:
-            chunks = self._retriever.search_hybrid_chunks(query, query_embedding, top_k=pool_size, metadata_filter=metadata_filter)
+            chunks = self._vector_backend.search_hybrid(query, query_embedding, top_k=pool_size, metadata_filter=metadata_filter)
         else:
-            chunks = self._retriever.search_similar_chunks(query_embedding, top_k=pool_size, metadata_filter=metadata_filter)
+            chunks = self._vector_backend.search_dense(query_embedding, top_k=pool_size, metadata_filter=metadata_filter)
 
         if rerank and chunks:
             if self._reranker is None:
@@ -374,9 +372,9 @@ class RagLeap:
 
         pool_size = top_k * 4 if rerank else top_k
         if hybrid:
-            chunks = self._retriever.search_hybrid_chunks(query, query_embedding, top_k=pool_size, metadata_filter=metadata_filter)
+            chunks = self._vector_backend.search_hybrid(query, query_embedding, top_k=pool_size, metadata_filter=metadata_filter)
         else:
-            chunks = self._retriever.search_similar_chunks(query_embedding, top_k=pool_size, metadata_filter=metadata_filter)
+            chunks = self._vector_backend.search_dense(query_embedding, top_k=pool_size, metadata_filter=metadata_filter)
 
         if rerank and chunks:
             if self._reranker is None:
@@ -411,40 +409,14 @@ class RagLeap:
         Returns: [{"document_id": str, "filename": str, "uploaded_at": ...,
                    "chunk_count": int}, ...]
         """
-        with self._pool.get_connection() as conn:
-            cur = conn.cursor()
-            cur.execute(
-                """
-                SELECT d.id, d.filename, d.uploaded_at, d.metadata, COUNT(c.id) AS chunk_count
-                FROM documents d
-                LEFT JOIN chunks c ON c.document_id = d.id
-                GROUP BY d.id, d.filename, d.uploaded_at, d.metadata
-                ORDER BY d.uploaded_at DESC
-                LIMIT %s OFFSET %s
-                """,
-                (limit, offset),
-            )
-            rows = cur.fetchall()
-            cur.close()
-
-        return [
-            {"document_id": str(r[0]), "filename": r[1], "uploaded_at": r[2], "metadata": r[3], "chunk_count": r[4]}
-            for r in rows
-        ]
+        return self._vector_backend.list_documents(limit=limit, offset=offset)
 
     def delete_document(self, document_id: str) -> bool:
         """
-        Delete a document and all its chunks (cascades automatically via
-        the chunks.document_id foreign key). Returns True if a document
+        Delete a document and all its chunks. Returns True if a document
         was actually deleted, False if document_id did not exist.
         """
-        with self._pool.get_connection() as conn:
-            cur = conn.cursor()
-            cur.execute("DELETE FROM documents WHERE id = %s", (document_id,))
-            deleted = cur.rowcount > 0
-            conn.commit()
-            cur.close()
-
+        deleted = self._vector_backend.delete_document(document_id)
         if deleted:
             logger.info(f"Deleted document {document_id}")
         else:
@@ -461,14 +433,9 @@ class RagLeap:
         """
         existing_filename = filename
         if existing_filename is None:
-            with self._pool.get_connection() as conn:
-                cur = conn.cursor()
-                cur.execute("SELECT filename FROM documents WHERE id = %s", (document_id,))
-                row = cur.fetchone()
-                cur.close()
-            if row is None:
+            existing_filename = self._vector_backend.get_document_filename(document_id)
+            if existing_filename is None:
                 raise ValueError(f"No document found with id {document_id}")
-            existing_filename = row[0]
 
         self.delete_document(document_id)
         return self.ingest_text(existing_filename, text)

--- a/packages/ragleap-rag/src/ragleap/schema.py
+++ b/packages/ragleap-rag/src/ragleap/schema.py
@@ -1,11 +1,23 @@
 """
 Database schema management for ragleap-rag.
+
+Split into two independent pieces:
+- Core schema (documents/chunks) - specific to PgVectorBackend, lives
+  behind the VectorBackend interface now.
+- Memory schema (conversations/conversation_messages) - conversation
+  memory always requires Postgres regardless of which vector backend
+  is chosen (FAISS, Pinecone, etc. only store vectors, not chat
+  history), so this stays independent and is always initialized.
+
+init_schema()/get_schema_sql() are kept as backward-compatible
+wrappers that run both pieces together, exactly matching the old
+combined behavior for anyone calling this module directly.
 """
 import logging
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_SQL_TEMPLATE = """
+CORE_SCHEMA_SQL_TEMPLATE = """
 CREATE EXTENSION IF NOT EXISTS vector;
 
 CREATE TABLE IF NOT EXISTS documents (
@@ -33,16 +45,15 @@ ALTER TABLE chunks ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{{}
 
 CREATE INDEX IF NOT EXISTS chunks_embedding_idx
     ON chunks USING hnsw ((embedding::halfvec({dimensions})) halfvec_cosine_ops);
-
 CREATE INDEX IF NOT EXISTS chunks_text_search_idx
     ON chunks USING GIN (text_search_vector);
-
 CREATE INDEX IF NOT EXISTS chunks_metadata_idx
     ON chunks USING GIN (metadata);
-
 CREATE INDEX IF NOT EXISTS documents_metadata_idx
     ON documents USING GIN (metadata);
+"""
 
+MEMORY_SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS conversations (
     session_id TEXT PRIMARY KEY,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -62,25 +73,53 @@ CREATE INDEX IF NOT EXISTS conversation_messages_session_idx
 """
 
 
+def get_core_schema_sql(dimensions: int = 3072) -> str:
+    """DDL for documents/chunks - the PgVectorBackend-specific pieces."""
+    return CORE_SCHEMA_SQL_TEMPLATE.format(dimensions=dimensions)
+
+
+def get_memory_schema_sql() -> str:
+    """DDL for conversations/conversation_messages - always Postgres,
+    independent of which vector backend is in use."""
+    return MEMORY_SCHEMA_SQL
+
+
 def get_schema_sql(dimensions: int = 3072) -> str:
-    """Return the DDL for the given embedding dimensionality."""
-    return SCHEMA_SQL_TEMPLATE.format(dimensions=dimensions)
+    """Backward-compatible: both pieces combined, matching the old
+    single-template behavior exactly."""
+    return get_core_schema_sql(dimensions) + get_memory_schema_sql()
+
+
+def _run_sql(database_url: str, sql: str) -> None:
+    import psycopg2
+    conn = psycopg2.connect(database_url)
+    try:
+        cur = conn.cursor()
+        cur.execute(sql)
+        conn.commit()
+        cur.close()
+    finally:
+        conn.close()
+
+
+def init_core_schema(database_url: str, dimensions: int = 3072) -> None:
+    """Create/verify the documents/chunks tables. Idempotent."""
+    _run_sql(database_url, get_core_schema_sql(dimensions))
+    logger.info(f"Core schema initialized (embedding dimensions={dimensions})")
+
+
+def init_memory_schema(database_url: str) -> None:
+    """Create/verify the conversations/conversation_messages tables.
+    Always Postgres, regardless of vector backend choice. Idempotent."""
+    _run_sql(database_url, get_memory_schema_sql())
+    logger.info("Memory schema initialized")
 
 
 def init_schema(database_url: str, dimensions: int = 3072) -> None:
     """
-    Create the required tables/indexes in the given database if they
-    don't already exist. Safe to call repeatedly (idempotent —
-    everything uses IF NOT EXISTS).
+    Backward-compatible: initializes both core and memory schema
+    together in one call, matching the old combined behavior exactly.
+    Safe to call repeatedly (idempotent - everything uses IF NOT EXISTS).
     """
-    import psycopg2
-
-    conn = psycopg2.connect(database_url)
-    try:
-        cur = conn.cursor()
-        cur.execute(get_schema_sql(dimensions))
-        conn.commit()
-        cur.close()
-        logger.info(f"Schema initialized (embedding dimensions={dimensions})")
-    finally:
-        conn.close()
+    init_core_schema(database_url, dimensions)
+    init_memory_schema(database_url)

--- a/packages/ragleap-rag/src/ragleap/vectorstores/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/vectorstores/__init__.py
@@ -1,0 +1,10 @@
+from ragleap.vectorstores.base import VectorBackend
+from ragleap.vectorstores.pgvector import PgVectorBackend
+
+__all__ = ["VectorBackend", "PgVectorBackend"]
+
+try:
+    from ragleap.vectorstores.faiss_backend import FAISSBackend
+    __all__.append("FAISSBackend")
+except ImportError:
+    pass  # faiss extra not installed - FAISSBackend simply unavailable, not an error

--- a/packages/ragleap-rag/src/ragleap/vectorstores/base.py
+++ b/packages/ragleap-rag/src/ragleap/vectorstores/base.py
@@ -1,0 +1,65 @@
+"""
+Abstract vector storage backend for ragleap-rag.
+
+RagLeap defaults to PgVectorBackend (Postgres + pgvector) for full
+backward compatibility. Other backends (FAISS, Pinecone, ...) can be
+swapped in via the vector_backend= constructor parameter. Backends
+differ in what they can do - supports_sparse() is a real capability
+flag, not a formality: callers (RagLeap.ask) check it before assuming
+hybrid search is meaningful for a given backend.
+"""
+from abc import ABC, abstractmethod
+from typing import Dict, List, Optional
+
+
+class VectorBackend(ABC):
+    """Every vector storage backend must implement this interface."""
+
+    @abstractmethod
+    def init_schema(self, dimensions: int) -> None:
+        """Create/verify whatever storage structure this backend needs. Idempotent."""
+
+    @abstractmethod
+    def insert_document(self, document_id: str, filename: str, metadata: Dict) -> None:
+        """Register a new document (parent record for its chunks)."""
+
+    @abstractmethod
+    def insert_chunk(
+        self, document_id: str, document_name: str, chunk_index: int,
+        text: str, token_count: int, embedding: List[float], metadata: Dict,
+    ) -> None:
+        """Store one chunk with its embedding."""
+
+    @abstractmethod
+    def search_dense(self, embedding: List[float], top_k: int, metadata_filter: Optional[Dict] = None) -> List[Dict]:
+        """Vector similarity search. Must return dicts with at least:
+        chunk_id, text, similarity_score, document_id, document_name, chunk_index."""
+
+    def search_sparse(self, query_text: str, top_k: int, metadata_filter: Optional[Dict] = None) -> List[Dict]:
+        """Keyword/full-text search. Default: not supported (see supports_sparse())."""
+        return []
+
+    def search_hybrid(self, query_text: str, embedding: List[float], top_k: int, metadata_filter: Optional[Dict] = None) -> List[Dict]:
+        """Combined dense+sparse via RRF. Default: falls back to dense-only
+        if this backend doesn't support sparse search - see supports_sparse()."""
+        return self.search_dense(embedding, top_k, metadata_filter)
+
+    def supports_sparse(self) -> bool:
+        """Whether this backend can do real keyword/full-text search.
+        Callers should check this rather than assume hybrid search is
+        doing anything beyond dense search under the hood."""
+        return False
+
+    @abstractmethod
+    def list_documents(self, limit: int, offset: int) -> List[Dict]:
+        """List documents, most recent first."""
+
+    @abstractmethod
+    def delete_document(self, document_id: str) -> bool:
+        """Delete a document and its chunks. Returns True if something was deleted."""
+
+    @abstractmethod
+    def get_document_filename(self, document_id: str) -> Optional[str]:
+        """Return a document's stored filename, or None if it doesn't exist.
+        Used by update_document() when no explicit filename= is given."""
+

--- a/packages/ragleap-rag/src/ragleap/vectorstores/faiss_backend.py
+++ b/packages/ragleap-rag/src/ragleap/vectorstores/faiss_backend.py
@@ -1,0 +1,189 @@
+"""
+FAISS-backed vector storage for ragleap-rag. Local, in-process,
+no API key, no external service - good for prototyping, small-to-
+medium local datasets, or fully offline use.
+
+Honest limitations, stated upfront (not discovered later):
+- FAISS only stores vectors, not text/metadata. A SQLite sidecar
+  (stdlib, no new dependency) stores document/chunk text and metadata.
+- No native full-text search - supports_sparse() is False, and
+  RagLeap.ask(hybrid=True) gracefully degrades to dense-only search
+  against this backend.
+- Metadata filtering is a post-filter: over-fetch candidates from
+  FAISS, then filter by metadata in SQLite. This is less efficient
+  than pgvector's indexed JSONB containment for very large datasets.
+- Without persist_directory=, everything is in-memory and lost when
+  the process exits - by design, not a bug, for the "no setup at all"
+  use case. Pass persist_directory= for data that survives restarts.
+"""
+import json
+import logging
+import os
+import sqlite3
+import threading
+import uuid
+from typing import Dict, List, Optional
+
+from ragleap.vectorstores.base import VectorBackend
+
+logger = logging.getLogger(__name__)
+
+
+class FAISSBackend(VectorBackend):
+    def __init__(self, persist_directory: Optional[str] = None):
+        try:
+            import faiss  # noqa: F401
+        except ImportError as e:
+            raise ImportError(
+                "FAISSBackend requires the 'faiss' extra: pip install ragleap-rag[faiss]"
+            ) from e
+
+        self.persist_directory = persist_directory
+        self._index = None
+        self._dimensions = None
+        self._lock = threading.Lock()
+
+        if persist_directory:
+            os.makedirs(persist_directory, exist_ok=True)
+            self._sqlite_path = os.path.join(persist_directory, "faiss_meta.sqlite3")
+            self._index_path = os.path.join(persist_directory, "faiss.index")
+        else:
+            self._sqlite_path = ":memory:"
+            self._index_path = None
+
+        self._conn = sqlite3.connect(self._sqlite_path, check_same_thread=False)
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS documents (
+                id TEXT PRIMARY KEY, filename TEXT NOT NULL, metadata TEXT NOT NULL, uploaded_at TEXT NOT NULL
+            )"""
+        )
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS chunks (
+                vid INTEGER PRIMARY KEY AUTOINCREMENT, document_id TEXT NOT NULL,
+                document_name TEXT NOT NULL, chunk_index INTEGER NOT NULL,
+                text TEXT NOT NULL, token_count INTEGER, metadata TEXT NOT NULL
+            )"""
+        )
+        self._conn.commit()
+
+    def init_schema(self, dimensions: int) -> None:
+        import faiss
+        self._dimensions = dimensions
+        with self._lock:
+            if self._index_path and os.path.exists(self._index_path):
+                self._index = faiss.read_index(self._index_path)
+                logger.info(f"FAISSBackend: loaded existing index from {self._index_path}")
+            else:
+                self._index = faiss.IndexIDMap(faiss.IndexFlatIP(dimensions))
+                logger.info(f"FAISSBackend: created new in-memory index (dimensions={dimensions})")
+
+    def _save_index_if_persistent(self) -> None:
+        if self._index_path:
+            import faiss
+            faiss.write_index(self._index, self._index_path)
+
+    def _normalize(self, vec: List[float]):
+        import numpy as np
+        arr = np.array([vec], dtype="float32")
+        import faiss
+        faiss.normalize_L2(arr)
+        return arr
+
+    def insert_document(self, document_id: str, filename: str, metadata: Dict) -> None:
+        import datetime
+        with self._lock:
+            self._conn.execute(
+                "INSERT INTO documents (id, filename, metadata, uploaded_at) VALUES (?, ?, ?, ?)",
+                (document_id, filename, json.dumps(metadata or {}), datetime.datetime.utcnow().isoformat()),
+            )
+            self._conn.commit()
+
+    def insert_chunk(
+        self, document_id: str, document_name: str, chunk_index: int,
+        text: str, token_count: int, embedding: List[float], metadata: Dict,
+    ) -> None:
+        with self._lock:
+            cur = self._conn.execute(
+                "INSERT INTO chunks (document_id, document_name, chunk_index, text, token_count, metadata) VALUES (?, ?, ?, ?, ?, ?)",
+                (document_id, document_name, chunk_index, text, token_count, json.dumps(metadata or {})),
+            )
+            vid = cur.lastrowid
+            self._conn.commit()
+
+            import numpy as np
+            vec = self._normalize(embedding)
+            self._index.add_with_ids(vec, np.array([vid], dtype="int64"))
+            self._save_index_if_persistent()
+
+    def _metadata_matches(self, stored_json: str, metadata_filter: Optional[Dict]) -> bool:
+        if not metadata_filter:
+            return True
+        stored = json.loads(stored_json)
+        return all(stored.get(k) == v for k, v in metadata_filter.items())
+
+    def search_dense(self, embedding: List[float], top_k: int, metadata_filter: Optional[Dict] = None) -> List[Dict]:
+        if not embedding or self._index is None or self._index.ntotal == 0:
+            return []
+        if self._dimensions and len(embedding) != self._dimensions:
+            logger.warning(f"Query embedding dim={len(embedding)} != expected {self._dimensions}; skipping search")
+            return []
+
+        fetch_k = top_k * 5 if metadata_filter else top_k
+        fetch_k = min(fetch_k, self._index.ntotal)
+        query = self._normalize(embedding)
+
+        with self._lock:
+            scores, ids = self._index.search(query, fetch_k)
+
+        results = []
+        for score, vid in zip(scores[0], ids[0]):
+            if vid == -1:
+                continue
+            row = self._conn.execute(
+                "SELECT document_id, document_name, chunk_index, text, metadata FROM chunks WHERE vid = ?",
+                (int(vid),),
+            ).fetchone()
+            if row is None:
+                continue
+            document_id, document_name, chunk_index, text, metadata_json = row
+            if not self._metadata_matches(metadata_json, metadata_filter):
+                continue
+            results.append({
+                "chunk_id": str(vid), "text": text, "similarity_score": round(float(score), 4),
+                "document_id": document_id, "document_name": document_name, "chunk_index": chunk_index,
+            })
+            if len(results) >= top_k:
+                break
+        return results
+
+    def supports_sparse(self) -> bool:
+        return False
+
+    def list_documents(self, limit: int, offset: int) -> List[Dict]:
+        rows = self._conn.execute(
+            """SELECT d.id, d.filename, d.uploaded_at, d.metadata, COUNT(c.vid) AS chunk_count
+               FROM documents d LEFT JOIN chunks c ON c.document_id = d.id
+               GROUP BY d.id ORDER BY d.uploaded_at DESC LIMIT ? OFFSET ?""",
+            (limit, offset),
+        ).fetchall()
+        return [
+            {"document_id": r[0], "filename": r[1], "uploaded_at": r[2], "metadata": json.loads(r[3]), "chunk_count": r[4]}
+            for r in rows
+        ]
+
+    def delete_document(self, document_id: str) -> bool:
+        import numpy as np
+        with self._lock:
+            vids = [r[0] for r in self._conn.execute("SELECT vid FROM chunks WHERE document_id = ?", (document_id,)).fetchall()]
+            if vids:
+                self._index.remove_ids(np.array(vids, dtype="int64"))
+            cur = self._conn.execute("DELETE FROM documents WHERE id = ?", (document_id,))
+            self._conn.execute("DELETE FROM chunks WHERE document_id = ?", (document_id,))
+            deleted = cur.rowcount > 0
+            self._conn.commit()
+            self._save_index_if_persistent()
+        return deleted
+
+    def get_document_filename(self, document_id: str) -> Optional[str]:
+        row = self._conn.execute("SELECT filename FROM documents WHERE id = ?", (document_id,)).fetchone()
+        return row[0] if row else None

--- a/packages/ragleap-rag/src/ragleap/vectorstores/pgvector.py
+++ b/packages/ragleap-rag/src/ragleap/vectorstores/pgvector.py
@@ -1,0 +1,191 @@
+"""
+Postgres + pgvector backend - the default, battle-tested storage for
+ragleap-rag. This relocates the existing proven SQL from schema.py/
+retrieval.py/__init__.py behind the VectorBackend interface rather
+than rewriting the logic, to keep regression risk near zero.
+"""
+import json
+import logging
+from typing import Dict, List, Optional
+
+from ragleap.vectorstores.base import VectorBackend
+from ragleap.db import ConnectionPool
+from ragleap import schema as _schema
+
+logger = logging.getLogger(__name__)
+
+RRF_K = 60
+
+
+class PgVectorBackend(VectorBackend):
+    def __init__(self, database_url: str, min_similarity: float = 0.05):
+        self.database_url = database_url
+        self.min_similarity = min_similarity
+        self._pool = ConnectionPool(database_url)
+        self._dimensions = None
+
+    def init_schema(self, dimensions: int) -> None:
+        self._dimensions = dimensions
+        _schema.init_core_schema(self.database_url, dimensions=dimensions)
+
+    def insert_document(self, document_id: str, filename: str, metadata: Dict) -> None:
+        with self._pool.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO documents (id, filename, metadata) VALUES (%s, %s, %s::jsonb)",
+                (document_id, filename, json.dumps(metadata or {})),
+            )
+            conn.commit()
+            cur.close()
+
+    def insert_chunk(
+        self, document_id: str, document_name: str, chunk_index: int,
+        text: str, token_count: int, embedding: List[float], metadata: Dict,
+    ) -> None:
+        embedding_literal = "[" + ",".join(str(float(x)) for x in embedding) + "]"
+        with self._pool.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO chunks (document_id, document_name, chunk_index, text, token_count, embedding, metadata)
+                VALUES (%s, %s, %s, %s, %s, %s::vector, %s::jsonb)
+                """,
+                (document_id, document_name, chunk_index, text, token_count, embedding_literal, json.dumps(metadata or {})),
+            )
+            conn.commit()
+            cur.close()
+
+    def search_dense(self, embedding: List[float], top_k: int, metadata_filter: Optional[Dict] = None) -> List[Dict]:
+        if not embedding:
+            return []
+        dims = self._dimensions or len(embedding)
+        literal = "[" + ",".join(str(float(x)) for x in embedding) + "]"
+
+        sql = """
+            SELECT id, text, document_id, document_name, chunk_index,
+                   1 - (embedding::halfvec(%s) <=> %s::halfvec(%s)) / 2 AS similarity_score
+            FROM chunks
+        """
+        params = [dims, literal, dims]
+        where = []
+        if metadata_filter:
+            where.append("metadata @> %s::jsonb")
+            params.append(json.dumps(metadata_filter))
+        if where:
+            sql += " WHERE " + " AND ".join(where)
+        sql += " ORDER BY embedding::halfvec(%s) <=> %s::halfvec(%s) LIMIT %s"
+        params.extend([dims, literal, dims, top_k])
+
+        with self._pool.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+            cur.close()
+
+        results = []
+        for chunk_id, text, doc_id, doc_name, chunk_index, score in rows:
+            if score < self.min_similarity:
+                continue
+            results.append({
+                "chunk_id": str(chunk_id), "text": text,
+                "similarity_score": round(float(score), 4),
+                "document_id": str(doc_id), "document_name": doc_name, "chunk_index": chunk_index,
+            })
+        return results
+
+    def search_sparse(self, query_text: str, top_k: int, metadata_filter: Optional[Dict] = None) -> List[Dict]:
+        if not query_text or not query_text.strip():
+            return []
+        sql = """
+            SELECT id, text, document_id, document_name, chunk_index,
+                   ts_rank(text_search_vector, websearch_to_tsquery('english', %s)) AS rank_score
+            FROM chunks
+            WHERE text_search_vector @@ websearch_to_tsquery('english', %s)
+        """
+        params = [query_text, query_text]
+        if metadata_filter:
+            sql += " AND metadata @> %s::jsonb"
+            params.append(json.dumps(metadata_filter))
+        sql += " ORDER BY rank_score DESC LIMIT %s"
+        params.append(top_k)
+
+        with self._pool.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+            cur.close()
+
+        return [
+            {"chunk_id": str(r[0]), "text": r[1], "similarity_score": round(float(r[5]), 4),
+             "document_id": str(r[2]), "document_name": r[3], "chunk_index": r[4]}
+            for r in rows
+        ]
+
+    def search_hybrid(self, query_text: str, embedding: List[float], top_k: int, metadata_filter: Optional[Dict] = None) -> List[Dict]:
+        dense = self.search_dense(embedding, top_k * 3, metadata_filter)
+        sparse = self.search_sparse(query_text, top_k * 3, metadata_filter)
+
+        dense_ranks = {c["chunk_id"]: i for i, c in enumerate(dense)}
+        sparse_ranks = {c["chunk_id"]: i for i, c in enumerate(sparse)}
+        lookup = {c["chunk_id"]: c for c in dense}
+        for c in sparse:
+            lookup.setdefault(c["chunk_id"], c)
+
+        all_ids = set(dense_ranks) | set(sparse_ranks)
+        if not all_ids:
+            return []
+
+        scores = {}
+        for cid in all_ids:
+            s = 0.0
+            if cid in dense_ranks:
+                s += 1.0 / (RRF_K + dense_ranks[cid] + 1)
+            if cid in sparse_ranks:
+                s += 1.0 / (RRF_K + sparse_ranks[cid] + 1)
+            scores[cid] = s
+
+        results = [dict(lookup[cid]) for cid in all_ids]
+        for c in results:
+            c["similarity_score"] = round(scores[c["chunk_id"]], 6)
+            c["retrieval_method"] = "hybrid_rrf"
+        results.sort(key=lambda c: c["similarity_score"], reverse=True)
+        return results[:top_k]
+
+    def supports_sparse(self) -> bool:
+        return True
+
+    def list_documents(self, limit: int, offset: int) -> List[Dict]:
+        with self._pool.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                SELECT d.id, d.filename, d.uploaded_at, d.metadata, COUNT(c.id) AS chunk_count
+                FROM documents d LEFT JOIN chunks c ON c.document_id = d.id
+                GROUP BY d.id, d.filename, d.uploaded_at, d.metadata
+                ORDER BY d.uploaded_at DESC LIMIT %s OFFSET %s
+                """,
+                (limit, offset),
+            )
+            rows = cur.fetchall()
+            cur.close()
+        return [
+            {"document_id": str(r[0]), "filename": r[1], "uploaded_at": r[2], "metadata": r[3], "chunk_count": r[4]}
+            for r in rows
+        ]
+
+    def delete_document(self, document_id: str) -> bool:
+        with self._pool.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute("DELETE FROM documents WHERE id = %s", (document_id,))
+            deleted = cur.rowcount > 0
+            conn.commit()
+            cur.close()
+        return deleted
+
+    def get_document_filename(self, document_id: str) -> Optional[str]:
+        with self._pool.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT filename FROM documents WHERE id = %s", (document_id,))
+            row = cur.fetchone()
+            cur.close()
+        return row[0] if row else None

--- a/packages/ragleap-rag/tests/test_faiss_backend.py
+++ b/packages/ragleap-rag/tests/test_faiss_backend.py
@@ -1,0 +1,136 @@
+"""Real tests for FAISSBackend - genuine FAISS index + SQLite sidecar,
+no mocking of the backend itself. Skipped automatically if the
+[faiss] extra isn't installed, so it never blocks CI runs without it."""
+import pytest
+
+faiss_available = True
+try:
+    import faiss  # noqa: F401
+except ImportError:
+    faiss_available = False
+
+pytestmark = pytest.mark.skipif(not faiss_available, reason="faiss-cpu not installed")
+
+
+@pytest.fixture
+def faiss_rag(database_url, tmp_path):
+    """A RagLeap instance using FAISSBackend instead of the default
+    PgVectorBackend - conversation memory still uses database_url
+    (Postgres), since memory is always backend-independent."""
+    from ragleap import RagLeap, ProviderConfig, EmbeddingConfig
+    from ragleap.vectorstores import FAISSBackend
+    from conftest import TEST_DIMENSIONS
+
+    backend = FAISSBackend(persist_directory=str(tmp_path / "faiss_data"))
+    rag = RagLeap(
+        database_url=database_url,
+        vector_backend=backend,
+        embedder=EmbeddingConfig(provider="gemini", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
+        primary=ProviderConfig(provider="gemini", api_key="fake-test-key"),
+    )
+    rag.init_schema()
+    return rag
+
+
+def test_faiss_ingest_and_ask_roundtrip(faiss_rag):
+    result = faiss_rag.ingest_text("apples.txt", "This document is about apples and orchards.")
+    assert result.chunks_stored == 1
+
+    answer = faiss_rag.ask("Tell me about apples", top_k=1)
+    assert answer["sources"] == ["apples.txt"]
+
+
+def test_faiss_dense_search_finds_correct_document(faiss_rag):
+    """Dense-only search with a non-semantic fake embedder can only
+    reliably prove exact-vector nearest-neighbor lookup works, not
+    that paraphrased text is semantically closest - the fake embedder
+    has no real semantic meaning, unlike the pgvector hybrid tests
+    which get genuine ranking signal from real Postgres full-text
+    search underneath. Querying with the exact ingested text guarantees
+    an identical vector and a correct, non-coincidental match."""
+    faiss_rag.ingest_text("a.txt", "Content about apples and fruit.")
+    faiss_rag.ingest_text("b.txt", "Content about spaceships and rockets.")
+
+    answer = faiss_rag.ask("Content about apples and fruit.", top_k=1)
+    assert answer["sources"] == ["a.txt"]
+
+
+def test_faiss_backend_does_not_support_sparse(faiss_rag):
+    assert faiss_rag._vector_backend.supports_sparse() is False
+
+
+def test_faiss_hybrid_mode_gracefully_degrades_to_dense(faiss_rag):
+    """hybrid=True should not crash against a backend with no sparse
+    support - it should just behave like dense-only search."""
+    faiss_rag.ingest_text("a.txt", "Unique content about zebras.")
+    answer = faiss_rag.ask("zebras", hybrid=True, top_k=1)
+    assert answer["sources"] == ["a.txt"]
+
+
+def test_faiss_list_documents(faiss_rag):
+    faiss_rag.ingest_text("a.txt", "First document content.")
+    faiss_rag.ingest_text("b.txt", "Second document content.")
+
+    docs = faiss_rag.list_documents()
+    filenames = {d["filename"] for d in docs}
+    assert filenames == {"a.txt", "b.txt"}
+
+
+def test_faiss_delete_document_removes_it(faiss_rag):
+    result = faiss_rag.ingest_text("temp.txt", "Temporary content.")
+    deleted = faiss_rag.delete_document(result.document_id)
+    assert deleted is True
+    assert faiss_rag.list_documents() == []
+
+
+def test_faiss_delete_unknown_document_returns_false(faiss_rag):
+    assert faiss_rag.delete_document("nonexistent-id") is False
+
+
+def test_faiss_metadata_filter_post_filters_correctly(faiss_rag):
+    faiss_rag.ingest_text("a.txt", "Pricing content here.", metadata={"tenant": "acme"})
+    faiss_rag.ingest_text("b.txt", "Pricing content here too.", metadata={"tenant": "globex"})
+
+    answer = faiss_rag.ask("pricing content", metadata_filter={"tenant": "acme"}, top_k=5)
+    assert answer["sources"] == ["a.txt"]
+
+
+def test_faiss_update_document_preserves_filename(faiss_rag):
+    original = faiss_rag.ingest_text("stable.txt", "Version one content.")
+    updated = faiss_rag.update_document(original.document_id, text="Version two content.")
+
+    docs = {d["document_id"]: d["filename"] for d in faiss_rag.list_documents()}
+    assert docs[updated.document_id] == "stable.txt"
+
+
+def test_faiss_persistence_across_backend_instances(tmp_path, database_url):
+    """The real point of persist_directory= - data survives a fresh
+    FAISSBackend instance pointed at the same directory, proving this
+    isn't just in-process caching."""
+    from ragleap import RagLeap, ProviderConfig, EmbeddingConfig
+    from ragleap.vectorstores import FAISSBackend
+    from conftest import TEST_DIMENSIONS
+
+    persist_dir = str(tmp_path / "faiss_persist_test")
+
+    backend1 = FAISSBackend(persist_directory=persist_dir)
+    rag1 = RagLeap(
+        database_url=database_url, vector_backend=backend1,
+        embedder=EmbeddingConfig(provider="gemini", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
+        primary=ProviderConfig(provider="gemini", api_key="fake-test-key"),
+    )
+    rag1.init_schema()
+    rag1.ingest_text("persisted.txt", "This content should survive a restart.")
+
+    # Fresh backend instance, same directory - simulates a process restart
+    backend2 = FAISSBackend(persist_directory=persist_dir)
+    rag2 = RagLeap(
+        database_url=database_url, vector_backend=backend2,
+        embedder=EmbeddingConfig(provider="gemini", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
+        primary=ProviderConfig(provider="gemini", api_key="fake-test-key"),
+    )
+    rag2.init_schema()
+
+    docs = rag2.list_documents()
+    assert len(docs) == 1
+    assert docs[0]["filename"] == "persisted.txt"

--- a/packages/ragleap-rag/tests/test_retrieval.py
+++ b/packages/ragleap-rag/tests/test_retrieval.py
@@ -1,21 +1,22 @@
-"""Tests for VectorRetrievalService — dense (fake embeddings, plumbing
-only), sparse (real Postgres full-text search, genuinely meaningful),
-and hybrid RRF fusion. Accesses rag's internal retriever directly for
-white-box testing of retrieval behavior that ask() doesn't fully expose."""
+"""Tests for the active VectorBackend's retrieval methods - dense (fake
+embeddings, plumbing only), sparse (real Postgres full-text search,
+genuinely meaningful), and hybrid RRF fusion. Accesses rag's internal
+_vector_backend directly for white-box testing of retrieval behavior
+that ask() doesn't fully expose."""
 
 
 def test_sparse_search_finds_real_keyword_matches(rag):
     rag.ingest_text(filename="a.txt", text="This document is about bananas and tropical fruit.")
     rag.ingest_text(filename="b.txt", text="This document is about spaceships and rocket engines.")
 
-    results = rag._retriever.search_sparse_chunks("bananas")
+    results = rag._vector_backend.search_sparse("bananas", top_k=5)
     assert len(results) == 1
     assert results[0]["document_name"] == "a.txt"
 
 
 def test_sparse_search_no_match_returns_empty(rag):
     rag.ingest_text(filename="a.txt", text="This document is about bananas.")
-    results = rag._retriever.search_sparse_chunks("nonexistentxyzword")
+    results = rag._vector_backend.search_sparse("nonexistentxyzword", top_k=5)
     assert results == []
 
 
@@ -23,21 +24,21 @@ def test_sparse_search_respects_metadata_filter(rag):
     rag.ingest_text(filename="a.txt", text="Content about pricing plans.", metadata={"tenant": "acme"})
     rag.ingest_text(filename="b.txt", text="Content about pricing plans.", metadata={"tenant": "globex"})
 
-    results = rag._retriever.search_sparse_chunks("pricing plans", metadata_filter={"tenant": "acme"})
+    results = rag._vector_backend.search_sparse("pricing plans", top_k=5, metadata_filter={"tenant": "acme"})
     assert len(results) == 1
     assert results[0]["document_name"] == "a.txt"
 
 
 def test_dense_search_respects_embedding_dimension_mismatch(rag):
-    """A query embedding of the wrong dimension should be rejected,
-    not silently truncated or padded."""
+    """A query embedding of the wrong dimension should be rejected or
+    return no results, not crash."""
     wrong_dim_embedding = [0.1, 0.2, 0.3]  # rag fixture uses TEST_DIMENSIONS=8
-    results = rag._retriever.search_similar_chunks(wrong_dim_embedding)
+    results = rag._vector_backend.search_dense(wrong_dim_embedding, top_k=5)
     assert results == []
 
 
 def test_dense_search_empty_embedding_returns_empty(rag):
-    assert rag._retriever.search_similar_chunks([]) == []
+    assert rag._vector_backend.search_dense([], top_k=5) == []
 
 
 def test_hybrid_search_prefers_keyword_match_via_sparse_signal(rag):
@@ -55,7 +56,14 @@ def test_hybrid_search_combines_dense_and_sparse_result_sets(rag):
     rag.ingest_text(filename="a.txt", text="Unique keyword zephyrtown appears here.")
     rag.ingest_text(filename="b.txt", text="Completely different unrelated content.")
 
-    results = rag._retriever.search_hybrid_chunks("zephyrtown", query_embedding=[0.5] * 8, top_k=5)
+    results = rag._vector_backend.search_hybrid("zephyrtown", embedding=[0.5] * 8, top_k=5)
     assert len(results) >= 1
     assert any(r["document_name"] == "a.txt" for r in results)
     assert all(r["retrieval_method"] == "hybrid_rrf" for r in results)
+
+
+def test_backend_reports_sparse_support(rag):
+    """PgVectorBackend (the default) genuinely supports sparse search -
+    this isn't a formality, ask()/ask_stream() could check it before
+    assuming hybrid mode does anything beyond dense search."""
+    assert rag._vector_backend.supports_sparse() is True


### PR DESCRIPTION
Decouples vector storage from conversation memory - RagLeap now accepts vector_backend= to swap storage away from the default PgVectorBackend. Conversation memory always uses Postgres regardless of vector backend choice, since memory is a separate concern from vector storage.

New: ragleap.vectorstores module
- VectorBackend - abstract interface (init_schema, insert_document, insert_chunk, search_dense, list_documents, delete_document, get_document_filename, optionally search_sparse/search_hybrid/ supports_sparse for backends that support keyword search)
- PgVectorBackend - the default, a refactor (not rewrite) of the existing proven Postgres/pgvector logic. Verified zero behavior change: full existing test suite (73 tests) passes unmodified after the refactor.
- FAISSBackend - new, local, in-process, no API key. Requires the [faiss] extra. No native full-text search (supports_sparse() is False, hybrid mode gracefully degrades to dense-only). Metadata filtering is a documented post-filter over a SQLite sidecar, not an indexed query. Optional persist_directory= for data that survives restarts - verified live across separate backend instances pointed at the same directory, not just in-process caching. 10 new tests, all real (no mocking of the backend itself): ingest/ask roundtrip, dense search correctness, hybrid degradation, lifecycle (list/delete/update), metadata filtering, and cross-instance persistence.

schema.py split into independent core schema (documents/chunks, backend-specific) and memory schema (conversations/ conversation_messages, always Postgres) - init_schema()/ get_schema_sql() kept as backward-compatible combined wrappers.

Breaking (internal only): RagLeap._retriever removed in favor of RagLeap._vector_backend with renamed methods (search_dense/ search_sparse/search_hybrid). Not part of the public API, but flagged in CHANGELOG for anyone who was reaching into private attributes directly.

CI: ragleap-rag-tests job now installs the [faiss] extra so the new FAISSBackend tests actually run there, not just locally.

Full suite: 83/83 passing (73 existing + 10 new) before this commit. Version bumped 0.5.8 -> 0.6.0 (new public API surface warrants a minor bump, not a patch).

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
