### PR TITLE
breaking: remove all hardcoded model defaults (v0.9.0)

### DIFF
--- a/packages/ragleap-rag/CHANGELOG.md
+++ b/packages/ragleap-rag/CHANGELOG.md
@@ -8,6 +8,20 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `docs`: Celery integration guide + runnable example ([#57](https://github.com/antonyrag/ragleap-core/pull/57))
 - `test`: comprehensive pytest suite (67 tests) + CI integration — first automated testing this package has had ([#58](https://github.com/antonyrag/ragleap-core/pull/58))
 
+## [0.9.0]
+
+### Breaking
+
+- **No provider ever hardcodes a default model again** - `ProviderConfig` (Gemini, Anthropic) and `EmbeddingConfig` (all 7 embedding providers) now require `model=` explicitly (constructor arg or env var), and `EmbeddingConfig` additionally requires `dimensions=` explicitly for every provider - not just `together`, which set this precedent from the start.
+- This is a deliberate reliability-over-convenience decision, not an oversight: v0.8.1 fixed a hardcoded Gemini default that broke in production when Google deprecated it. Investigating a "safer" fix (using Google's own `gemini-flash-latest` rolling alias instead of a pinned model string) found that the alias mechanism itself has also been deprecated before - there's no model string, pinned or aliased, that stays permanently safe to hardcode in a fast-moving space. Rather than trade one staleness risk for another, the library now always asks you to know and specify your model.
+- **Migration**: any code relying on an implicit default (e.g. `ProviderConfig(provider="gemini", api_key="...")` with no `model=`, or `EmbeddingConfig(provider="gemini", api_key="...")` with no `model=`/`dimensions=`) will now raise a `ValueError` with a clear message telling you exactly what to pass, or which environment variable to set instead.
+- Every example in `examples/`, the README, and the module docstring updated accordingly.
+
+### Added
+
+- `provider="custom"` + `base_url=...` support for `EmbeddingConfig`, mirroring `ProviderConfig`'s existing support for chat models - reaches any OpenAI-compatible embeddings endpoint not otherwise named (self-hosted servers, or providers without dedicated code here yet). Several Chinese providers - Qwen/DashScope, Zhipu/GLM, Moonshot/Kimi - ship OpenAI-compatible modes and work via this path today, alongside the already-named `deepseek` in `ProviderConfig` and aggregators like `openrouter`.
+- 9 new tests (150 -> 159 passing): `test_embedding.py` rewritten to test the new explicit-required contract instead of old default-resolution behavior, plus 4 new tests covering the `custom` embedding provider.
+
 ## [0.8.1]
 
 ### Fixed

--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -22,8 +22,8 @@ from ragleap import RagLeap, ProviderConfig, EmbeddingConfig
 
 rag = RagLeap(
     database_url="postgresql://user:pass@localhost/mydb",
-    embedder=EmbeddingConfig(provider="gemini", api_key="your-gemini-key"),
-    primary=ProviderConfig(provider="gemini", api_key="your-gemini-key"),
+    embedder=EmbeddingConfig(provider="gemini", model="models/gemini-embedding-001", dimensions=3072, api_key="your-gemini-key"),
+    primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="your-gemini-key"),
 )
 rag.init_schema()  # one-time, idempotent — safe to call every run
 
@@ -50,8 +50,8 @@ from ragleap.vectorstores import FAISSBackend
 rag = RagLeap(
     database_url="postgresql://user:pass@localhost/mydb",  # still required, for conversation memory
     vector_backend=FAISSBackend(persist_directory="./my_faiss_data"),  # vectors go here instead
-    embedder=EmbeddingConfig(provider="gemini", api_key="..."),
-    primary=ProviderConfig(provider="gemini", api_key="..."),
+    embedder=EmbeddingConfig(provider="gemini", model="models/gemini-embedding-001", dimensions=3072, api_key="..."),
+    primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="..."),
 )
 rag.init_schema()
 ```
@@ -90,8 +90,8 @@ bad key on your primary provider doesn't mean a failed request:
 ```python
 rag = RagLeap(
     database_url="...",
-    embedder=EmbeddingConfig(provider="gemini", api_key="..."),
-    primary=ProviderConfig(provider="gemini", api_key="..."),
+    embedder=EmbeddingConfig(provider="gemini", model="models/gemini-embedding-001", dimensions=3072, api_key="..."),
+    primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="..."),
     fallbacks=[ProviderConfig(provider="groq", api_key="...", model="llama-3.3-70b-versatile")],
 )
 ```
@@ -521,8 +521,8 @@ def get_rag() -> RagLeap:
     if _rag_instance is None:
         _rag_instance = RagLeap(
             database_url="postgresql://...",
-            embedder=EmbeddingConfig(provider="gemini", api_key="..."),
-            primary=ProviderConfig(provider="gemini", api_key="..."),
+            embedder=EmbeddingConfig(provider="gemini", model="models/gemini-embedding-001", dimensions=3072, api_key="..."),
+            primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="..."),
             # Same Redis server as the broker above is fine - a different
             # db index keeps the query cache and the task queue from colliding.
             cache_backend="redis",
@@ -606,6 +606,8 @@ Perplexity, or a custom endpoint (`provider="custom"` + `base_url=...`).
 Install extras as needed: `pip install ragleap-rag[anthropic]`,
 `[openai]`, or `[all]`.
 
+**`model=` is always required** (constructor arg or the relevant env var, e.g. `GEMINI_CHAT_MODEL`/`ANTHROPIC_MODEL`) - `ragleap-rag` never hardcodes a default model for any provider. This was a deliberate v0.9.0 decision, not an oversight: a hardcoded Gemini default broke in production mid-project when Google deprecated it, and there's no model string (pinned or a provider's own "-latest" alias) that stays safe indefinitely - even Google's own `-latest` aliases have been deprecated before. Rather than trade one staleness risk for another, the library just always asks you to know and specify your model.
+
 ## Supported embedding providers
 
 ```python
@@ -613,16 +615,18 @@ from ragleap import RagLeap, ProviderConfig, EmbeddingConfig
 
 rag = RagLeap(
     database_url="...",
-    embedder=EmbeddingConfig(provider="ollama"),  # local, no API key, no cost
-    primary=ProviderConfig(...),
+    embedder=EmbeddingConfig(provider="ollama", model="nomic-embed-text", dimensions=768),  # local, no API key, no cost
+    primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="..."),
 )
 ```
 
 Gemini, OpenAI, Mistral, Together, and Ollama (all OpenAI-compatible under the hood, no new dependency), plus Cohere and Voyage AI (own API shapes, via `requests`). Mistral/Together/Ollama reuse the `openai` package's client pointed at a different `base_url` — install the `[openai]` extra for any of them (`pip install ragleap-rag[openai]`), even if you don't have an OpenAI account or key; it's the underlying HTTP client library, not an OpenAI dependency in the account sense.
 
-**Live-verification status**, following this project's own standard of testing against real infrastructure before calling anything done: `gemini` and `openai` are long-verified. `ollama` was live-verified this release — fully local, no API key, tested end-to-end through real ingestion + real FAISS retrieval. `mistral`, `together`, `cohere`, and `voyage` are code-complete based on public API documentation but **not live-verified** against a real account (the same caveat already attached to the Pinecone vector backend) — their default models/dimensions are best-effort until confirmed live.
+**`model=` and `dimensions=` are always required** for every embedding provider (constructor arg or env var, e.g. `GEMINI_EMBEDDING_MODEL`/`EMBEDDING_DIMENSIONS`) - same reasoning as generation providers above. `dimensions=` in particular can't be safely inferred without assuming a specific model, so it's mandatory everywhere now, not just for `together` (which set this precedent from the start).
 
-`together` has no default embedding model or dimensions (too many incompatible models on the platform to guess safely) — pass `model=` and `dimensions=` explicitly, or it raises a clear error rather than guessing wrong.
+**Live-verification status**, following this project's own standard of testing against real infrastructure before calling anything done: `gemini` and `openai` are long-verified. `ollama` was live-verified this release — fully local, no API key, tested end-to-end through real ingestion + real FAISS retrieval. `mistral`, `together`, `cohere`, and `voyage` are code-complete based on public API documentation but **not live-verified** against a real account (the same caveat already attached to the Pinecone vector backend).
+
+`provider="custom"` + `base_url=...` reaches any OpenAI-compatible embeddings endpoint not otherwise named above - a self-hosted server (vLLM, LM Studio, etc.), or a provider without dedicated code here yet. Several Chinese providers - Qwen/DashScope, Zhipu/GLM, Moonshot/Kimi - ship OpenAI-compatible modes and work via this path today. Mirrors `generation.py`'s existing `provider="custom"` support for chat models.
 
 Honest limitation for `cohere`: its API distinguishes query vs. document embeddings via an `input_type` parameter for better retrieval quality, but `embed_text()`/`embed_batch()` don't currently know which context they're called in — Cohere calls always use `input_type="search_document"`, which isn't optimal for query embeddings specifically.
 

--- a/packages/ragleap-rag/examples/01_basic_ingest_and_ask.py
+++ b/packages/ragleap-rag/examples/01_basic_ingest_and_ask.py
@@ -20,8 +20,8 @@ DATABASE_URL = "postgresql://postgres:postgres@localhost:5432/postgres"
 
 rag = RagLeap(
     database_url=DATABASE_URL,
-    embedder=EmbeddingConfig(provider="gemini", api_key=GEMINI_API_KEY),
-    primary=ProviderConfig(provider="gemini", api_key=GEMINI_API_KEY),
+    embedder=EmbeddingConfig(provider="gemini", model="models/gemini-embedding-001", api_key=GEMINI_API_KEY),
+    primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key=GEMINI_API_KEY),
 )
 
 # One-time setup — creates the required tables/indexes if they don't exist.

--- a/packages/ragleap-rag/examples/02_streaming.py
+++ b/packages/ragleap-rag/examples/02_streaming.py
@@ -15,8 +15,8 @@ DATABASE_URL = "postgresql://postgres:postgres@localhost:5432/postgres"
 
 rag = RagLeap(
     database_url=DATABASE_URL,
-    embedder=EmbeddingConfig(provider="gemini", api_key=GEMINI_API_KEY),
-    primary=ProviderConfig(provider="gemini", api_key=GEMINI_API_KEY),
+    embedder=EmbeddingConfig(provider="gemini", model="models/gemini-embedding-001", api_key=GEMINI_API_KEY),
+    primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key=GEMINI_API_KEY),
 )
 rag.init_schema()
 

--- a/packages/ragleap-rag/examples/03_fallback_and_hybrid_search.py
+++ b/packages/ragleap-rag/examples/03_fallback_and_hybrid_search.py
@@ -21,8 +21,8 @@ DATABASE_URL = "postgresql://postgres:postgres@localhost:5432/postgres"
 
 rag = RagLeap(
     database_url=DATABASE_URL,
-    embedder=EmbeddingConfig(provider="gemini", api_key=GEMINI_API_KEY),
-    primary=ProviderConfig(provider="gemini", api_key=GEMINI_API_KEY),
+    embedder=EmbeddingConfig(provider="gemini", model="models/gemini-embedding-001", api_key=GEMINI_API_KEY),
+    primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key=GEMINI_API_KEY),
     fallbacks=[
         ProviderConfig(provider="groq", api_key=GROQ_API_KEY, model="llama-3.3-70b-versatile"),
     ],

--- a/packages/ragleap-rag/examples/04_flask_web_api.py
+++ b/packages/ragleap-rag/examples/04_flask_web_api.py
@@ -26,8 +26,8 @@ app = Flask(__name__)
 
 rag = RagLeap(
     database_url=DATABASE_URL,
-    embedder=EmbeddingConfig(provider="gemini", api_key=GEMINI_API_KEY),
-    primary=ProviderConfig(provider="gemini", api_key=GEMINI_API_KEY),
+    embedder=EmbeddingConfig(provider="gemini", model="models/gemini-embedding-001", api_key=GEMINI_API_KEY),
+    primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key=GEMINI_API_KEY),
 )
 rag.init_schema()
 

--- a/packages/ragleap-rag/examples/05_celery_background_tasks.py
+++ b/packages/ragleap-rag/examples/05_celery_background_tasks.py
@@ -57,8 +57,8 @@ def get_rag() -> RagLeap:
     if _rag_instance is None:
         _rag_instance = RagLeap(
             database_url=DATABASE_URL,
-            embedder=EmbeddingConfig(provider="gemini", api_key=GEMINI_API_KEY),
-            primary=ProviderConfig(provider="gemini", api_key=GEMINI_API_KEY),
+            embedder=EmbeddingConfig(provider="gemini", model="models/gemini-embedding-001", api_key=GEMINI_API_KEY),
+            primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key=GEMINI_API_KEY),
             # Redis-backed cache is a *separate* concern from the Celery
             # broker above — same Redis server is fine, different db index
             # keeps them from colliding.

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.8.1"
+version = "0.9.0"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -5,8 +5,8 @@ ragleap-rag: a fast, honest, self-hosted RAG engine.
 
     rag = RagLeap(
         database_url="postgresql://user:pass@localhost/mydb",
-        embedder=EmbeddingConfig(provider="gemini", api_key="..."),
-        primary=ProviderConfig(provider="gemini", api_key="..."),
+        embedder=EmbeddingConfig(provider="gemini", model="models/gemini-embedding-001", dimensions=3072, api_key="..."),
+        primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="..."),
     )
     rag.init_schema()                  # one-time, idempotent
 
@@ -44,7 +44,7 @@ from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.8.1"
+__version__ = "0.9.0"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult", "TranscriptionConfig", "VectorBackend", "PgVectorBackend"]
 
 

--- a/packages/ragleap-rag/src/ragleap/embedding.py
+++ b/packages/ragleap-rag/src/ragleap/embedding.py
@@ -20,25 +20,6 @@ from typing import List, Optional
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_MODELS = {
-    "gemini": "models/gemini-embedding-001",
-    "openai": "text-embedding-3-small",
-    "mistral": "mistral-embed",
-    "ollama": "nomic-embed-text",
-    "cohere": "embed-english-v3.0",
-    "voyage": "voyage-3",
-    # "together" has no safe default - too many incompatible embedding
-    # models on the platform to guess correctly. Must be passed explicitly.
-}
-DEFAULT_DIMENSIONS = {
-    "gemini": 3072,
-    "openai": 1536,
-    "mistral": 1024,
-    "ollama": 768,
-    "cohere": 1024,
-    "voyage": 1024,
-}
-
 # Providers whose embeddings endpoint is OpenAI-compatible (same request/
 # response shape as OpenAI's /v1/embeddings) - reuses the openai package's
 # client pointed at a custom base_url, same trick generation.py uses.
@@ -52,11 +33,20 @@ OPENAI_COMPATIBLE_BASE_URLS = {
 # Providers with their own (non-OpenAI-compatible) response shape.
 CUSTOM_SHAPE_PROVIDERS = ("cohere", "voyage")
 
+_ALL_PROVIDERS = ("gemini",) + tuple(OPENAI_COMPATIBLE_BASE_URLS.keys()) + CUSTOM_SHAPE_PROVIDERS + ("custom",)
+
 
 @dataclass
 class EmbeddingConfig:
     """Explicit embedding provider configuration. Use this for library
-    integration rather than relying on environment variables."""
+    integration rather than relying on environment variables.
+
+    No model or dimensions value is ever hardcoded as a silent default -
+    provider model names, availability, and dimensions all change over
+    time (a hardcoded gemini generation model default broke in production
+    mid-project - see CHANGELOG v0.8.1/v0.9.0), so this always requires
+    you to know and specify both, one way or another (constructor arg or
+    environment variable)."""
     provider: str
     api_key: Optional[str] = None
     model: Optional[str] = None
@@ -68,39 +58,41 @@ class EmbeddingConfig:
 
         if self.provider == "gemini":
             self.api_key = self.api_key or os.environ.get("GEMINI_API_KEY")
-            self.model = self.model or os.environ.get("GEMINI_EMBEDDING_MODEL", DEFAULT_MODELS["gemini"])
-            self.dimensions = self.dimensions or int(
-                os.environ.get("EMBEDDING_DIMENSIONS", str(DEFAULT_DIMENSIONS["gemini"]))
-            )
+            self.model = self.model or os.environ.get("GEMINI_EMBEDDING_MODEL")
+            env_dims = os.environ.get("EMBEDDING_DIMENSIONS")
+            self.dimensions = self.dimensions or (int(env_dims) if env_dims else None)
         elif self.provider in OPENAI_COMPATIBLE_BASE_URLS:
             self.api_key = self.api_key or os.environ.get(f"{self.provider.upper()}_API_KEY")
-            self.model = self.model or os.environ.get(
-                f"{self.provider.upper()}_EMBEDDING_MODEL", DEFAULT_MODELS.get(self.provider)
-            )
+            self.model = self.model or os.environ.get(f"{self.provider.upper()}_EMBEDDING_MODEL")
             env_dims = os.environ.get(f"{self.provider.upper()}_EMBEDDING_DIMENSIONS") or os.environ.get("EMBEDDING_DIMENSIONS")
-            default_dims = DEFAULT_DIMENSIONS.get(self.provider)
-            self.dimensions = self.dimensions or (int(env_dims) if env_dims else default_dims)
+            self.dimensions = self.dimensions or (int(env_dims) if env_dims else None)
             self.base_url = self.base_url or OPENAI_COMPATIBLE_BASE_URLS[self.provider]
-
-            if self.provider == "together" and (not self.model or not self.dimensions):
-                raise ValueError(
-                    "Provider 'together' has no safe default embedding model or "
-                    "dimensions - too many incompatible models on the platform to "
-                    "guess correctly. Pass model= and dimensions= explicitly to "
-                    "EmbeddingConfig(), or set TOGETHER_EMBEDDING_MODEL and "
-                    "TOGETHER_EMBEDDING_DIMENSIONS in your environment."
-                )
         elif self.provider in CUSTOM_SHAPE_PROVIDERS:
             self.api_key = self.api_key or os.environ.get(f"{self.provider.upper()}_API_KEY")
-            self.model = self.model or os.environ.get(
-                f"{self.provider.upper()}_EMBEDDING_MODEL", DEFAULT_MODELS.get(self.provider)
-            )
+            self.model = self.model or os.environ.get(f"{self.provider.upper()}_EMBEDDING_MODEL")
             env_dims = os.environ.get(f"{self.provider.upper()}_EMBEDDING_DIMENSIONS") or os.environ.get("EMBEDDING_DIMENSIONS")
-            self.dimensions = self.dimensions or (int(env_dims) if env_dims else DEFAULT_DIMENSIONS.get(self.provider))
+            self.dimensions = self.dimensions or (int(env_dims) if env_dims else None)
+        elif self.provider == "custom":
+            # Any OpenAI-compatible embeddings endpoint not already named
+            # above - self-hosted servers (vLLM, LM Studio, etc.), or a
+            # provider without dedicated code here yet (many Chinese
+            # providers - Qwen/DashScope, Zhipu/GLM, Moonshot/Kimi - ship
+            # OpenAI-compatible modes and work via this path today).
+            self.api_key = self.api_key or os.environ.get("CUSTOM_EMBEDDING_API_KEY")
+            self.model = self.model or os.environ.get("CUSTOM_EMBEDDING_MODEL")
+            env_dims = os.environ.get("CUSTOM_EMBEDDING_DIMENSIONS") or os.environ.get("EMBEDDING_DIMENSIONS")
+            self.dimensions = self.dimensions or (int(env_dims) if env_dims else None)
+            self.base_url = self.base_url or os.environ.get("CUSTOM_EMBEDDING_BASE_URL")
+            if not self.base_url:
+                raise ValueError(
+                    "No base_url for provider 'custom'. Pass base_url= explicitly "
+                    "to EmbeddingConfig(), or set CUSTOM_EMBEDDING_BASE_URL in your "
+                    "environment - it must point to an OpenAI-compatible /embeddings endpoint."
+                )
         else:
             raise ValueError(
                 f"Unknown embedding provider '{self.provider}'. Supported: "
-                f"gemini, openai, mistral, together, ollama, cohere, voyage."
+                f"{', '.join(_ALL_PROVIDERS)}."
             )
 
         if not self.api_key and self.provider != "ollama":
@@ -108,6 +100,24 @@ class EmbeddingConfig:
                 f"No API key for embedding provider '{self.provider}'. Pass api_key= "
                 f"explicitly to EmbeddingConfig(), or set {self.provider.upper()}_API_KEY "
                 f"in your environment."
+            )
+        if not self.model:
+            raise ValueError(
+                f"No embedding model specified for provider '{self.provider}'. Pass "
+                f"model= explicitly to EmbeddingConfig(), or set "
+                f"{self.provider.upper()}_EMBEDDING_MODEL in your environment. "
+                f"ragleap-rag never hardcodes a default embedding model - provider "
+                f"model availability and dimensions change too frequently for a "
+                f"baked-in default to stay reliable."
+            )
+        if not self.dimensions:
+            raise ValueError(
+                f"No dimensions specified for embedding provider '{self.provider}' "
+                f"model '{self.model}'. Pass dimensions= explicitly to "
+                f"EmbeddingConfig(), or set EMBEDDING_DIMENSIONS (or "
+                f"{self.provider.upper()}_EMBEDDING_DIMENSIONS) in your environment - "
+                f"dimensions must match your chosen model exactly, and ragleap-rag "
+                f"can't safely guess it."
             )
 
 
@@ -129,7 +139,7 @@ class EmbeddingService:
         try:
             if self.config.provider == "gemini":
                 return self._embed_gemini(text)
-            elif self.config.provider in OPENAI_COMPATIBLE_BASE_URLS:
+            elif self.config.provider in OPENAI_COMPATIBLE_BASE_URLS or self.config.provider == "custom":
                 return self._embed_openai_compatible(text)
             elif self.config.provider == "cohere":
                 return self._embed_cohere([text])[0]
@@ -147,7 +157,7 @@ class EmbeddingService:
         try:
             if self.config.provider == "gemini":
                 return self._embed_batch_gemini(texts)
-            elif self.config.provider in OPENAI_COMPATIBLE_BASE_URLS:
+            elif self.config.provider in OPENAI_COMPATIBLE_BASE_URLS or self.config.provider == "custom":
                 return self._embed_batch_openai_compatible(texts)
             elif self.config.provider == "cohere":
                 return self._embed_cohere(texts)

--- a/packages/ragleap-rag/src/ragleap/generation.py
+++ b/packages/ragleap-rag/src/ragleap/generation.py
@@ -45,13 +45,17 @@ class ProviderConfig:
         self.provider = self.provider.lower()
 
         # Convenience env-var fallback (e.g. for quick scripts) — explicit
-        # values passed to the constructor always take precedence.
+        # values passed to the constructor always take precedence. No model
+        # is ever hardcoded as a silent default: provider model names and
+        # deprecations change frequently (learned the hard way - see
+        # CHANGELOG v0.8.1/v0.9.0), so ragleap-rag always requires you to
+        # know and specify which model you're using, one way or another.
         if self.provider == "gemini":
             self.api_key = self.api_key or os.environ.get("GEMINI_API_KEY")
-            self.model = self.model or os.environ.get("GEMINI_CHAT_MODEL", "gemini-3.6-flash")
+            self.model = self.model or os.environ.get("GEMINI_CHAT_MODEL")
         elif self.provider == "anthropic":
             self.api_key = self.api_key or os.environ.get("ANTHROPIC_API_KEY")
-            self.model = self.model or os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-4-5")
+            self.model = self.model or os.environ.get("ANTHROPIC_MODEL")
         elif self.provider in PROVIDER_BASE_URLS:
             self.api_key = self.api_key or os.environ.get(f"{self.provider.upper()}_API_KEY")
             self.model = self.model or os.environ.get(f"{self.provider.upper()}_MODEL")
@@ -68,6 +72,14 @@ class ProviderConfig:
             raise ValueError(f"No API key for provider '{self.provider}'. Pass api_key= explicitly.")
         if self.provider not in ("gemini", "anthropic") and not self.base_url:
             raise ValueError(f"No base_url for provider '{self.provider}'. Pass base_url= explicitly.")
+        if not self.model and self.provider != "custom":
+            env_var_name = "GEMINI_CHAT_MODEL" if self.provider == "gemini" else "ANTHROPIC_MODEL" if self.provider == "anthropic" else f"{self.provider.upper()}_MODEL"
+            raise ValueError(
+                f"No model specified for provider '{self.provider}'. Pass model= explicitly "
+                f"to ProviderConfig(), or set {env_var_name} in your environment. "
+                f"ragleap-rag never hardcodes a default model - provider model names and "
+                f"deprecations change too frequently for a baked-in default to stay reliable."
+            )
         if self.provider not in ("gemini", "anthropic") and not self.model:
             raise ValueError(f"No model for provider '{self.provider}'. Pass model= explicitly.")
 

--- a/packages/ragleap-rag/tests/conftest.py
+++ b/packages/ragleap-rag/tests/conftest.py
@@ -81,8 +81,8 @@ def _init_schema_once(database_url):
     this once per test session is safe and matches real-world usage."""
     rag = RagLeap(
         database_url=database_url,
-        embedder=EmbeddingConfig(provider="gemini", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
-        primary=ProviderConfig(provider="gemini", api_key="fake-test-key"),
+        embedder=EmbeddingConfig(provider="gemini", model="models/gemini-embedding-001", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
+        primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="fake-test-key"),
     )
     rag.init_schema()
     yield
@@ -110,6 +110,6 @@ def rag(database_url):
     automatically via the autouse fixtures above."""
     return RagLeap(
         database_url=database_url,
-        embedder=EmbeddingConfig(provider="gemini", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
-        primary=ProviderConfig(provider="gemini", api_key="fake-test-key"),
+        embedder=EmbeddingConfig(provider="gemini", model="models/gemini-embedding-001", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
+        primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="fake-test-key"),
     )

--- a/packages/ragleap-rag/tests/test_cache.py
+++ b/packages/ragleap-rag/tests/test_cache.py
@@ -57,8 +57,8 @@ def test_rag_cache_disabled_returns_zeroed_stats(database_url):
 
     rag = RagLeap(
         database_url=database_url,
-        embedder=EmbeddingConfig(provider="gemini", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
-        primary=ProviderConfig(provider="gemini", api_key="fake-test-key"),
+        embedder=EmbeddingConfig(provider="gemini", model="models/gemini-embedding-001", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
+        primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="fake-test-key"),
         cache_enabled=False,
     )
     assert rag.cache_stats() == {"hits": 0, "misses": 0, "hit_rate": 0.0, "size": 0, "enabled": False}
@@ -85,7 +85,7 @@ def test_rag_cache_backend_redis_requires_redis_url(database_url):
     with pytest.raises(ValueError, match="requires redis_url"):
         RagLeap(
             database_url=database_url,
-            embedder=EmbeddingConfig(provider="gemini", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
-            primary=ProviderConfig(provider="gemini", api_key="fake-test-key"),
+            embedder=EmbeddingConfig(provider="gemini", model="models/gemini-embedding-001", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
+            primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="fake-test-key"),
             cache_backend="redis",
         )

--- a/packages/ragleap-rag/tests/test_cost.py
+++ b/packages/ragleap-rag/tests/test_cost.py
@@ -10,8 +10,8 @@ from conftest import TEST_DATABASE_URL, TEST_DIMENSIONS
 def _make_rag(primary=None, **kwargs):
     return RagLeap(
         database_url=TEST_DATABASE_URL,
-        embedder=EmbeddingConfig(provider="gemini", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
-        primary=primary or ProviderConfig(provider="gemini", api_key="fake-test-key"),
+        embedder=EmbeddingConfig(provider="gemini", model="models/gemini-embedding-001", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
+        primary=primary or ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="fake-test-key"),
         **kwargs,
     )
 
@@ -85,7 +85,7 @@ def test_cost_tracker_over_budget_after_threshold_crossed():
 # --- Integration tests: real ask() wiring through RagLeap ---
 
 def test_ask_result_has_cost_field_with_known_pricing():
-    rag = _make_rag(primary=ProviderConfig(provider="gemini", api_key="fake-test-key", model="gemini-3.6-flash"))
+    rag = _make_rag(primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="fake-test-key"))
     rag.ingest_text("a.txt", "Some content about testing things.")
 
     result = rag.ask("A question")
@@ -101,7 +101,7 @@ def test_ask_result_cost_unavailable_for_unpriced_model():
     name rather than relying on "whatever the current default happens
     to be", since that default is not a stable thing to couple a test
     to (see: gemini-2.5-flash getting deprecated by Google mid-project)."""
-    rag = _make_rag(primary=ProviderConfig(provider="gemini", api_key="fake-test-key", model="some-future-unpriced-gemini-model"))
+    rag = _make_rag(primary=ProviderConfig(provider="gemini", model="some-future-unpriced-gemini-model", api_key="fake-test-key"))
     rag.ingest_text("a.txt", "Some content.")
 
     result = rag.ask("A question")
@@ -112,7 +112,7 @@ def test_ask_result_cost_unavailable_for_unpriced_model():
 
 def test_ask_pricing_table_override_applies_through_rag_constructor():
     rag = _make_rag(
-        primary=ProviderConfig(provider="gemini", api_key="fake-test-key", model="gemini-3.6-flash"),
+        primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="fake-test-key"),
         pricing_table={"gemini": {"gemini-3.6-flash": {"input": 0.05, "output": 0.10}}},
     )
     rag.ingest_text("a.txt", "Some content.")
@@ -125,7 +125,7 @@ def test_ask_pricing_table_override_applies_through_rag_constructor():
 
 
 def test_cumulative_cost_grows_across_multiple_ask_calls():
-    rag = _make_rag(primary=ProviderConfig(provider="gemini", api_key="fake-test-key", model="gemini-3.6-flash"))
+    rag = _make_rag(primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="fake-test-key"))
     rag.ingest_text("a.txt", "Some content.")
 
     first = rag.ask("Q1")
@@ -139,7 +139,7 @@ def test_budget_fallback_triggers_switch_to_fallback_provider():
     Its real cost then crosses the tiny budget, so the second call must
     use budget_fallback instead - proving override_provider actually
     reaches the generation chain, not just that cost is tracked."""
-    primary = ProviderConfig(provider="gemini", api_key="fake-test-key", model="gemini-3.6-flash")
+    primary = ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="fake-test-key")
     fallback = ProviderConfig(provider="anthropic", api_key="fake-test-key", model="claude-haiku-4-5-20251001")
     rag = _make_rag(
         primary=primary,
@@ -158,7 +158,7 @@ def test_budget_fallback_triggers_switch_to_fallback_provider():
 def test_no_budget_fallback_configured_never_switches_provider():
     """budget_usd_per_month set but no budget_fallback provider -> stays
     on primary regardless of spend, since there's nowhere to fall back to."""
-    primary = ProviderConfig(provider="gemini", api_key="fake-test-key", model="gemini-3.6-flash")
+    primary = ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="fake-test-key")
     rag = _make_rag(primary=primary, budget_usd_per_month=0.00001)
     rag.ingest_text("a.txt", "Some content.")
 
@@ -171,7 +171,7 @@ def test_no_budget_fallback_configured_never_switches_provider():
 def test_ask_stream_cost_is_always_unavailable():
     """Streaming has no token usage data (see generate_answer_stream's
     docstring) - cost must honestly report unavailable, not fabricated."""
-    rag = _make_rag(primary=ProviderConfig(provider="gemini", api_key="fake-test-key", model="gemini-3.6-flash"))
+    rag = _make_rag(primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="fake-test-key"))
     rag.ingest_text("a.txt", "Some content.")
 
     list(rag.ask_stream("A question"))

--- a/packages/ragleap-rag/tests/test_embedding.py
+++ b/packages/ragleap-rag/tests/test_embedding.py
@@ -1,13 +1,19 @@
-"""Tests for embedding provider expansion (v0.7.0). Split into two
-groups: config-resolution tests for providers with no live key/instance
-available (mistral, together, cohere, voyage) - no network calls, just
-verifying defaults/env-fallback/error-raising logic - and real live
-tests against a genuinely running local Ollama instance, skipped
-automatically if Ollama isn't reachable so CI never fails on its
-absence."""
+"""Tests for embedding provider expansion (v0.7.0), updated for v0.9.0's
+removal of all hardcoded model/dimension defaults - every provider now
+requires explicit model= and dimensions= (constructor arg or env var),
+matching the precedent "together" always set. Split into two groups:
+config-resolution tests (no network calls, no keys needed beyond fakes)
+and real live tests against a genuinely running local Ollama instance,
+skipped automatically if Ollama isn't reachable so CI never fails on
+its absence."""
 import os
 import pytest
 from ragleap.embedding import EmbeddingConfig, EmbeddingService
+
+# Captured before conftest.py's autouse fake_embedder fixture monkeypatches
+# EmbeddingService.embed_text/embed_batch for every test in the suite - lets
+# the dispatch test below temporarily restore real behavior for one test.
+_REAL_EMBED_TEXT = EmbeddingService.embed_text
 
 ollama_available = True
 try:
@@ -17,17 +23,22 @@ except Exception:
     ollama_available = False
 
 
-# --- Config-resolution tests (no network calls, no keys needed) ---
+# --- Config-resolution tests: explicit model=/dimensions= now mandatory ---
 
-def test_mistral_default_model_and_dimensions():
-    config = EmbeddingConfig(provider="mistral", api_key="fake-key")
+def test_mistral_requires_explicit_model_and_dimensions():
+    with pytest.raises(ValueError, match="No embedding model specified"):
+        EmbeddingConfig(provider="mistral", api_key="fake-key")
+
+
+def test_mistral_works_with_explicit_model_and_dimensions():
+    config = EmbeddingConfig(provider="mistral", api_key="fake-key", model="mistral-embed", dimensions=1024)
     assert config.model == "mistral-embed"
     assert config.dimensions == 1024
     assert config.base_url == "https://api.mistral.ai/v1"
 
 
 def test_together_requires_explicit_model_and_dimensions():
-    with pytest.raises(ValueError, match="no safe default"):
+    with pytest.raises(ValueError, match="No embedding model specified"):
         EmbeddingConfig(provider="together", api_key="fake-key")
 
 
@@ -38,37 +49,64 @@ def test_together_works_with_explicit_model_and_dimensions():
     assert config.base_url == "https://api.together.xyz/v1"
 
 
-def test_cohere_default_model_and_dimensions():
-    config = EmbeddingConfig(provider="cohere", api_key="fake-key")
+def test_cohere_requires_explicit_model_and_dimensions():
+    with pytest.raises(ValueError, match="No embedding model specified"):
+        EmbeddingConfig(provider="cohere", api_key="fake-key")
+
+
+def test_cohere_works_with_explicit_model_and_dimensions():
+    config = EmbeddingConfig(provider="cohere", api_key="fake-key", model="embed-english-v3.0", dimensions=1024)
     assert config.model == "embed-english-v3.0"
     assert config.dimensions == 1024
 
 
-def test_voyage_default_model_and_dimensions():
-    config = EmbeddingConfig(provider="voyage", api_key="fake-key")
+def test_voyage_requires_explicit_model_and_dimensions():
+    with pytest.raises(ValueError, match="No embedding model specified"):
+        EmbeddingConfig(provider="voyage", api_key="fake-key")
+
+
+def test_voyage_works_with_explicit_model_and_dimensions():
+    config = EmbeddingConfig(provider="voyage", api_key="fake-key", model="voyage-3", dimensions=1024)
     assert config.model == "voyage-3"
     assert config.dimensions == 1024
 
 
 def test_missing_api_key_raises_for_mistral():
     with pytest.raises(ValueError, match="No API key"):
-        EmbeddingConfig(provider="mistral")
+        EmbeddingConfig(provider="mistral", model="mistral-embed", dimensions=1024)
 
 
 def test_missing_api_key_raises_for_cohere():
     with pytest.raises(ValueError, match="No API key"):
-        EmbeddingConfig(provider="cohere")
+        EmbeddingConfig(provider="cohere", model="embed-english-v3.0", dimensions=1024)
 
 
 def test_missing_api_key_raises_for_voyage():
     with pytest.raises(ValueError, match="No API key"):
-        EmbeddingConfig(provider="voyage")
+        EmbeddingConfig(provider="voyage", model="voyage-3", dimensions=1024)
 
 
-def test_ollama_needs_no_api_key():
+def test_missing_model_raises_even_with_valid_api_key():
+    """The core of the v0.9.0 change - having an API key isn't enough,
+    model= (and dimensions=) are always required regardless of provider."""
+    with pytest.raises(ValueError, match="No embedding model specified"):
+        EmbeddingConfig(provider="cohere", api_key="real-looking-key")
+
+
+def test_missing_dimensions_raises_even_with_model_specified():
+    with pytest.raises(ValueError, match="No dimensions specified"):
+        EmbeddingConfig(provider="cohere", api_key="fake-key", model="embed-english-v3.0")
+
+
+def test_ollama_needs_no_api_key_but_still_needs_model_and_dimensions():
     """Mirrors generation.py's existing ollama exemption from requiring
-    an api_key - local inference, nothing to authenticate."""
-    config = EmbeddingConfig(provider="ollama")
+    an api_key - local inference, nothing to authenticate. But model=
+    and dimensions= are still mandatory - no provider is exempt from
+    that, ollama included."""
+    with pytest.raises(ValueError, match="No embedding model specified"):
+        EmbeddingConfig(provider="ollama")
+
+    config = EmbeddingConfig(provider="ollama", model="nomic-embed-text", dimensions=768)
     assert config.api_key is None
     assert config.model == "nomic-embed-text"
     assert config.dimensions == 768
@@ -78,19 +116,82 @@ def test_ollama_needs_no_api_key():
 def test_env_var_fallback_for_mistral(monkeypatch):
     monkeypatch.setenv("MISTRAL_API_KEY", "env-key")
     monkeypatch.setenv("MISTRAL_EMBEDDING_MODEL", "custom-mistral-model")
+    monkeypatch.setenv("MISTRAL_EMBEDDING_DIMENSIONS", "1024")
     config = EmbeddingConfig(provider="mistral")
     assert config.api_key == "env-key"
     assert config.model == "custom-mistral-model"
+    assert config.dimensions == 1024
 
 
 def test_unknown_provider_raises():
     with pytest.raises(ValueError, match="Unknown embedding provider"):
-        EmbeddingConfig(provider="not-a-real-provider", api_key="fake-key")
+        EmbeddingConfig(provider="not-a-real-provider", api_key="fake-key", model="whatever", dimensions=100)
 
 
-def test_explicit_dimensions_override_default():
-    config = EmbeddingConfig(provider="cohere", api_key="fake-key", dimensions=256)
+def test_explicit_dimensions_always_required_no_override_concept():
+    """There's no "default to override" anymore - dimensions must always
+    be passed explicitly one way or another."""
+    config = EmbeddingConfig(provider="cohere", api_key="fake-key", model="embed-english-v3.0", dimensions=256)
     assert config.dimensions == 256
+
+
+def test_custom_provider_requires_base_url():
+    with pytest.raises(ValueError, match="No base_url for provider 'custom'"):
+        EmbeddingConfig(provider="custom", api_key="fake-key", model="some-model", dimensions=512)
+
+
+def test_custom_provider_works_with_all_fields_explicit():
+    """Proves the escape hatch this session was about: any OpenAI-
+    compatible embeddings endpoint not otherwise named - a self-hosted
+    server, or a provider without dedicated code (many Chinese providers
+    - Qwen/DashScope, Zhipu/GLM, Moonshot/Kimi - ship OpenAI-compatible
+    modes and work via this path today)."""
+    config = EmbeddingConfig(
+        provider="custom",
+        api_key="fake-key",
+        model="some-chinese-provider-embedding-model",
+        dimensions=1024,
+        base_url="https://api.some-provider.example.com/v1",
+    )
+    assert config.base_url == "https://api.some-provider.example.com/v1"
+    assert config.model == "some-chinese-provider-embedding-model"
+    assert config.dimensions == 1024
+
+
+def test_custom_provider_env_var_fallback(monkeypatch):
+    monkeypatch.setenv("CUSTOM_EMBEDDING_API_KEY", "env-key")
+    monkeypatch.setenv("CUSTOM_EMBEDDING_MODEL", "env-model")
+    monkeypatch.setenv("CUSTOM_EMBEDDING_DIMENSIONS", "512")
+    monkeypatch.setenv("CUSTOM_EMBEDDING_BASE_URL", "https://env-configured.example.com/v1")
+    config = EmbeddingConfig(provider="custom")
+    assert config.api_key == "env-key"
+    assert config.model == "env-model"
+    assert config.dimensions == 512
+    assert config.base_url == "https://env-configured.example.com/v1"
+
+
+def test_custom_provider_dispatches_to_openai_compatible_path(monkeypatch):
+    """Confirms EmbeddingService actually routes provider="custom" through
+    the same _embed_openai_compatible code path as openai/mistral/etc,
+    not treating it as an unknown/unhandled provider that silently
+    returns None. Restores the real embed_text() for this one test,
+    since conftest.py's autouse fake_embedder fixture globally fakes it
+    for the whole suite - without restoring it, this test would call the
+    fake version and never actually exercise the real dispatch logic."""
+    from unittest.mock import patch
+
+    monkeypatch.setattr(EmbeddingService, "embed_text", _REAL_EMBED_TEXT)
+
+    config = EmbeddingConfig(
+        provider="custom", api_key="fake-key", model="test-model",
+        dimensions=4, base_url="https://fake.example.com/v1",
+    )
+    service = EmbeddingService(config)
+
+    with patch.object(EmbeddingService, "_embed_openai_compatible", return_value=[0.1, 0.2, 0.3, 0.4]) as mock_embed:
+        result = service.embed_text("test")
+        mock_embed.assert_called_once()
+        assert result == [0.1, 0.2, 0.3, 0.4]
 
 
 # --- Live Ollama tests - skipped automatically if Ollama isn't running ---
@@ -100,7 +201,7 @@ pytestmark_ollama = pytest.mark.skipif(not ollama_available, reason="Ollama not 
 
 @pytestmark_ollama
 def test_ollama_embed_text_returns_real_vector():
-    config = EmbeddingConfig(provider="ollama")
+    config = EmbeddingConfig(provider="ollama", model="nomic-embed-text", dimensions=768)
     service = EmbeddingService(config)
     vec = service.embed_text("This is a live test of the Ollama embedding path.")
     assert vec is not None
@@ -110,7 +211,7 @@ def test_ollama_embed_text_returns_real_vector():
 
 @pytestmark_ollama
 def test_ollama_embed_batch_returns_real_vectors():
-    config = EmbeddingConfig(provider="ollama")
+    config = EmbeddingConfig(provider="ollama", model="nomic-embed-text", dimensions=768)
     service = EmbeddingService(config)
     batch = service.embed_batch(["first text", "second text", "third text"])
     assert len(batch) == 3
@@ -119,7 +220,7 @@ def test_ollama_embed_batch_returns_real_vectors():
 
 @pytestmark_ollama
 def test_ollama_embed_text_empty_string_returns_none():
-    config = EmbeddingConfig(provider="ollama")
+    config = EmbeddingConfig(provider="ollama", model="nomic-embed-text", dimensions=768)
     service = EmbeddingService(config)
     assert service.embed_text("") is None
     assert service.embed_text("   ") is None
@@ -137,9 +238,9 @@ def test_ollama_full_rag_integration_with_faiss(tmp_path, database_url):
     backend = FAISSBackend(persist_directory=str(tmp_path / "ollama_faiss_data"))
     rag = RagLeap(
         database_url=database_url,
-        embedder=EC(provider="ollama"),
+        embedder=EC(provider="ollama", model="nomic-embed-text", dimensions=768),
         vector_backend=backend,
-        primary=ProviderConfig(provider="gemini", api_key="fake-test-key"),
+        primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="fake-test-key"),
     )
     rag.init_schema()
 

--- a/packages/ragleap-rag/tests/test_faiss_backend.py
+++ b/packages/ragleap-rag/tests/test_faiss_backend.py
@@ -25,8 +25,8 @@ def faiss_rag(database_url, tmp_path):
     rag = RagLeap(
         database_url=database_url,
         vector_backend=backend,
-        embedder=EmbeddingConfig(provider="gemini", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
-        primary=ProviderConfig(provider="gemini", api_key="fake-test-key"),
+        embedder=EmbeddingConfig(provider="gemini", model="models/gemini-embedding-001", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
+        primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="fake-test-key"),
     )
     rag.init_schema()
     return rag
@@ -116,8 +116,8 @@ def test_faiss_persistence_across_backend_instances(tmp_path, database_url):
     backend1 = FAISSBackend(persist_directory=persist_dir)
     rag1 = RagLeap(
         database_url=database_url, vector_backend=backend1,
-        embedder=EmbeddingConfig(provider="gemini", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
-        primary=ProviderConfig(provider="gemini", api_key="fake-test-key"),
+        embedder=EmbeddingConfig(provider="gemini", model="models/gemini-embedding-001", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
+        primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="fake-test-key"),
     )
     rag1.init_schema()
     rag1.ingest_text("persisted.txt", "This content should survive a restart.")
@@ -126,8 +126,8 @@ def test_faiss_persistence_across_backend_instances(tmp_path, database_url):
     backend2 = FAISSBackend(persist_directory=persist_dir)
     rag2 = RagLeap(
         database_url=database_url, vector_backend=backend2,
-        embedder=EmbeddingConfig(provider="gemini", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
-        primary=ProviderConfig(provider="gemini", api_key="fake-test-key"),
+        embedder=EmbeddingConfig(provider="gemini", model="models/gemini-embedding-001", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
+        primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="fake-test-key"),
     )
     rag2.init_schema()
 

--- a/packages/ragleap-rag/tests/test_guardrails.py
+++ b/packages/ragleap-rag/tests/test_guardrails.py
@@ -10,8 +10,8 @@ from conftest import TEST_DATABASE_URL, TEST_DIMENSIONS
 def _make_rag(**kwargs):
     return RagLeap(
         database_url=TEST_DATABASE_URL,
-        embedder=EmbeddingConfig(provider="gemini", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
-        primary=ProviderConfig(provider="gemini", api_key="fake-test-key"),
+        embedder=EmbeddingConfig(provider="gemini", model="models/gemini-embedding-001", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
+        primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="fake-test-key"),
         **kwargs,
     )
 

--- a/packages/ragleap-rag/tests/test_observability.py
+++ b/packages/ragleap-rag/tests/test_observability.py
@@ -8,8 +8,8 @@ from conftest import TEST_DATABASE_URL, TEST_DIMENSIONS
 def _make_rag(**kwargs):
     return RagLeap(
         database_url=TEST_DATABASE_URL,
-        embedder=EmbeddingConfig(provider="gemini", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
-        primary=ProviderConfig(provider="gemini", api_key="fake-test-key"),
+        embedder=EmbeddingConfig(provider="gemini", model="models/gemini-embedding-001", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
+        primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="fake-test-key"),
         **kwargs,
     )
 

--- a/packages/ragleap-rag/tests/test_structured.py
+++ b/packages/ragleap-rag/tests/test_structured.py
@@ -16,8 +16,8 @@ from conftest import TEST_DATABASE_URL, TEST_DIMENSIONS
 def _make_rag(**kwargs):
     return RagLeap(
         database_url=TEST_DATABASE_URL,
-        embedder=EmbeddingConfig(provider="gemini", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
-        primary=ProviderConfig(provider="gemini", api_key="fake-test-key"),
+        embedder=EmbeddingConfig(provider="gemini", model="models/gemini-embedding-001", api_key="fake-test-key", dimensions=TEST_DIMENSIONS),
+        primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="fake-test-key"),
         **kwargs,
     )
 


### PR DESCRIPTION
- ProviderConfig (gemini, anthropic) and EmbeddingConfig (all 7 embedding providers) now require model= explicitly - constructor arg or env var, no silent fallback ever. EmbeddingConfig additionally requires dimensions= explicitly everywhere, not just for together (which set this precedent from the start).
- Deliberate reliability-over-convenience decision: v0.8.1 fixed a hardcoded Gemini default that broke in production when Google deprecated it. Investigated using Google's gemini-flash-latest rolling alias as a 'safer' fix - found that alias mechanism has ALSO been deprecated before. No model string, pinned or aliased, stays permanently safe to hardcode. Rather than trade one staleness risk for another, always require the caller to know their model.
- Migration: code relying on an implicit default now raises a clear ValueError telling you exactly what to pass or which env var to set.
- Added provider="custom" + base_url= to EmbeddingConfig, mirroring ProviderConfig's existing chat-model support - reaches any OpenAI-compatible embeddings endpoint not otherwise named (self- hosted servers, or providers without dedicated code yet - several Chinese providers ship OpenAI-compatible modes and work via this path today).
- Updated all 5 examples/, README, module docstring, and 8 test files to pass model=/dimensions= explicitly instead of relying on removed defaults.
- test_embedding.py rewritten to test the new explicit-required contract; 4 new tests for the custom embedding provider.
- 159/159 tests passing (150 -> 159).

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
