### PR TITLE
fix: update deprecated default Gemini model to gemini-3.6-flash (v0.8.1)

### DIFF
--- a/packages/ragleap-rag/CHANGELOG.md
+++ b/packages/ragleap-rag/CHANGELOG.md
@@ -8,6 +8,13 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `docs`: Celery integration guide + runnable example ([#57](https://github.com/antonyrag/ragleap-core/pull/57))
 - `test`: comprehensive pytest suite (67 tests) + CI integration — first automated testing this package has had ([#58](https://github.com/antonyrag/ragleap-core/pull/58))
 
+## [0.8.1]
+
+### Fixed
+- Default Gemini generation model changed from `gemini-2.5-flash` (deprecated by Google, returns `404 NOT_FOUND` on new API calls as of this release) to `gemini-3.6-flash` - the current GA general-purpose Flash tier, confirmed via live web search (BenchLM pricing sync 2026-07-28, innFactory release notes 2026-07-21) and matching the model already used in `cost.py`'s seed pricing table. Affects only callers relying on the default `ProviderConfig(provider="gemini", ...)` without passing `model=` explicitly. Discovered during v0.8.0's live structured-output verification (see that release's "Known issue" note).
+- `gemini-2.5-flash-lite` (a different, still-current cheaper tier per the same search) is unaffected and unchanged.
+- Two `test_cost.py` tests were coupled to the old default model string and started failing once it changed (one because the new default is now priced, one because it hardcoded the old model name in a pricing_table override) - both fixed by using explicit `model=` rather than relying on whatever the library's default happens to be, since that default has now demonstrably changed once already.
+
 ## [0.8.0]
 
 ### Added

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.8.0"
+version = "0.8.1"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -44,7 +44,7 @@ from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult", "TranscriptionConfig", "VectorBackend", "PgVectorBackend"]
 
 

--- a/packages/ragleap-rag/src/ragleap/generation.py
+++ b/packages/ragleap-rag/src/ragleap/generation.py
@@ -48,7 +48,7 @@ class ProviderConfig:
         # values passed to the constructor always take precedence.
         if self.provider == "gemini":
             self.api_key = self.api_key or os.environ.get("GEMINI_API_KEY")
-            self.model = self.model or os.environ.get("GEMINI_CHAT_MODEL", "gemini-2.5-flash")
+            self.model = self.model or os.environ.get("GEMINI_CHAT_MODEL", "gemini-3.6-flash")
         elif self.provider == "anthropic":
             self.api_key = self.api_key or os.environ.get("ANTHROPIC_API_KEY")
             self.model = self.model or os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-4-5")

--- a/packages/ragleap-rag/tests/test_cost.py
+++ b/packages/ragleap-rag/tests/test_cost.py
@@ -95,10 +95,13 @@ def test_ask_result_has_cost_field_with_known_pricing():
     assert result["cost"]["cumulative_cost_usd"] == pytest.approx(0.000053, abs=1e-9)
 
 
-def test_ask_result_cost_unavailable_for_unpriced_default_model():
-    """Default gemini model (no explicit model= passed) isn't in the seed
-    pricing table - cost must honestly report unavailable, never guess."""
-    rag = _make_rag()  # ProviderConfig(provider="gemini", api_key=...) -> defaults to "gemini-2.5-flash"
+def test_ask_result_cost_unavailable_for_unpriced_model():
+    """A model not in the seed pricing table - cost must honestly report
+    unavailable, never guess. Uses an explicit, deliberately-fake model
+    name rather than relying on "whatever the current default happens
+    to be", since that default is not a stable thing to couple a test
+    to (see: gemini-2.5-flash getting deprecated by Google mid-project)."""
+    rag = _make_rag(primary=ProviderConfig(provider="gemini", api_key="fake-test-key", model="some-future-unpriced-gemini-model"))
     rag.ingest_text("a.txt", "Some content.")
 
     result = rag.ask("A question")
@@ -108,7 +111,10 @@ def test_ask_result_cost_unavailable_for_unpriced_default_model():
 
 
 def test_ask_pricing_table_override_applies_through_rag_constructor():
-    rag = _make_rag(pricing_table={"gemini": {"gemini-2.5-flash": {"input": 0.05, "output": 0.10}}})
+    rag = _make_rag(
+        primary=ProviderConfig(provider="gemini", api_key="fake-test-key", model="gemini-3.6-flash"),
+        pricing_table={"gemini": {"gemini-3.6-flash": {"input": 0.05, "output": 0.10}}},
+    )
     rag.ingest_text("a.txt", "Some content.")
 
     result = rag.ask("A question")


### PR DESCRIPTION
gemini-2.5-flash (the library's default) was deprecated by Google mid-project (404 on new API calls, confirmed live). New default gemini-3.6-flash confirmed current via web search and live-verified with a real API call. Small patch release, no new features.