### PR TITLE
feat: observability hooks (0.6.3)

### DIFF
--- a/packages/ragleap-rag/CHANGELOG.md
+++ b/packages/ragleap-rag/CHANGELOG.md
@@ -8,6 +8,16 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `docs`: Celery integration guide + runnable example ([#57](https://github.com/antonyrag/ragleap-core/pull/57))
 - `test`: comprehensive pytest suite (67 tests) + CI integration — first automated testing this package has had ([#58](https://github.com/antonyrag/ragleap-core/pull/58))
 
+## [0.6.3]
+
+### Added
+- Observability hooks: `on_ingest=`/`on_query=`/`on_answer=` on `RagLeap.__init__()` - lightweight, fire-and-forget event emission, not a dashboard or storage layer. Each is a list of `(event: dict) -> None` callables.
+- `on_ingest` fires after successful ingestion with document_id/filename/chunks_stored/chunks_attempted.
+- `on_query` fires after retrieval (before generation) with query/hybrid/rerank/top_k/chunks_retrieved/streaming.
+- `on_answer` fires after generation on both `ask()` (provider_used/usage/chunks_sent/guardrail_blocked) and `ask_stream()` (answer_length, since usage isn't available for streaming) - every event includes `streaming: bool`.
+- A hook that raises is caught, logged as a warning, and swallowed - never breaks the actual ingest/ask operation. New `ragleap.observability` module (`fire_event()`).
+- 7 new tests, including explicit coverage that a broken hook does not break ingestion or asking.
+
 ## [0.6.2]
 
 ### Added

--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -264,6 +264,28 @@ print(result["results"][0])               # per-case detail: query, answer, sour
 
 Any extra keyword arguments (`top_k=`, `rerank=`, `hybrid=`, `metadata_filter=`, etc.) are passed through to every `ask()` call the evaluation makes. This is a fast, free, repeatable sanity check for catching regressions in your own retrieval/generation setup - not a substitute for human review, and not a claim of measuring "truthfulness." A full LLM-as-judge evaluation framework is planned as a separate, dedicated tool (see the project roadmap).
 
+## Observability hooks
+
+`on_ingest=`/`on_query=`/`on_answer=` are lightweight, fire-and-forget event emission points - not a dashboard or storage layer, just an instrumentation seam for logging, metrics, tracing, or a future observability tool to plug into. Each is a list of callables `(event: dict) -> None`.
+
+```python
+import logging
+logger = logging.getLogger("ragleap.events")
+
+rag = RagLeap(
+    database_url="...",
+    embedder=EmbeddingConfig(...),
+    primary=ProviderConfig(...),
+    on_ingest=[lambda e: logger.info(f"Ingested {e['filename']}: {e['chunks_stored']} chunks")],
+    on_query=[lambda e: logger.info(f"Query: {e['query']!r} (hybrid={e['hybrid']}, streaming={e['streaming']})")],
+    on_answer=[lambda e: logger.info(f"Answered via {e.get('provider_used')}, usage={e.get('usage')}")],
+)
+```
+
+A hook that raises an exception is caught, logged as a warning, and swallowed - it never breaks the actual ingest/ask call. This is fire-and-forget, not a delivery guarantee: if a hook is slow or fails, that's on the hook, not on your RAG pipeline.
+
+`on_answer` fires on both `ask()` (with `provider_used`, `usage`, `chunks_sent`, `guardrail_blocked`) and `ask_stream()` (with `answer_length`, since usage isn't available for streaming - see the Streaming section). Every event includes `streaming: bool` so one handler can distinguish the two if needed.
+
 ## Citations
 
 Every ask() response includes a citations field - a structured, chunk-level breakdown that resolves a real ambiguity: a citation like "(Source 1)" in an answer could mean a whole document or one specific passage within it. It always means the latter.

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.6.2"
+version = "0.6.3"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -27,6 +27,7 @@ from ragleap.vectorstores import VectorBackend, PgVectorBackend
 from ragleap.generation import GenerationService, ProviderConfig
 from ragleap.guardrails import GuardrailViolation, run_guardrails
 from ragleap import evaluation as _evaluation
+from ragleap.observability import fire_event
 from ragleap.parsers import extract_text
 from ragleap.memory import ConversationMemory
 from ragleap.reranking import RerankerService
@@ -42,7 +43,7 @@ from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult", "TranscriptionConfig", "VectorBackend", "PgVectorBackend"]
 
 
@@ -81,6 +82,9 @@ class RagLeap:
         cache_ttl_seconds: int = 86400,
         input_guardrails: Optional[List[Callable[[str], str]]] = None,
         output_guardrails: Optional[List[Callable[[str], str]]] = None,
+        on_ingest: Optional[List[Callable[[Dict], None]]] = None,
+        on_query: Optional[List[Callable[[Dict], None]]] = None,
+        on_answer: Optional[List[Callable[[Dict], None]]] = None,
     ):
         """
         database_url is always required - conversation memory is
@@ -96,6 +100,9 @@ class RagLeap:
         self._vector_backend = vector_backend or PgVectorBackend(database_url)
         self._input_guardrails = input_guardrails
         self._output_guardrails = output_guardrails
+        self._on_ingest = on_ingest
+        self._on_query = on_query
+        self._on_answer = on_answer
 
         self._chunker = TextChunker(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
         self._embedder = EmbeddingService(embedder)
@@ -301,6 +308,12 @@ class RagLeap:
             raise ValueError(f"All {len(chunks)} chunk(s) failed to embed — nothing was stored.")
 
         logger.info(f"Ingested '{filename}': {stored}/{len(chunks)} chunks stored")
+
+        fire_event(
+            {"document_id": document_id, "filename": filename, "chunks_stored": stored, "chunks_attempted": len(chunks)},
+            self._on_ingest, "on_ingest",
+        )
+
         return IngestResult(document_id=document_id, chunks_stored=stored)
 
     def ask(
@@ -345,6 +358,11 @@ class RagLeap:
                 self._reranker = RerankerService()
             chunks = self._reranker.rerank(query, chunks, top_k=top_k)
 
+        fire_event(
+            {"query": query, "hybrid": hybrid, "rerank": rerank, "top_k": top_k, "chunks_retrieved": len(chunks), "streaming": False},
+            self._on_query, "on_query",
+        )
+
         history_prefix = self._memory.build_history_prompt(session_id) if session_id else ""
 
         result = self._generator.generate_answer(
@@ -359,6 +377,12 @@ class RagLeap:
             except GuardrailViolation as e:
                 result["answer"] = f"Response blocked by guardrail: {e}"
                 result["guardrail_blocked"] = True
+
+        fire_event(
+            {"query": query, "provider_used": result.get("provider_used"), "usage": result.get("usage"),
+             "chunks_sent": result.get("chunks_sent"), "guardrail_blocked": result.get("guardrail_blocked", False), "streaming": False},
+            self._on_answer, "on_answer",
+        )
 
         if session_id:
             self._memory.add_message(session_id, "user", query)
@@ -397,6 +421,11 @@ class RagLeap:
                 self._reranker = RerankerService()
             chunks = self._reranker.rerank(query, chunks, top_k=top_k)
 
+        fire_event(
+            {"query": query, "hybrid": hybrid, "rerank": rerank, "top_k": top_k, "chunks_retrieved": len(chunks), "streaming": True},
+            self._on_query, "on_query",
+        )
+
         history_prefix = self._memory.build_history_prompt(session_id) if session_id else ""
 
         pieces = []
@@ -417,6 +446,11 @@ class RagLeap:
                     f"but tokens were already yielded to the caller and cannot be "
                     f"retroactively un-sent: {e}"
                 )
+
+        fire_event(
+            {"query": query, "answer_length": len(full_answer), "streaming": True},
+            self._on_answer, "on_answer",
+        )
 
         if session_id:
             self._memory.add_message(session_id, "user", query)

--- a/packages/ragleap-rag/src/ragleap/observability.py
+++ b/packages/ragleap-rag/src/ragleap/observability.py
@@ -1,0 +1,29 @@
+"""
+Lightweight observability hooks for ragleap-rag - fire-and-forget
+event emission points that other tools (logging, metrics, tracing,
+or a future ragleap-observability package) can consume. This module
+does NOT implement any dashboard, storage, or analysis itself - it
+is purely the instrumentation seam.
+
+Design philosophy: a broken or slow hook must never break the actual
+RAG operation. Every hook call is wrapped in try/except - an
+exception in a hook is logged as a warning and swallowed, never
+propagated. This is fire-and-forget, not a guarantee of delivery.
+"""
+import logging
+from typing import Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def fire_event(event: Dict, handlers: Optional[List[Callable[[Dict], None]]], hook_name: str) -> None:
+    """Call each handler with the event dict, in order. A handler
+    raising an exception is logged and swallowed - never propagated,
+    since observability must never break the actual RAG operation."""
+    if not handlers:
+        return
+    for handler in handlers:
+        try:
+            handler(event)
+        except Exception as e:
+            logger.warning(f"Observability hook '{hook_name}' raised an exception (swallowed): {e}")

--- a/packages/ragleap-rag/tests/test_observability.py
+++ b/packages/ragleap-rag/tests/test_observability.py
@@ -1,0 +1,109 @@
+"""Tests for on_ingest/on_query/on_answer observability hooks - fire-
+and-forget event emission that never breaks the actual RAG operation,
+even when a hook raises."""
+from ragleap import RagLeap, ProviderConfig, EmbeddingConfig
+from conftest import TEST_DATABASE_URL, TEST_DIMENSIONS
+
+
+def _make_rag(**kwargs):
+    return RagLeap(
+        database_url=TEST_DATABASE_URL,
+        embedder=EmbeddingConfig(provider="gemini", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
+        primary=ProviderConfig(provider="gemini", api_key="fake-test-key"),
+        **kwargs,
+    )
+
+
+def test_on_ingest_fires_with_correct_event_shape():
+    events = []
+    rag = _make_rag(on_ingest=[events.append])
+
+    result = rag.ingest_text("a.txt", "Some content about testing things.")
+
+    assert len(events) == 1
+    assert events[0]["document_id"] == result.document_id
+    assert events[0]["filename"] == "a.txt"
+    assert events[0]["chunks_stored"] == 1
+    assert events[0]["chunks_attempted"] == 1
+
+
+def test_on_query_and_on_answer_fire_on_ask(rag):
+    query_events = []
+    answer_events = []
+    rag._on_query = [query_events.append]
+    rag._on_answer = [answer_events.append]
+
+    rag.ingest_text("a.txt", "Some content.")
+    rag.ask("A question", top_k=3, hybrid=True)
+
+    assert len(query_events) == 1
+    assert query_events[0]["query"] == "A question"
+    assert query_events[0]["hybrid"] is True
+    assert query_events[0]["top_k"] == 3
+    assert query_events[0]["streaming"] is False
+
+    assert len(answer_events) == 1
+    assert answer_events[0]["provider_used"] == "gemini"
+    assert answer_events[0]["streaming"] is False
+    assert answer_events[0]["guardrail_blocked"] is False
+
+
+def test_on_query_and_on_answer_fire_on_ask_stream(rag):
+    query_events = []
+    answer_events = []
+    rag._on_query = [query_events.append]
+    rag._on_answer = [answer_events.append]
+
+    rag.ingest_text("a.txt", "Some content.")
+    list(rag.ask_stream("A question"))
+
+    assert len(query_events) == 1
+    assert query_events[0]["streaming"] is True
+
+    assert len(answer_events) == 1
+    assert answer_events[0]["streaming"] is True
+    assert answer_events[0]["answer_length"] == len("This is a fake streamed answer.")
+
+
+def test_multiple_handlers_all_fire_in_order():
+    calls = []
+    rag = _make_rag(on_ingest=[lambda e: calls.append("first"), lambda e: calls.append("second")])
+
+    rag.ingest_text("a.txt", "Some content.")
+
+    assert calls == ["first", "second"]
+
+
+def test_broken_hook_does_not_break_ingestion(caplog):
+    import logging
+
+    def broken_hook(event):
+        raise RuntimeError("this hook is broken")
+
+    rag = _make_rag(on_ingest=[broken_hook])
+
+    with caplog.at_level(logging.WARNING):
+        result = rag.ingest_text("a.txt", "Some content.")
+
+    # Ingestion succeeded despite the broken hook
+    assert result.chunks_stored == 1
+    assert any("on_ingest" in record.message and "broken" in record.message for record in caplog.records)
+
+
+def test_broken_hook_does_not_break_ask(rag):
+    def broken_hook(event):
+        raise RuntimeError("boom")
+
+    rag._on_answer = [broken_hook]
+    rag.ingest_text("a.txt", "Some content.")
+
+    answer = rag.ask("A question")
+    assert answer["answer"] != ""
+
+
+def test_no_hooks_configured_is_a_true_no_op(rag):
+    """No hooks set (the default) - fire_event should be a silent
+    no-op, not an error."""
+    rag.ingest_text("a.txt", "Some content.")
+    answer = rag.ask("A question")
+    assert answer["answer"] != ""


### PR DESCRIPTION
Adds on_ingest=/on_query=/on_answer= to RagLeap.__init__() - lightweight, fire-and-forget event emission points, not a dashboard or storage layer. Each is a list of (event: dict) -> None callables - the instrumentation seam a future ragleap-observability package (or any logging/metrics/ tracing tool today) can plug into.

- on_ingest fires after successful ingestion: document_id, filename, chunks_stored, chunks_attempted.
- on_query fires after retrieval, before generation: query, hybrid, rerank, top_k, chunks_retrieved, streaming.
- on_answer fires after generation on both ask() (provider_used, usage, chunks_sent, guardrail_blocked) and ask_stream() (answer_length, since usage isn't available for streaming) - every event includes streaming: bool so one handler can distinguish the two.

Design philosophy: a broken or slow hook must never break the actual RAG operation. Every hook call is wrapped in try/except - an exception is logged as a warning and swallowed, never propagated. New ragleap.observability module (fire_event()).

7 new tests, including explicit coverage that a broken hook does not break ingestion or asking (the core reliability guarantee of this feature).

Full suite: 106/106 passing (99 existing + 7 new) before this commit - zero regression, since hooks are fully opt-in (None by default).

Version bumped 0.6.2 -> 0.6.3.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
