### PR TITLE
feat: guardrail hooks (0.6.1)

### DIFF
--- a/packages/ragleap-rag/CHANGELOG.md
+++ b/packages/ragleap-rag/CHANGELOG.md
@@ -8,6 +8,15 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `docs`: Celery integration guide + runnable example ([#57](https://github.com/antonyrag/ragleap-core/pull/57))
 - `test`: comprehensive pytest suite (67 tests) + CI integration — first automated testing this package has had ([#58](https://github.com/antonyrag/ragleap-core/pull/58))
 
+## [0.6.1]
+
+### Added
+- Guardrail hooks: `input_guardrails=`/`output_guardrails=` on `RagLeap.__init__()` - user-supplied validation callbacks that extend (not replace) the existing sanitization/injection-risk detection. Each guardrail is `(text: str) -> str`, or raises `GuardrailViolation` to reject content.
+- `input_guardrails` run during `ingest_text()`, after sanitization - a violation aborts ingestion with nothing stored.
+- `output_guardrails` run on `ask()`'s answer - a violation replaces the answer with a refusal message and sets `answer["guardrail_blocked"] = True`.
+- `ask_stream()` support with an honestly-documented limitation: output guardrails can only run after the full answer is assembled, but tokens are already yielded to the caller by then - a violation during streaming is logged as a warning, not enforced. Use `ask()` instead if blocking bad output before the user sees it matters.
+- 8 new tests covering modification, rejection, ordering, and the ask()/ask_stream() enforcement difference.
+
 ## [0.6.0]
 
 ### Added

--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -213,6 +213,35 @@ Sanitization strips null bytes, control characters, and invisible/zero-width Uni
 
 Injection-risk detection is heuristic pattern matching against a fixed list of common trigger phrases ("ignore previous instructions", "reveal your system prompt", etc). It logs a warning and does NOT block ingestion. Honest limitation: this is pattern matching, not semantic understanding - prompt injection via retrieved content is an open research problem, and a sufficiently motivated attacker can rephrase around any fixed pattern list. Treat a warning as a signal to review, not a guarantee of safety, and treat the absence of a warning as "nothing matched", not "this content is safe."
 
+## Guardrails
+
+Beyond the built-in sanitization above, `input_guardrails=`/`output_guardrails=` let you plug in your own validation callbacks - a PII filter, a profanity check, a brand-voice check, whatever your use case needs. Each guardrail is a function `(text: str) -> str` that returns the (possibly modified) text, or raises `GuardrailViolation` to reject it outright.
+
+```python
+from ragleap import RagLeap, ProviderConfig, EmbeddingConfig
+from ragleap.guardrails import GuardrailViolation
+
+def reject_pii(text: str) -> str:
+    if "ssn:" in text.lower():
+        raise GuardrailViolation("Document appears to contain an SSN")
+    return text
+
+def enforce_brand_voice(text: str) -> str:
+    return text.replace("gonna", "going to")
+
+rag = RagLeap(
+    database_url="...",
+    embedder=EmbeddingConfig(...),
+    primary=ProviderConfig(...),
+    input_guardrails=[reject_pii],       # runs during ingest_text(), after sanitization
+    output_guardrails=[enforce_brand_voice],  # runs on ask()/ask_stream()'s answer
+)
+```
+
+On `ask()`, a raised `GuardrailViolation` replaces the answer with a refusal message and sets `answer["guardrail_blocked"] = True` (the key is only present when guardrails are configured). On `ingest_text()`, a violation aborts ingestion entirely - nothing is stored.
+
+Honest limitation for `ask_stream()`: output guardrails can only run *after* the full answer is assembled, but by then individual tokens have already been yielded to the caller - streaming can't retroactively un-send content. A violation during streaming is logged as a warning, not enforced. If blocking bad output before the user sees any of it matters for your use case, use `ask()` instead of `ask_stream()`.
+
 ## Citations
 
 Every ask() response includes a citations field - a structured, chunk-level breakdown that resolves a real ambiguity: a citation like "(Source 1)" in an answer could mean a whole document or one specific passage within it. It always means the latter.

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.6.0"
+version = "0.6.1"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -19,12 +19,13 @@ ragleap-rag: a fast, honest, self-hosted RAG engine.
 import uuid
 import logging
 from dataclasses import dataclass
-from typing import Dict, Iterator, List, Optional
+from typing import Callable, Dict, Iterator, List, Optional
 
 from ragleap.chunker import TextChunker
 from ragleap.embedding import EmbeddingService, EmbeddingConfig
 from ragleap.vectorstores import VectorBackend, PgVectorBackend
 from ragleap.generation import GenerationService, ProviderConfig
+from ragleap.guardrails import GuardrailViolation, run_guardrails
 from ragleap.parsers import extract_text
 from ragleap.memory import ConversationMemory
 from ragleap.reranking import RerankerService
@@ -40,7 +41,7 @@ from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult", "TranscriptionConfig", "VectorBackend", "PgVectorBackend"]
 
 
@@ -77,6 +78,8 @@ class RagLeap:
         cache_backend: str = "memory",
         redis_url: Optional[str] = None,
         cache_ttl_seconds: int = 86400,
+        input_guardrails: Optional[List[Callable[[str], str]]] = None,
+        output_guardrails: Optional[List[Callable[[str], str]]] = None,
     ):
         """
         database_url is always required - conversation memory is
@@ -90,6 +93,8 @@ class RagLeap:
         self.embedding_dimensions = embedder.dimensions
         self._pool = ConnectionPool(database_url)
         self._vector_backend = vector_backend or PgVectorBackend(database_url)
+        self._input_guardrails = input_guardrails
+        self._output_guardrails = output_guardrails
 
         self._chunker = TextChunker(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
         self._embedder = EmbeddingService(embedder)
@@ -268,6 +273,8 @@ class RagLeap:
                     f"signal, not a block - review the content if unexpected."
                 )
 
+        text = run_guardrails(text, self._input_guardrails)
+
         chunks = self._chunker.chunk_text(text)
         if not chunks:
             raise ValueError("No chunks produced from input text — is it empty?")
@@ -344,6 +351,14 @@ class RagLeap:
             max_tokens=max_tokens, history_prefix=history_prefix,
         )
 
+        if self._output_guardrails:
+            try:
+                result["answer"] = run_guardrails(result["answer"], self._output_guardrails)
+                result["guardrail_blocked"] = False
+            except GuardrailViolation as e:
+                result["answer"] = f"Response blocked by guardrail: {e}"
+                result["guardrail_blocked"] = True
+
         if session_id:
             self._memory.add_message(session_id, "user", query)
             self._memory.add_message(session_id, "assistant", result["answer"])
@@ -391,9 +406,20 @@ class RagLeap:
             pieces.append(piece)
             yield piece
 
+        full_answer = "".join(pieces)
+        if self._output_guardrails:
+            try:
+                run_guardrails(full_answer, self._output_guardrails)
+            except GuardrailViolation as e:
+                logger.warning(
+                    f"Output guardrail would have blocked this streamed response, "
+                    f"but tokens were already yielded to the caller and cannot be "
+                    f"retroactively un-sent: {e}"
+                )
+
         if session_id:
             self._memory.add_message(session_id, "user", query)
-            self._memory.add_message(session_id, "assistant", "".join(pieces))
+            self._memory.add_message(session_id, "assistant", full_answer)
 
     def get_history(self, session_id: str) -> List[Dict]:
         """Return the stored conversation history for a session, oldest first."""

--- a/packages/ragleap-rag/src/ragleap/guardrails.py
+++ b/packages/ragleap-rag/src/ragleap/guardrails.py
@@ -1,0 +1,38 @@
+"""
+Guardrail hooks for ragleap-rag - user-supplied validation callbacks
+for ingested content (input_guardrails) and generated answers
+(output_guardrails). This extends the existing sanitization module
+(null-byte stripping, injection-risk heuristics) rather than
+replacing it - guardrails run in addition to, after, that baseline.
+
+Honest scope: for ask_stream(), output guardrails can only run AFTER
+the full answer has been assembled - by then, individual tokens have
+already been yielded to the caller. A GuardrailViolation raised during
+streaming is logged as a warning, not silently enforced, since
+already-streamed content cannot be retroactively un-sent. Guardrails
+are fully enforced (block before the caller sees anything) only for
+the non-streaming ask().
+"""
+import logging
+from typing import Callable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class GuardrailViolation(Exception):
+    """Raise this from a guardrail callable to reject content.
+    For input_guardrails, this aborts ingestion - nothing is stored.
+    For output_guardrails on ask() (not ask_stream()), this replaces
+    the answer with a refusal message before it's returned."""
+
+
+def run_guardrails(text: str, guardrails: Optional[List[Callable[[str], str]]]) -> str:
+    """Run each guardrail callable in order, threading the (possibly
+    modified) text through each one. A guardrail can either return a
+    (possibly transformed) string, or raise GuardrailViolation to
+    reject the content outright."""
+    if not guardrails:
+        return text
+    for guardrail in guardrails:
+        text = guardrail(text)
+    return text

--- a/packages/ragleap-rag/tests/test_guardrails.py
+++ b/packages/ragleap-rag/tests/test_guardrails.py
@@ -1,0 +1,123 @@
+"""Tests for input_guardrails/output_guardrails - user-supplied
+validation callbacks that extend (not replace) sanitization and
+injection-risk detection."""
+import pytest
+from ragleap import RagLeap, ProviderConfig, EmbeddingConfig
+from ragleap.guardrails import GuardrailViolation
+from conftest import TEST_DATABASE_URL, TEST_DIMENSIONS
+
+
+def _make_rag(**kwargs):
+    return RagLeap(
+        database_url=TEST_DATABASE_URL,
+        embedder=EmbeddingConfig(provider="gemini", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
+        primary=ProviderConfig(provider="gemini", api_key="fake-test-key"),
+        **kwargs,
+    )
+
+
+def test_input_guardrail_can_modify_text(database_url):
+    def uppercase_guardrail(text):
+        return text.upper()
+
+    rag = _make_rag(input_guardrails=[uppercase_guardrail])
+    rag.ingest_text("a.txt", "some lowercase content")
+
+    import psycopg2
+    conn = psycopg2.connect(database_url)
+    cur = conn.cursor()
+    cur.execute("SELECT text FROM chunks ORDER BY created_at DESC LIMIT 1")
+    stored_text = cur.fetchone()[0]
+    cur.close()
+    conn.close()
+
+    assert stored_text == "SOME LOWERCASE CONTENT"
+
+
+def test_input_guardrail_violation_aborts_ingestion_with_nothing_stored(database_url):
+    def reject_banned_word(text):
+        if "banned" in text.lower():
+            raise GuardrailViolation("content contains a banned word")
+        return text
+
+    rag = _make_rag(input_guardrails=[reject_banned_word])
+
+    with pytest.raises(GuardrailViolation):
+        rag.ingest_text("bad.txt", "this text has a banned word in it")
+
+    assert rag.list_documents() == []
+
+
+def test_input_guardrails_run_in_order(database_url):
+    calls = []
+
+    def first(text):
+        calls.append("first")
+        return text
+
+    def second(text):
+        calls.append("second")
+        return text
+
+    rag = _make_rag(input_guardrails=[first, second])
+    rag.ingest_text("a.txt", "some content")
+
+    assert calls == ["first", "second"]
+
+
+def test_ask_output_guardrail_passes_through_when_no_violation(rag):
+    def noop_guardrail(text):
+        return text
+
+    rag._output_guardrails = [noop_guardrail]
+    rag.ingest_text("a.txt", "Some content about testing.")
+
+    answer = rag.ask("What is this about?")
+    assert answer["guardrail_blocked"] is False
+    assert answer["answer"] != ""
+
+
+def test_ask_output_guardrail_blocks_and_replaces_answer(rag):
+    def reject_everything(text):
+        raise GuardrailViolation("all responses blocked for this test")
+
+    rag._output_guardrails = [reject_everything]
+    rag.ingest_text("a.txt", "Some content.")
+
+    answer = rag.ask("A question")
+    assert answer["guardrail_blocked"] is True
+    assert "blocked by guardrail" in answer["answer"].lower()
+
+
+def test_ask_without_output_guardrails_has_no_blocked_key(rag):
+    rag.ingest_text("a.txt", "Some content.")
+    answer = rag.ask("A question")
+    assert "guardrail_blocked" not in answer
+
+
+def test_ask_stream_guardrail_violation_logs_warning_but_still_yields(rag, caplog):
+    import logging
+
+    def reject_everything(text):
+        raise GuardrailViolation("blocked for this test")
+
+    rag._output_guardrails = [reject_everything]
+    rag.ingest_text("a.txt", "Some content.")
+
+    with caplog.at_level(logging.WARNING):
+        pieces = list(rag.ask_stream("A question"))
+
+    # Tokens are still yielded - streaming can't retroactively un-send them
+    assert "".join(pieces) == "This is a fake streamed answer."
+    assert any("would have blocked" in record.message for record in caplog.records)
+
+
+def test_ask_stream_output_guardrail_passes_through_when_no_violation(rag):
+    def noop_guardrail(text):
+        return text
+
+    rag._output_guardrails = [noop_guardrail]
+    rag.ingest_text("a.txt", "Some content.")
+
+    pieces = list(rag.ask_stream("A question"))
+    assert "".join(pieces) == "This is a fake streamed answer."


### PR DESCRIPTION
Adds input_guardrails=/output_guardrails= to RagLeap.__init__() - user-supplied validation callbacks that extend (not replace) the existing sanitization/injection-risk detection.

New: ragleap.guardrails module - GuardrailViolation exception, run_guardrails() helper. Each guardrail is (text: str) -> str, returning the (possibly modified) text, or raising GuardrailViolation to reject content.

- input_guardrails run during ingest_text(), after sanitization, before chunking/storage. A violation aborts ingestion cleanly - nothing is inserted (guardrail check happens before insert_document is called, so no cleanup/rollback is needed).
- output_guardrails run on ask()'s generated answer. A violation replaces the answer with a refusal message and sets answer['guardrail_blocked'] = True (key only present when guardrails are configured, so existing callers see no shape change).
- ask_stream() gets the same hooks, with an honestly-documented limitation: output guardrails can only run after the full answer is assembled, but individual tokens have already been yielded to the caller by then - streaming can't retroactively un-send content. A violation during streaming is logged as a warning, not enforced. Documented clearly in both the docstring and README, with a recommendation to use ask() instead where enforcement matters.

8 new tests: input guardrail text modification, violation aborting ingestion with nothing stored, guardrails running in order, output guardrail pass-through and blocking on ask(), no guardrail_blocked key when unconfigured, and the ask_stream() warn-not-block behavior verified via caplog.

Full suite: 91/91 passing (83 existing + 8 new) before this commit - zero regression, since guardrails are fully opt-in (None by default).

Version bumped 0.6.0 -> 0.6.1.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
