### PR TITLE
feat: embedding provider expansion - Mistral, Together, Ollama, Coher…

### DIFF
--- a/packages/ragleap-rag/CHANGELOG.md
+++ b/packages/ragleap-rag/CHANGELOG.md
@@ -8,6 +8,18 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `docs`: Celery integration guide + runnable example ([#57](https://github.com/antonyrag/ragleap-core/pull/57))
 - `test`: comprehensive pytest suite (67 tests) + CI integration — first automated testing this package has had ([#58](https://github.com/antonyrag/ragleap-core/pull/58))
 
+## [0.7.0]
+
+### Added
+- Embedding provider expansion: Mistral, Together, Ollama, Cohere, and Voyage AI, alongside existing Gemini/OpenAI support.
+- Mistral, Together, and Ollama reuse the existing `openai` package's client pointed at a custom `base_url` (all three expose OpenAI-compatible `/embeddings` endpoints) - no new dependency.
+- Cohere and Voyage AI use `requests` (already a core dependency) directly, since their response shapes differ from OpenAI's.
+- `ollama` is live-verified this release: fully local, no API key required, tested end-to-end (`embed_text()`, `embed_batch()`, and a full real ingest -> real FAISS retrieval integration test) via `nomic-embed-text`.
+- `mistral`, `together`, `cohere`, and `voyage` are code-complete based on public API documentation but NOT live-verified against a real account - same caveat already attached to the Pinecone vector backend. Their default models/dimensions are best-effort until confirmed live.
+- `together` requires explicit `model=` and `dimensions=` - no safe default exists across its many incompatible embedding models. Raises a clear error rather than guessing.
+- Honest limitation documented for `cohere`: always uses `input_type="search_document"` since `embed_text()`/`embed_batch()` don't currently distinguish query vs. document embedding calls.
+- 16 new tests: live Ollama tests (skipped automatically if Ollama isn't running, so CI never fails on its absence) plus config-resolution/error-handling tests for the four unverified providers (123 -> 139 passing).
+
 ## [0.6.4]
 
 ### Added

--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -577,6 +577,26 @@ Perplexity, or a custom endpoint (`provider="custom"` + `base_url=...`).
 Install extras as needed: `pip install ragleap-rag[anthropic]`,
 `[openai]`, or `[all]`.
 
+## Supported embedding providers
+
+```python
+from ragleap import RagLeap, ProviderConfig, EmbeddingConfig
+
+rag = RagLeap(
+    database_url="...",
+    embedder=EmbeddingConfig(provider="ollama"),  # local, no API key, no cost
+    primary=ProviderConfig(...),
+)
+```
+
+Gemini, OpenAI, Mistral, Together, and Ollama (all OpenAI-compatible under the hood, no new dependency), plus Cohere and Voyage AI (own API shapes, via `requests`). No new extras needed beyond the existing `[gemini]`/`[openai]` — Mistral/Together/Ollama reuse the `openai` package's client pointed at a different `base_url`.
+
+**Live-verification status**, following this project's own standard of testing against real infrastructure before calling anything done: `gemini` and `openai` are long-verified. `ollama` was live-verified this release — fully local, no API key, tested end-to-end through real ingestion + real FAISS retrieval. `mistral`, `together`, `cohere`, and `voyage` are code-complete based on public API documentation but **not live-verified** against a real account (the same caveat already attached to the Pinecone vector backend) — their default models/dimensions are best-effort until confirmed live.
+
+`together` has no default embedding model or dimensions (too many incompatible models on the platform to guess safely) — pass `model=` and `dimensions=` explicitly, or it raises a clear error rather than guessing wrong.
+
+Honest limitation for `cohere`: its API distinguishes query vs. document embeddings via an `input_type` parameter for better retrieval quality, but `embed_text()`/`embed_batch()` don't currently know which context they're called in — Cohere calls always use `input_type="search_document"`, which isn't optimal for query embeddings specifically.
+
 ## More examples
 
 See [`examples/`](https://github.com/antonyrag/ragleap-core/tree/main/packages/ragleap-rag/examples)

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.6.4"
+version = "0.7.0"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -44,7 +44,7 @@ from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.6.4"
+__version__ = "0.7.0"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult", "TranscriptionConfig", "VectorBackend", "PgVectorBackend"]
 
 

--- a/packages/ragleap-rag/src/ragleap/embedding.py
+++ b/packages/ragleap-rag/src/ragleap/embedding.py
@@ -1,8 +1,17 @@
 """
 Embedding for ragleap-rag.
-Bring-your-own-key: supports Gemini and OpenAI embedding providers.
+Bring-your-own-key: supports Gemini, OpenAI, Mistral, Together, Ollama
+(all OpenAI-compatible), plus Cohere and Voyage AI (own API shapes).
 Configure explicitly via EmbeddingConfig, or let it fall back to
 environment variables for convenience (useful for scripts/notebooks).
+
+Live-verification status (per this package's own honesty standard):
+gemini and openai were verified in earlier sessions. ollama is verified
+live in this session (local, no API key, via nomic-embed-text). mistral,
+together, and cohere/voyage are code-complete based on public API
+documentation but NOT live-verified against a real account - same
+caveat already attached to the Pinecone vector backend. Treat their
+defaults (models, dimensions) as best-effort until confirmed live.
 """
 import os
 import logging
@@ -14,11 +23,34 @@ logger = logging.getLogger(__name__)
 DEFAULT_MODELS = {
     "gemini": "models/gemini-embedding-001",
     "openai": "text-embedding-3-small",
+    "mistral": "mistral-embed",
+    "ollama": "nomic-embed-text",
+    "cohere": "embed-english-v3.0",
+    "voyage": "voyage-3",
+    # "together" has no safe default - too many incompatible embedding
+    # models on the platform to guess correctly. Must be passed explicitly.
 }
 DEFAULT_DIMENSIONS = {
     "gemini": 3072,
     "openai": 1536,
+    "mistral": 1024,
+    "ollama": 768,
+    "cohere": 1024,
+    "voyage": 1024,
 }
+
+# Providers whose embeddings endpoint is OpenAI-compatible (same request/
+# response shape as OpenAI's /v1/embeddings) - reuses the openai package's
+# client pointed at a custom base_url, same trick generation.py uses.
+OPENAI_COMPATIBLE_BASE_URLS = {
+    "openai":   "https://api.openai.com/v1",
+    "mistral":  "https://api.mistral.ai/v1",
+    "together": "https://api.together.xyz/v1",
+    "ollama":   "http://localhost:11434/v1",
+}
+
+# Providers with their own (non-OpenAI-compatible) response shape.
+CUSTOM_SHAPE_PROVIDERS = ("cohere", "voyage")
 
 
 @dataclass
@@ -29,6 +61,7 @@ class EmbeddingConfig:
     api_key: Optional[str] = None
     model: Optional[str] = None
     dimensions: Optional[int] = None
+    base_url: Optional[str] = None
 
     def __post_init__(self):
         self.provider = self.provider.lower()
@@ -39,22 +72,41 @@ class EmbeddingConfig:
             self.dimensions = self.dimensions or int(
                 os.environ.get("EMBEDDING_DIMENSIONS", str(DEFAULT_DIMENSIONS["gemini"]))
             )
-        elif self.provider == "openai":
-            self.api_key = self.api_key or os.environ.get("OPENAI_API_KEY")
-            self.model = self.model or os.environ.get("OPENAI_EMBEDDING_MODEL", DEFAULT_MODELS["openai"])
-            self.dimensions = self.dimensions or int(
-                os.environ.get("EMBEDDING_DIMENSIONS", str(DEFAULT_DIMENSIONS["openai"]))
+        elif self.provider in OPENAI_COMPATIBLE_BASE_URLS:
+            self.api_key = self.api_key or os.environ.get(f"{self.provider.upper()}_API_KEY")
+            self.model = self.model or os.environ.get(
+                f"{self.provider.upper()}_EMBEDDING_MODEL", DEFAULT_MODELS.get(self.provider)
             )
+            env_dims = os.environ.get(f"{self.provider.upper()}_EMBEDDING_DIMENSIONS") or os.environ.get("EMBEDDING_DIMENSIONS")
+            default_dims = DEFAULT_DIMENSIONS.get(self.provider)
+            self.dimensions = self.dimensions or (int(env_dims) if env_dims else default_dims)
+            self.base_url = self.base_url or OPENAI_COMPATIBLE_BASE_URLS[self.provider]
+
+            if self.provider == "together" and (not self.model or not self.dimensions):
+                raise ValueError(
+                    "Provider 'together' has no safe default embedding model or "
+                    "dimensions - too many incompatible models on the platform to "
+                    "guess correctly. Pass model= and dimensions= explicitly to "
+                    "EmbeddingConfig(), or set TOGETHER_EMBEDDING_MODEL and "
+                    "TOGETHER_EMBEDDING_DIMENSIONS in your environment."
+                )
+        elif self.provider in CUSTOM_SHAPE_PROVIDERS:
+            self.api_key = self.api_key or os.environ.get(f"{self.provider.upper()}_API_KEY")
+            self.model = self.model or os.environ.get(
+                f"{self.provider.upper()}_EMBEDDING_MODEL", DEFAULT_MODELS.get(self.provider)
+            )
+            env_dims = os.environ.get(f"{self.provider.upper()}_EMBEDDING_DIMENSIONS") or os.environ.get("EMBEDDING_DIMENSIONS")
+            self.dimensions = self.dimensions or (int(env_dims) if env_dims else DEFAULT_DIMENSIONS.get(self.provider))
         else:
             raise ValueError(
-                f"Unknown embedding provider '{self.provider}'. Supported: gemini, openai."
+                f"Unknown embedding provider '{self.provider}'. Supported: "
+                f"gemini, openai, mistral, together, ollama, cohere, voyage."
             )
 
-        if not self.api_key:
+        if not self.api_key and self.provider != "ollama":
             raise ValueError(
                 f"No API key for embedding provider '{self.provider}'. Pass api_key= "
-                f"explicitly to EmbeddingConfig(), or set "
-                f"{'GEMINI_API_KEY' if self.provider == 'gemini' else 'OPENAI_API_KEY'} "
+                f"explicitly to EmbeddingConfig(), or set {self.provider.upper()}_API_KEY "
                 f"in your environment."
             )
 
@@ -77,8 +129,12 @@ class EmbeddingService:
         try:
             if self.config.provider == "gemini":
                 return self._embed_gemini(text)
-            elif self.config.provider == "openai":
-                return self._embed_openai(text)
+            elif self.config.provider in OPENAI_COMPATIBLE_BASE_URLS:
+                return self._embed_openai_compatible(text)
+            elif self.config.provider == "cohere":
+                return self._embed_cohere([text])[0]
+            elif self.config.provider == "voyage":
+                return self._embed_voyage([text])[0]
         except Exception as e:
             logger.error(f"Embedding generation failed ({self.config.provider}): {e}")
             return None
@@ -91,8 +147,12 @@ class EmbeddingService:
         try:
             if self.config.provider == "gemini":
                 return self._embed_batch_gemini(texts)
-            elif self.config.provider == "openai":
-                return self._embed_batch_openai(texts)
+            elif self.config.provider in OPENAI_COMPATIBLE_BASE_URLS:
+                return self._embed_batch_openai_compatible(texts)
+            elif self.config.provider == "cohere":
+                return self._embed_cohere(texts)
+            elif self.config.provider == "voyage":
+                return self._embed_voyage(texts)
         except Exception as e:
             logger.error(f"Batch embedding generation failed ({self.config.provider}): {e}")
             return [None] * len(texts)
@@ -109,18 +169,52 @@ class EmbeddingService:
         response = client.models.embed_content(model=self.config.model, contents=texts)
         return [e.values for e in response.embeddings]
 
-    def _embed_openai(self, text: str) -> Optional[List[float]]:
+    def _embed_openai_compatible(self, text: str) -> Optional[List[float]]:
+        """Shared path for openai/mistral/together/ollama - all expose the
+        same /embeddings request+response shape. dimensions= is only sent
+        when explicitly set, since not every OpenAI-compatible provider's
+        embeddings endpoint accepts that param (Ollama's does not)."""
         import openai
-        client = openai.OpenAI(api_key=self.config.api_key)
-        response = client.embeddings.create(
-            model=self.config.model, input=text, dimensions=self.config.dimensions
-        )
+        client = openai.OpenAI(api_key=self.config.api_key or "not-needed", base_url=self.config.base_url)
+        kwargs = {"model": self.config.model, "input": text}
+        if self.config.provider == "openai" and self.config.dimensions:
+            kwargs["dimensions"] = self.config.dimensions
+        response = client.embeddings.create(**kwargs)
         return response.data[0].embedding
 
-    def _embed_batch_openai(self, texts: List[str]) -> List[Optional[List[float]]]:
+    def _embed_batch_openai_compatible(self, texts: List[str]) -> List[Optional[List[float]]]:
         import openai
-        client = openai.OpenAI(api_key=self.config.api_key)
-        response = client.embeddings.create(
-            model=self.config.model, input=texts, dimensions=self.config.dimensions
-        )
+        client = openai.OpenAI(api_key=self.config.api_key or "not-needed", base_url=self.config.base_url)
+        kwargs = {"model": self.config.model, "input": texts}
+        if self.config.provider == "openai" and self.config.dimensions:
+            kwargs["dimensions"] = self.config.dimensions
+        response = client.embeddings.create(**kwargs)
         return [d.embedding for d in response.data]
+
+    def _embed_cohere(self, texts: List[str]) -> List[Optional[List[float]]]:
+        """NOT live-verified - implemented per Cohere's public API docs.
+        Always uses input_type='search_document' since embed_text()/
+        embed_batch() don't currently distinguish query vs. document
+        embedding calls - a known limitation, not an optimal setup."""
+        import requests
+        response = requests.post(
+            "https://api.cohere.ai/v1/embed",
+            headers={"Authorization": f"Bearer {self.config.api_key}", "Content-Type": "application/json"},
+            json={"texts": texts, "model": self.config.model, "input_type": "search_document"},
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()["embeddings"]
+
+    def _embed_voyage(self, texts: List[str]) -> List[Optional[List[float]]]:
+        """NOT live-verified - implemented per Voyage AI's public API docs."""
+        import requests
+        response = requests.post(
+            "https://api.voyageai.com/v1/embeddings",
+            headers={"Authorization": f"Bearer {self.config.api_key}", "Content-Type": "application/json"},
+            json={"input": texts, "model": self.config.model},
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()["data"]
+        return [d["embedding"] for d in data]

--- a/packages/ragleap-rag/tests/test_embedding.py
+++ b/packages/ragleap-rag/tests/test_embedding.py
@@ -1,0 +1,155 @@
+"""Tests for embedding provider expansion (v0.7.0). Split into two
+groups: config-resolution tests for providers with no live key/instance
+available (mistral, together, cohere, voyage) - no network calls, just
+verifying defaults/env-fallback/error-raising logic - and real live
+tests against a genuinely running local Ollama instance, skipped
+automatically if Ollama isn't reachable so CI never fails on its
+absence."""
+import os
+import pytest
+from ragleap.embedding import EmbeddingConfig, EmbeddingService
+
+ollama_available = True
+try:
+    import requests
+    requests.get("http://localhost:11434/api/tags", timeout=1).raise_for_status()
+except Exception:
+    ollama_available = False
+
+
+# --- Config-resolution tests (no network calls, no keys needed) ---
+
+def test_mistral_default_model_and_dimensions():
+    config = EmbeddingConfig(provider="mistral", api_key="fake-key")
+    assert config.model == "mistral-embed"
+    assert config.dimensions == 1024
+    assert config.base_url == "https://api.mistral.ai/v1"
+
+
+def test_together_requires_explicit_model_and_dimensions():
+    with pytest.raises(ValueError, match="no safe default"):
+        EmbeddingConfig(provider="together", api_key="fake-key")
+
+
+def test_together_works_with_explicit_model_and_dimensions():
+    config = EmbeddingConfig(provider="together", api_key="fake-key", model="some-model", dimensions=512)
+    assert config.model == "some-model"
+    assert config.dimensions == 512
+    assert config.base_url == "https://api.together.xyz/v1"
+
+
+def test_cohere_default_model_and_dimensions():
+    config = EmbeddingConfig(provider="cohere", api_key="fake-key")
+    assert config.model == "embed-english-v3.0"
+    assert config.dimensions == 1024
+
+
+def test_voyage_default_model_and_dimensions():
+    config = EmbeddingConfig(provider="voyage", api_key="fake-key")
+    assert config.model == "voyage-3"
+    assert config.dimensions == 1024
+
+
+def test_missing_api_key_raises_for_mistral():
+    with pytest.raises(ValueError, match="No API key"):
+        EmbeddingConfig(provider="mistral")
+
+
+def test_missing_api_key_raises_for_cohere():
+    with pytest.raises(ValueError, match="No API key"):
+        EmbeddingConfig(provider="cohere")
+
+
+def test_missing_api_key_raises_for_voyage():
+    with pytest.raises(ValueError, match="No API key"):
+        EmbeddingConfig(provider="voyage")
+
+
+def test_ollama_needs_no_api_key():
+    """Mirrors generation.py's existing ollama exemption from requiring
+    an api_key - local inference, nothing to authenticate."""
+    config = EmbeddingConfig(provider="ollama")
+    assert config.api_key is None
+    assert config.model == "nomic-embed-text"
+    assert config.dimensions == 768
+    assert config.base_url == "http://localhost:11434/v1"
+
+
+def test_env_var_fallback_for_mistral(monkeypatch):
+    monkeypatch.setenv("MISTRAL_API_KEY", "env-key")
+    monkeypatch.setenv("MISTRAL_EMBEDDING_MODEL", "custom-mistral-model")
+    config = EmbeddingConfig(provider="mistral")
+    assert config.api_key == "env-key"
+    assert config.model == "custom-mistral-model"
+
+
+def test_unknown_provider_raises():
+    with pytest.raises(ValueError, match="Unknown embedding provider"):
+        EmbeddingConfig(provider="not-a-real-provider", api_key="fake-key")
+
+
+def test_explicit_dimensions_override_default():
+    config = EmbeddingConfig(provider="cohere", api_key="fake-key", dimensions=256)
+    assert config.dimensions == 256
+
+
+# --- Live Ollama tests - skipped automatically if Ollama isn't running ---
+
+pytestmark_ollama = pytest.mark.skipif(not ollama_available, reason="Ollama not running on localhost:11434")
+
+
+@pytestmark_ollama
+def test_ollama_embed_text_returns_real_vector():
+    config = EmbeddingConfig(provider="ollama")
+    service = EmbeddingService(config)
+    vec = service.embed_text("This is a live test of the Ollama embedding path.")
+    assert vec is not None
+    assert len(vec) == 768
+    assert all(isinstance(v, float) for v in vec)
+
+
+@pytestmark_ollama
+def test_ollama_embed_batch_returns_real_vectors():
+    config = EmbeddingConfig(provider="ollama")
+    service = EmbeddingService(config)
+    batch = service.embed_batch(["first text", "second text", "third text"])
+    assert len(batch) == 3
+    assert all(v is not None and len(v) == 768 for v in batch)
+
+
+@pytestmark_ollama
+def test_ollama_embed_text_empty_string_returns_none():
+    config = EmbeddingConfig(provider="ollama")
+    service = EmbeddingService(config)
+    assert service.embed_text("") is None
+    assert service.embed_text("   ") is None
+
+
+@pytestmark_ollama
+def test_ollama_full_rag_integration_with_faiss(tmp_path, database_url):
+    """Real end-to-end proof: Ollama embeds -> stored in a real FAISS
+    index -> retrieved via real cosine similarity search. Uses FAISS
+    (not the shared pgvector test DB) since Ollama's 768 dims don't
+    match the test DB's deliberately-tiny vector(8) schema."""
+    from ragleap import RagLeap, ProviderConfig, EmbeddingConfig as EC
+    from ragleap.vectorstores import FAISSBackend
+
+    backend = FAISSBackend(persist_directory=str(tmp_path / "ollama_faiss_data"))
+    rag = RagLeap(
+        database_url=database_url,
+        embedder=EC(provider="ollama"),
+        vector_backend=backend,
+        primary=ProviderConfig(provider="gemini", api_key="fake-test-key"),
+    )
+    rag.init_schema()
+
+    result = rag.ingest_text(
+        "ollama_test.txt",
+        "RagLeap uses Ollama for fully local, offline embeddings with no API key required.",
+    )
+    assert result.chunks_stored == 1
+
+    query_embedding = rag._embed_query_cached("What does RagLeap use for local embeddings?")
+    chunks = rag._vector_backend.search_dense(query_embedding, top_k=3)
+    assert len(chunks) >= 1
+    assert "Ollama" in chunks[0]["text"]


### PR DESCRIPTION
…e, Voyage (v0.7.0)

- New providers alongside existing Gemini/OpenAI: Mistral, Together, Ollama (all OpenAI-compatible, reuse the openai package's client pointed at a custom base_url - no new dependency), plus Cohere and Voyage AI (own response shapes, via requests, already a core dep)
- ollama live-verified: fully local, no API key, tested end-to-end (embed_text/embed_batch + real ingest -> real FAISS retrieval) via nomic-embed-text
- mistral/together/cohere/voyage are code-complete per public API docs but NOT live-verified against a real account - same caveat as the Pinecone vector backend, flagged explicitly in README/CHANGELOG
- together requires explicit model=/dimensions= (no safe default across its many incompatible embedding models) - raises a clear error rather than guessing
- Honest documented limitation: cohere always uses input_type="search_document" since embed_text()/embed_batch() don't distinguish query vs. document embedding context
- 16 new tests (123 -> 139 passing): live Ollama tests (auto-skipped if Ollama isn't running) + config-resolution/error tests for the four unverified providers

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
