### PR TITLE
feat: lightweight evaluation utility (0.6.2)

### DIFF
--- a/packages/ragleap-rag/CHANGELOG.md
+++ b/packages/ragleap-rag/CHANGELOG.md
@@ -8,6 +8,13 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `docs`: Celery integration guide + runnable example ([#57](https://github.com/antonyrag/ragleap-core/pull/57))
 - `test`: comprehensive pytest suite (67 tests) + CI integration — first automated testing this package has had ([#58](https://github.com/antonyrag/ragleap-core/pull/58))
 
+## [0.6.2]
+
+### Added
+- `rag.evaluate(test_cases)` - a lightweight, deterministic evaluation utility. Reports retrieval hit rate, keyword coverage, and citation groundedness against a labeled test set. Explicitly NOT an LLM-as-judge framework (no faithfulness/relevancy scoring like Ragas) - that requires careful judge-prompt calibration and is planned as a separate, dedicated tool. This is a fast, free, repeatable sanity check for catching regressions in your own retrieval/generation setup.
+- New `ragleap.evaluation` module: `evaluate()` and `evaluate_case()`.
+- 8 new tests, including using the fake test generator's real prompt-echo behavior to create genuinely checkable keyword overlap (not coincidental passes).
+
 ## [0.6.1]
 
 ### Added

--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -242,6 +242,28 @@ On `ask()`, a raised `GuardrailViolation` replaces the answer with a refusal mes
 
 Honest limitation for `ask_stream()`: output guardrails can only run *after* the full answer is assembled, but by then individual tokens have already been yielded to the caller - streaming can't retroactively un-send content. A violation during streaming is logged as a warning, not enforced. If blocking bad output before the user sees any of it matters for your use case, use `ask()` instead of `ask_stream()`.
 
+## Evaluation
+
+`rag.evaluate(test_cases)` runs a labeled test set through `ask()` and reports deterministic quality signals - it is **not** an LLM-as-judge framework (no faithfulness/relevancy scoring like Ragas). It measures three things that don't require an LLM call themselves:
+
+- **Retrieval hit rate** - did the expected document actually show up in `sources`?
+- **Keyword coverage** - what fraction of expected keywords appear in the generated answer?
+- **Citation groundedness** - of the keywords found in the answer, how many also appear in the chunks the answer actually cited? A low score here is a real (if heuristic) hallucination signal.
+
+```python
+result = rag.evaluate([
+    {"query": "What's the refund policy?", "expected_document": "policy.pdf", "expected_keywords": ["30 days", "receipt"]},
+    {"query": "How do I reset my password?", "expected_document": "faq.pdf", "expected_keywords": ["settings", "email link"]},
+])
+
+print(result["retrieval_hit_rate"])       # 1.0
+print(result["keyword_coverage_rate"])    # 0.75
+print(result["groundedness_rate"])        # 0.9
+print(result["results"][0])               # per-case detail: query, answer, sources, hits
+```
+
+Any extra keyword arguments (`top_k=`, `rerank=`, `hybrid=`, `metadata_filter=`, etc.) are passed through to every `ask()` call the evaluation makes. This is a fast, free, repeatable sanity check for catching regressions in your own retrieval/generation setup - not a substitute for human review, and not a claim of measuring "truthfulness." A full LLM-as-judge evaluation framework is planned as a separate, dedicated tool (see the project roadmap).
+
 ## Citations
 
 Every ask() response includes a citations field - a structured, chunk-level breakdown that resolves a real ambiguity: a citation like "(Source 1)" in an answer could mean a whole document or one specific passage within it. It always means the latter.

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.6.1"
+version = "0.6.2"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -26,6 +26,7 @@ from ragleap.embedding import EmbeddingService, EmbeddingConfig
 from ragleap.vectorstores import VectorBackend, PgVectorBackend
 from ragleap.generation import GenerationService, ProviderConfig
 from ragleap.guardrails import GuardrailViolation, run_guardrails
+from ragleap import evaluation as _evaluation
 from ragleap.parsers import extract_text
 from ragleap.memory import ConversationMemory
 from ragleap.reranking import RerankerService
@@ -41,7 +42,7 @@ from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult", "TranscriptionConfig", "VectorBackend", "PgVectorBackend"]
 
 
@@ -428,6 +429,21 @@ class RagLeap:
     def clear_session(self, session_id: str) -> None:
         """Delete a session and its full message history."""
         self._memory.clear_session(session_id)
+
+    def evaluate(self, test_cases: List[Dict], **ask_kwargs) -> Dict:
+        """
+        Run a labeled test set through ask() and report deterministic
+        quality signals - retrieval hit rate, keyword coverage, and
+        citation groundedness. NOT an LLM-as-judge framework (no
+        faithfulness/relevancy scoring) - see ragleap.evaluation for
+        the full honest scope of what this does and does not measure.
+
+        test_cases: list of {"query": str, "expected_document": str
+        (optional), "expected_keywords": List[str] (optional)}.
+        Any extra ask_kwargs (top_k, rerank, hybrid, etc.) are passed
+        through to every ask() call.
+        """
+        return _evaluation.evaluate(self, test_cases, **ask_kwargs)
 
     def list_documents(self, limit: int = 100, offset: int = 0) -> List[Dict]:
         """

--- a/packages/ragleap-rag/src/ragleap/evaluation.py
+++ b/packages/ragleap-rag/src/ragleap/evaluation.py
@@ -1,0 +1,125 @@
+"""
+Lightweight, deterministic evaluation utility for ragleap-rag.
+
+Honest scope: this is NOT an LLM-as-judge evaluation framework (like
+Ragas's faithfulness/relevancy scoring) - those require careful judge-
+prompt design and calibration, and belong in a separate, dedicated
+tool (planned as part of ragleap-observability, which will span more
+than just RAG). This module does three deterministic, measurable
+checks instead:
+
+1. Retrieval hit rate - did the expected source document actually
+   appear in the retrieved chunks for a query?
+2. Keyword coverage - what fraction of expected keywords appear
+   (case-insensitive substring match) in the generated answer?
+3. Citation groundedness - of the keywords found in the answer, what
+   fraction also appear in the text of the chunks the answer actually
+   cited? A low score here suggests the model may be answering from
+   outside the retrieved context (a real hallucination signal, though
+   still a heuristic - substring matching is not semantic understanding).
+
+None of these three checks require an LLM call themselves, so running
+an evaluation is fast and free beyond the ask() calls it makes.
+"""
+import logging
+from typing import Dict, List, Optional, TypedDict
+
+logger = logging.getLogger(__name__)
+
+
+class EvalCase(TypedDict, total=False):
+    query: str
+    expected_document: Optional[str]
+    expected_keywords: Optional[List[str]]
+
+
+def _keyword_hits(text: str, keywords: List[str]) -> List[str]:
+    text_lower = text.lower()
+    return [kw for kw in keywords if kw.lower() in text_lower]
+
+
+def evaluate_case(rag, case: Dict, **ask_kwargs) -> Dict:
+    """
+    Run a single evaluation case through rag.ask() and score it.
+    Returns per-case detail - see evaluate() for the aggregated form.
+    """
+    query = case["query"]
+    expected_document = case.get("expected_document")
+    expected_keywords = case.get("expected_keywords") or []
+
+    answer = rag.ask(query, **ask_kwargs)
+
+    retrieval_hit = None
+    if expected_document is not None:
+        retrieval_hit = expected_document in answer.get("sources", [])
+
+    keyword_hits = _keyword_hits(answer.get("answer", ""), expected_keywords)
+    keyword_coverage = (len(keyword_hits) / len(expected_keywords)) if expected_keywords else None
+
+    groundedness = None
+    if keyword_hits:
+        cited_text = " ".join(c.get("text_preview", "") for c in answer.get("citations", []))
+        grounded_hits = _keyword_hits(cited_text, keyword_hits)
+        groundedness = len(grounded_hits) / len(keyword_hits)
+
+    return {
+        "query": query,
+        "answer": answer.get("answer"),
+        "sources": answer.get("sources", []),
+        "retrieval_hit": retrieval_hit,
+        "keyword_coverage": keyword_coverage,
+        "keywords_found": keyword_hits,
+        "groundedness": groundedness,
+    }
+
+
+def evaluate(rag, test_cases: List[Dict], **ask_kwargs) -> Dict:
+    """
+    Run a labeled test set through rag.ask() and report aggregate
+    deterministic quality signals - retrieval hit rate, keyword
+    coverage, and citation groundedness. Not a replacement for human
+    review or a full LLM-as-judge eval framework - a fast, free,
+    repeatable sanity check for catching regressions in your own
+    retrieval/generation setup.
+
+    test_cases: list of dicts, each with:
+      - "query": str, required
+      - "expected_document": str, optional - a document_name that
+        should appear in answer["sources"] for this query
+      - "expected_keywords": List[str], optional - substrings that
+        should appear (case-insensitive) in the generated answer
+
+    Returns: {
+        "retrieval_hit_rate": float | None,   # None if no cases had expected_document
+        "keyword_coverage_rate": float | None, # None if no cases had expected_keywords
+        "groundedness_rate": float | None,     # None if no keyword hits occurred anywhere
+        "results": [per-case detail dicts, see evaluate_case()],
+    }
+    """
+    if not test_cases:
+        raise ValueError("evaluate() requires at least one test case.")
+
+    results = [evaluate_case(rag, case, **ask_kwargs) for case in test_cases]
+
+    hit_results = [r["retrieval_hit"] for r in results if r["retrieval_hit"] is not None]
+    retrieval_hit_rate = (sum(hit_results) / len(hit_results)) if hit_results else None
+
+    coverage_results = [r["keyword_coverage"] for r in results if r["keyword_coverage"] is not None]
+    keyword_coverage_rate = (sum(coverage_results) / len(coverage_results)) if coverage_results else None
+
+    groundedness_results = [r["groundedness"] for r in results if r["groundedness"] is not None]
+    groundedness_rate = (sum(groundedness_results) / len(groundedness_results)) if groundedness_results else None
+
+    logger.info(
+        f"Evaluation complete: {len(results)} cases, "
+        f"retrieval_hit_rate={retrieval_hit_rate}, "
+        f"keyword_coverage_rate={keyword_coverage_rate}, "
+        f"groundedness_rate={groundedness_rate}"
+    )
+
+    return {
+        "retrieval_hit_rate": retrieval_hit_rate,
+        "keyword_coverage_rate": keyword_coverage_rate,
+        "groundedness_rate": groundedness_rate,
+        "results": results,
+    }

--- a/packages/ragleap-rag/tests/test_evaluation.py
+++ b/packages/ragleap-rag/tests/test_evaluation.py
@@ -1,0 +1,100 @@
+"""Tests for rag.evaluate() - deterministic retrieval hit-rate, keyword
+coverage, and citation groundedness checks. Not testing real semantic
+quality (the fake embedder/generator have none) - testing that the
+scoring logic itself is correct, using real Postgres full-text search
+for retrieval and the fake generator's real prompt-echo behavior to
+create genuinely checkable keyword overlap."""
+import pytest
+
+
+def test_evaluate_requires_at_least_one_case(rag):
+    with pytest.raises(ValueError):
+        rag.evaluate([])
+
+
+def test_evaluate_retrieval_hit_rate_all_hits(rag):
+    rag.ingest_text("bananas.txt", "This document is about bananas and tropical fruit.")
+    rag.ingest_text("spaceships.txt", "This document is about spaceships and rockets.")
+
+    result = rag.evaluate([
+        {"query": "bananas", "expected_document": "bananas.txt"},
+        {"query": "spaceships", "expected_document": "spaceships.txt"},
+    ], hybrid=True)
+
+    assert result["retrieval_hit_rate"] == 1.0
+    assert len(result["results"]) == 2
+
+
+def test_evaluate_retrieval_hit_rate_partial_miss(rag):
+    rag.ingest_text("bananas.txt", "This document is about bananas and tropical fruit.")
+
+    result = rag.evaluate([
+        {"query": "bananas", "expected_document": "bananas.txt"},
+        {"query": "bananas", "expected_document": "nonexistent-doc.txt"},
+    ], hybrid=True)
+
+    assert result["retrieval_hit_rate"] == 0.5
+
+
+def test_evaluate_keyword_coverage_uses_real_answer_content(rag):
+    """The fake generator echoes the prompt's tail, which includes the
+    query - so a keyword drawn from the query genuinely appears in the
+    fake answer, making this a real test of the coverage calculation,
+    not a coincidence."""
+    rag.ingest_text("a.txt", "Some content about testing things.")
+
+    result = rag.evaluate([
+        {"query": "Tell me about bananas specifically", "expected_keywords": ["bananas"]},
+    ])
+
+    assert result["keyword_coverage_rate"] == 1.0
+    assert result["results"][0]["keywords_found"] == ["bananas"]
+
+
+def test_evaluate_keyword_coverage_partial(rag):
+    rag.ingest_text("a.txt", "Some content.")
+
+    result = rag.evaluate([
+        {"query": "Tell me about bananas", "expected_keywords": ["bananas", "spaceships", "rockets"]},
+    ])
+
+    # Only "bananas" appears in the query (which the fake generator echoes)
+    assert result["keyword_coverage_rate"] == pytest.approx(1 / 3)
+
+
+def test_evaluate_groundedness_when_keyword_in_cited_chunk(rag):
+    """Ingest text containing 'bananas' so it ends up in the cited
+    chunk's text_preview - if the fake answer also mentions 'bananas'
+    (via the query echo), groundedness should be 1.0 since the
+    keyword genuinely appears in both."""
+    rag.ingest_text("bananas.txt", "This document contains real information about bananas and fruit.")
+
+    result = rag.evaluate([
+        {"query": "Tell me about bananas", "expected_keywords": ["bananas"]},
+    ], hybrid=True)
+
+    assert result["groundedness_rate"] == 1.0
+
+
+def test_evaluate_returns_none_for_metrics_with_no_applicable_cases(rag):
+    rag.ingest_text("a.txt", "Some content.")
+
+    result = rag.evaluate([{"query": "a question with no expectations set"}])
+
+    assert result["retrieval_hit_rate"] is None
+    assert result["keyword_coverage_rate"] is None
+    assert result["groundedness_rate"] is None
+    assert len(result["results"]) == 1
+
+
+def test_evaluate_passes_through_ask_kwargs(rag):
+    rag.ingest_text("a.txt", "Acme tenant content.", metadata={"tenant": "acme"})
+    rag.ingest_text("b.txt", "Globex tenant content.", metadata={"tenant": "globex"})
+
+    result = rag.evaluate(
+        [{"query": "tenant content", "expected_document": "a.txt"}],
+        metadata_filter={"tenant": "acme"},
+        hybrid=False,
+    )
+
+    assert result["results"][0]["sources"] == ["a.txt"]


### PR DESCRIPTION
Adds rag.evaluate(test_cases) - deterministic quality checks against a labeled test set, explicitly NOT an LLM-as-judge framework (no faithfulness/relevancy scoring like Ragas). That kind of evaluation requires careful judge-prompt design and calibration and is planned as a separate, dedicated tool. This is a fast, free, repeatable sanity check instead:

- Retrieval hit rate: did the expected document show up in sources?
- Keyword coverage: what fraction of expected keywords appear in the generated answer?
- Citation groundedness: of the keywords found in the answer, how many also appear in the chunks the answer actually cited - a real, if heuristic, hallucination signal.

New ragleap.evaluation module (evaluate(), evaluate_case()), wired in as RagLeap.evaluate(). Any extra kwargs pass through to every ask() call the evaluation makes.

8 new tests. Notably, several tests use the fake test generator's real prompt-echo behavior (it returns the prompt's tail, which includes the query) to create genuinely checkable keyword overlap - not a coincidental pass, an actual test of the scoring logic against real content.

Full suite: 99/99 passing (91 existing + 8 new) before this commit. Version bumped 0.6.1 -> 0.6.2.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
