### PR TITLE
feat: query rewriting/expansion - contextual, hyde, multi_query (v0.1…

### DIFF
--- a/packages/ragleap-rag/CHANGELOG.md
+++ b/packages/ragleap-rag/CHANGELOG.md
@@ -8,6 +8,22 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `docs`: Celery integration guide + runnable example ([#57](https://github.com/antonyrag/ragleap-core/pull/57))
 - `test`: comprehensive pytest suite (67 tests) + CI integration — first automated testing this package has had ([#58](https://github.com/antonyrag/ragleap-core/pull/58))
 
+## [0.10.0]
+
+### Added
+
+- Query rewriting/expansion: `query_rewrite=` on `ask()` with three strategies grounded in established RAG research - `"contextual"` (resolves follow-up questions using session history, HyDE-adjacent single-call pattern cited in 2026 production case studies), `"hyde"` (Gao et al. 2022 - embeds a generated hypothetical answer instead of the raw query), and `"multi_query"` (Rackauckas 2023 RAG-Fusion - generates alternative phrasings, retrieves for each, merges via Reciprocal Rank Fusion).
+- New `ragleap.query_rewrite` module: `contextual_rewrite()`, `hyde_document()`, `multi_query_variants()`, `reciprocal_rank_fusion()`.
+- **Live-verified this release** with real Gemini calls: contextual rewrite correctly resolved a pronoun-laden follow-up ("it" -> "RagLeap"), HyDE generated an on-topic hypothetical passage, multi_query produced three genuinely distinct phrasings that all correctly retrieved the same chunk, RRF merge correctly ranked the doubly-retrieved chunk first. Full integration verified end-to-end (real embeddings, real FAISS retrieval, real generation) for all three strategies plus the no-rewrite backward-compat path.
+- Honest limitation documented, not hidden: `multi_query`'s generated variants can be "nearly identical and lacking in diversity" (a documented finding in the broader RAG-Fusion literature) and it costs `multi_query_n` retrieval calls instead of one - `contextual` and `hyde` are the cheap, fast options if that's what you want.
+- Every strategy fails open: if the extra rewrite LLM call itself fails, retrieval proceeds with the original, unmodified query - a broken rewrite step can never break retrieval entirely.
+- The final answer generation always uses the original query, never the rewritten form - rewriting only affects what gets retrieved.
+- The rewrite call's real token cost is recorded into the existing `CostTracker` infrastructure, contributing to `cumulative_cost_usd`.
+- `multi_query_n=3` param on `ask()` controls variant count for the `multi_query` strategy.
+- Result gains a `query_rewrite` field (strategy + rewritten_query/hyde_document/query_variants) only when `query_rewrite=` is passed - absent entirely otherwise, for backward compatibility.
+- Not supported on `ask_stream()`.
+- 19 new tests (159 -> 178 passing): isolated unit tests for `ragleap.query_rewrite` (via a lightweight stub generator for deterministic control), fail-open behavior coverage, and `ask()` plumbing tests via the existing fake-provider fixtures.
+
 ## [0.9.0]
 
 ### Breaking

--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -197,6 +197,34 @@ Filtering uses Postgres JSONB containment (metadata @> filter), backed by a GIN 
 
 Known limitation: update_document() does not currently preserve the original document's metadata - re-ingesting content via update_document() resets metadata to empty unless you pass it again yourself. Worth fixing in a follow-up if this trips anyone up.
 
+## Query rewriting
+
+Pass `query_rewrite=` to `ask()` to transform the query before it's embedded/searched - can improve retrieval quality, at the cost of one extra LLM call (or more, for `multi_query`). Grounded in established RAG research: HyDE (Gao et al. 2022), RAG-Fusion/multi-query (Rackauckas 2023).
+
+```python
+# Resolves follow-up questions using conversation history - needs session_id
+rag.ask("What about pricing?", session_id="s1", query_rewrite="contextual")
+
+# Generates a hypothetical answer and embeds that instead of the raw query
+rag.ask("What is RagLeap's pricing?", query_rewrite="hyde")
+
+# Generates alternative phrasings, retrieves for each, merges via Reciprocal Rank Fusion
+result = rag.ask("What is RagLeap's pricing?", query_rewrite="multi_query", multi_query_n=3)
+print(result["query_rewrite"])  # {"strategy": "multi_query", "query_variants": [...]}
+```
+
+Three strategies, each suited to a different problem:
+
+- **`"contextual"`** - rewrites a follow-up question ("what about its pricing?") into a standalone question using `session_id` conversation history. No-ops (uses the original query) if there's no history yet. One extra LLM call, no extra retrieval calls.
+- **`"hyde"`** - generates a hypothetical answer passage and embeds *that* instead of the raw query. Often a better semantic match than embedding a short question, since the hypothetical is closer in length/style to your actual corpus documents. One extra LLM call, no extra retrieval calls.
+- **`"multi_query"`** - generates `multi_query_n` alternative phrasings (default 3), retrieves separately for each, merges via Reciprocal Rank Fusion. Can improve recall by covering more of the query's "intent space" - but honestly, generated variants can be "nearly identical and lacking in diversity" (a documented limitation in the broader RAG-Fusion literature, not unique to this implementation), and it costs `multi_query_n` retrieval calls instead of one. If you want the cheap, fast option, use `"contextual"` or `"hyde"` instead.
+
+**The final answer generation always uses your original query, never the rewritten form** - rewriting only affects what gets retrieved, not what the model is asked to answer. Every strategy fails open: if the extra LLM call itself fails for any reason, retrieval proceeds with the original, unmodified query - a broken rewrite step can never break retrieval entirely.
+
+The result gains a `query_rewrite` field with the strategy used and what was actually retrieved-with (`rewritten_query`, `hyde_document`, or `query_variants`) whenever a strategy is set; it's absent entirely when `query_rewrite=` isn't passed, for backward compatibility. The extra LLM call's real token cost is recorded into the existing cost-tracking infrastructure (see Cost tracking), contributing to `cumulative_cost_usd`.
+
+Not currently supported on `ask_stream()`.
+
 ## Content sanitization
 
 ingest_text() sanitizes and screens content by default (sanitize=True, warn_on_injection_risk=True) - both can be disabled per call if you are already sanitizing upstream.

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.9.0"
+version = "0.10.0"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -26,6 +26,7 @@ from ragleap.embedding import EmbeddingService, EmbeddingConfig
 from ragleap.vectorstores import VectorBackend, PgVectorBackend
 from ragleap.generation import GenerationService, ProviderConfig
 from ragleap.cost import CostTracker
+from ragleap import query_rewrite as _query_rewrite
 from ragleap.guardrails import GuardrailViolation, run_guardrails
 from ragleap import evaluation as _evaluation
 from ragleap.observability import fire_event
@@ -44,7 +45,7 @@ from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult", "TranscriptionConfig", "VectorBackend", "PgVectorBackend"]
 
 
@@ -334,6 +335,8 @@ class RagLeap:
         rerank: bool = False,
         metadata_filter: Optional[Dict] = None,
         response_format: Optional[Dict] = None,
+        query_rewrite: Optional[str] = None,
+        multi_query_n: int = 3,
     ) -> Dict:
         """
         Answer a question grounded in previously ingested documents.
@@ -355,16 +358,77 @@ class RagLeap:
         still contains the JSON as a string either way, for backward
         compatibility with existing callers.
 
+        query_rewrite=<"contextual"|"hyde"|"multi_query"> improves
+        retrieval by transforming the query before it's embedded/
+        searched. "contextual" resolves follow-up questions ("what
+        about its pricing?") into standalone questions using session_id
+        history - needs session_id set, no-ops otherwise. "hyde"
+        generates a hypothetical answer and embeds that instead of the
+        raw query (Gao et al. 2022) - often better semantic match than
+        embedding a short question. "multi_query" generates
+        multi_query_n alternative phrasings, retrieves for each, and
+        merges via Reciprocal Rank Fusion - can improve recall, but
+        generated variants can be "nearly identical and lacking in
+        diversity" (a documented RAG-Fusion limitation, not unique to
+        this implementation), and costs multi_query_n retrieval calls
+        instead of one. Every strategy fails open: if the extra LLM
+        call itself fails, retrieval proceeds with the original query
+        unmodified - a broken rewrite step never breaks retrieval.
+        The final answer generation always uses your original query,
+        never the rewritten form - rewriting only affects what gets
+        retrieved. Result gains "query_rewrite" with the strategy used
+        and what was actually retrieved-with (rewritten_query,
+        hyde_document, or query_variants) when a strategy is set.
+
         Returns: {"answer": str, "sources": List[str], "provider_used": str,
                   "usage": dict|None, "chunks_sent": int}
         """
-        query_embedding = self._embed_query_cached(query)
+        history_prefix = self._memory.build_history_prompt(session_id) if session_id else ""
+
+        override_provider = (
+            self._budget_fallback
+            if (self._budget_fallback and self._cost_tracker.is_over_budget())
+            else None
+        )
+
+        query_rewrite_info = None
+        if query_rewrite == "contextual":
+            retrieval_query, rewrite_result = _query_rewrite.contextual_rewrite(self._generator, query, history_prefix, override_provider)
+            if rewrite_result is not None:
+                self._cost_tracker.record(rewrite_result.get("provider_used"), rewrite_result.get("model_used"), rewrite_result.get("usage"))
+            query_rewrite_info = {"strategy": "contextual", "rewritten_query": retrieval_query}
+            query_embedding = self._embed_query_cached(retrieval_query)
+        elif query_rewrite == "hyde":
+            hyde_text, rewrite_result = _query_rewrite.hyde_document(self._generator, query, override_provider)
+            if rewrite_result is not None:
+                self._cost_tracker.record(rewrite_result.get("provider_used"), rewrite_result.get("model_used"), rewrite_result.get("usage"))
+            query_rewrite_info = {"strategy": "hyde", "hyde_document": hyde_text}
+            query_embedding = self._embed_query_cached(hyde_text)
+        else:
+            query_embedding = self._embed_query_cached(query)
+
         if query_embedding is None:
             return {"answer": "Sorry, I couldn't process your question (embedding failed).",
                     "sources": [], "citations": [], "provider_used": None, "usage": None, "chunks_sent": 0}
 
         pool_size = top_k * 4 if rerank else top_k
-        if hybrid:
+
+        if query_rewrite == "multi_query":
+            variants, rewrite_result = _query_rewrite.multi_query_variants(self._generator, query, multi_query_n, override_provider)
+            if rewrite_result is not None:
+                self._cost_tracker.record(rewrite_result.get("provider_used"), rewrite_result.get("model_used"), rewrite_result.get("usage"))
+            query_rewrite_info = {"strategy": "multi_query", "query_variants": variants}
+            ranked_lists = []
+            for variant in variants:
+                variant_embedding = self._embed_query_cached(variant)
+                if variant_embedding is None:
+                    continue
+                if hybrid:
+                    ranked_lists.append(self._vector_backend.search_hybrid(variant, variant_embedding, top_k=pool_size, metadata_filter=metadata_filter))
+                else:
+                    ranked_lists.append(self._vector_backend.search_dense(variant_embedding, top_k=pool_size, metadata_filter=metadata_filter))
+            chunks = _query_rewrite.reciprocal_rank_fusion(ranked_lists)[:pool_size]
+        elif hybrid:
             chunks = self._vector_backend.search_hybrid(query, query_embedding, top_k=pool_size, metadata_filter=metadata_filter)
         else:
             chunks = self._vector_backend.search_dense(query_embedding, top_k=pool_size, metadata_filter=metadata_filter)
@@ -375,16 +439,8 @@ class RagLeap:
             chunks = self._reranker.rerank(query, chunks, top_k=top_k)
 
         fire_event(
-            {"query": query, "hybrid": hybrid, "rerank": rerank, "top_k": top_k, "chunks_retrieved": len(chunks), "streaming": False},
+            {"query": query, "hybrid": hybrid, "rerank": rerank, "top_k": top_k, "chunks_retrieved": len(chunks), "streaming": False, "query_rewrite": query_rewrite},
             self._on_query, "on_query",
-        )
-
-        history_prefix = self._memory.build_history_prompt(session_id) if session_id else ""
-
-        override_provider = (
-            self._budget_fallback
-            if (self._budget_fallback and self._cost_tracker.is_over_budget())
-            else None
         )
 
         result = self._generator.generate_answer(
@@ -392,6 +448,9 @@ class RagLeap:
             max_tokens=max_tokens, history_prefix=history_prefix,
             override_provider=override_provider, response_format=response_format,
         )
+
+        if query_rewrite_info is not None:
+            result["query_rewrite"] = query_rewrite_info
 
         cost_usd = self._cost_tracker.record(result.get("provider_used"), result.get("model_used"), result.get("usage"))
         result["cost"] = {

--- a/packages/ragleap-rag/src/ragleap/query_rewrite.py
+++ b/packages/ragleap-rag/src/ragleap/query_rewrite.py
@@ -1,0 +1,127 @@
+"""
+Query rewriting/expansion for ragleap-rag - three selectable strategies
+to improve retrieval quality. Grounded in established RAG research
+(HyDE - Gao et al. 2022; RAG-Fusion/multi-query - Rackauckas 2023) and
+current 2026 production practice - a cited production case study (mid-
+size SaaS customer support KB) used "query rewriting via a small LLM
+call" as part of a stack that cut wrong-answer rate from 22% to 4%.
+
+Honest limitation, stated plainly rather than oversold: multi_query's
+generated variants can be "nearly identical and lacking in diversity"
+(a documented finding in the broader RAG literature, not unique to
+this implementation) - it is not a guaranteed recall improvement, and
+it costs N retrieval calls instead of one. contextual and hyde each
+add exactly one extra LLM call and zero extra retrieval calls - if you
+want the cheap, fast option, use one of those instead.
+
+Every strategy fails open: if the rewrite LLM call itself fails for
+any reason, retrieval proceeds using the original, unmodified query -
+a broken rewrite step should never be able to break retrieval entirely.
+"""
+import logging
+from typing import Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+CONTEXTUAL_REWRITE_PROMPT = """Given the conversation history and a follow-up question, rewrite the follow-up question to be a standalone question that includes all necessary context from the history. Do not answer the question - only rewrite it. If the question is already standalone, return it unchanged. Respond with ONLY the rewritten question, nothing else.
+
+{history}
+Follow-up question: {query}
+
+Standalone question:"""
+
+HYDE_PROMPT = """Write a short, plausible passage that would answer the following question, as if it were an excerpt from a real document. Write confidently and specifically, even if you're not certain of the real answer - this passage is used only to improve document retrieval matching, it is never shown to the user.
+
+Question: {query}
+
+Passage:"""
+
+MULTI_QUERY_PROMPT = """Generate {n} different phrasings of the following question, capturing different angles or wordings a user might use to ask about the same underlying information need. Respond with ONLY the alternative questions, one per line, no numbering or extra text.
+
+Original question: {query}
+
+Alternative phrasings:"""
+
+
+def contextual_rewrite(generator, query: str, history_prefix: str, override_provider=None) -> Tuple[str, Optional[Dict]]:
+    """One extra LLM call: rewrites a (possibly ambiguous, pronoun-laden)
+    follow-up question into a standalone question using conversation
+    history. Falls back to the original query if there's no history to
+    rewrite against, or if the rewrite call fails for any reason.
+
+    Returns (query_to_use_for_retrieval, raw_generate_answer_result_or_None) -
+    the second element lets the caller record real token cost for this
+    call, or is None when no LLM call was made at all (no history).
+    """
+    if not history_prefix:
+        return query, None
+    prompt = CONTEXTUAL_REWRITE_PROMPT.format(history=history_prefix, query=query)
+    try:
+        result = generator.generate_answer(
+            query=prompt, chunks=[], history_prefix="", override_provider=override_provider,
+            system_prompt="Follow the instructions in the question below exactly. Do not add commentary, explanation, or a preamble - respond with only what was asked for.",
+        )
+        rewritten = (result.get("answer") or "").strip()
+        return (rewritten if rewritten else query), result
+    except Exception as e:
+        logger.warning(f"Contextual query rewrite failed, using original query for retrieval: {e}")
+        return query, None
+
+
+def hyde_document(generator, query: str, override_provider=None) -> Tuple[str, Optional[Dict]]:
+    """One extra LLM call: generates a hypothetical answer passage to
+    embed instead of the raw query for retrieval - HyDE (Gao et al.
+    2022). Falls back to the original query text on failure.
+
+    Returns (text_to_embed_for_retrieval, raw_generate_answer_result_or_None).
+    """
+    prompt = HYDE_PROMPT.format(query=query)
+    try:
+        result = generator.generate_answer(
+            query=prompt, chunks=[], history_prefix="", override_provider=override_provider,
+            system_prompt="Follow the instructions in the question below exactly. Do not add commentary, explanation, or a preamble - respond with only what was asked for.",
+        )
+        hypothetical = (result.get("answer") or "").strip()
+        return (hypothetical if hypothetical else query), result
+    except Exception as e:
+        logger.warning(f"HyDE passage generation failed, using original query for retrieval: {e}")
+        return query, None
+
+
+def multi_query_variants(generator, query: str, n: int = 3, override_provider=None) -> Tuple[List[str], Optional[Dict]]:
+    """One extra LLM call: generates up to n alternative phrasings of
+    the query. Always includes the original query as the first variant.
+    Falls back to [query] alone on failure.
+
+    Returns (list_of_query_variants, raw_generate_answer_result_or_None).
+    """
+    prompt = MULTI_QUERY_PROMPT.format(n=n, query=query)
+    try:
+        result = generator.generate_answer(
+            query=prompt, chunks=[], history_prefix="", override_provider=override_provider,
+            system_prompt="Follow the instructions in the question below exactly. Do not add commentary, explanation, or a preamble - respond with only what was asked for.",
+        )
+        lines = [line.strip(" -*\t") for line in (result.get("answer") or "").splitlines()]
+        lines = [line for line in lines if line]
+        variants = [query] + [line for line in lines if line.lower() != query.lower()]
+        return variants[:n] if len(variants) > n else variants, result
+    except Exception as e:
+        logger.warning(f"Multi-query generation failed, using original query only: {e}")
+        return [query], None
+
+
+def reciprocal_rank_fusion(ranked_lists: List[List[Dict]], k: int = 60) -> List[Dict]:
+    """Merges multiple ranked chunk lists into one, using Reciprocal
+    Rank Fusion (Cormack, Clarke, Buettcher 2009) - the standard merge
+    technique for multi-query/RAG-Fusion retrieval. Deduplicates by
+    chunk_id (falling back to (document_id, chunk_index) if a backend
+    doesn't populate chunk_id)."""
+    scores: Dict = {}
+    chunk_by_key: Dict = {}
+    for ranked_list in ranked_lists:
+        for rank, chunk in enumerate(ranked_list):
+            key = chunk.get("chunk_id") or (chunk.get("document_id"), chunk.get("chunk_index"))
+            scores[key] = scores.get(key, 0.0) + 1.0 / (k + rank + 1)
+            chunk_by_key.setdefault(key, chunk)
+    ranked_keys = sorted(scores.keys(), key=lambda key: scores[key], reverse=True)
+    return [chunk_by_key[key] for key in ranked_keys]

--- a/packages/ragleap-rag/tests/test_query_rewrite.py
+++ b/packages/ragleap-rag/tests/test_query_rewrite.py
@@ -1,0 +1,214 @@
+"""Tests for query rewriting/expansion (contextual, hyde, multi_query).
+Live semantic verification (real Gemini calls proving contextual
+rewrite correctly resolves pronouns, HyDE generates on-topic passages,
+multi_query produces genuinely distinct phrasings) was done manually
+this session and is documented in CHANGELOG - not automated into CI
+since it needs a real, currently-valid API key CI doesn't have.
+
+This file covers: isolated unit tests for ragleap.query_rewrite's
+functions (using a lightweight stub generator for deterministic
+control, not real GenerationService), fail-open behavior when the
+rewrite LLM call itself raises, and plumbing tests proving
+query_rewrite= flows correctly through ask() end-to-end via the
+existing fake_call_provider/fake_embedder fixtures."""
+import pytest
+from ragleap import RagLeap, ProviderConfig, EmbeddingConfig
+from ragleap.query_rewrite import (
+    contextual_rewrite, hyde_document, multi_query_variants, reciprocal_rank_fusion,
+)
+from conftest import TEST_DATABASE_URL, TEST_DIMENSIONS
+
+
+def _make_rag(**kwargs):
+    return RagLeap(
+        database_url=TEST_DATABASE_URL,
+        embedder=EmbeddingConfig(provider="gemini", model="models/gemini-embedding-001", dimensions=TEST_DIMENSIONS, api_key="fake-test-key"),
+        primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="fake-test-key"),
+        **kwargs,
+    )
+
+
+class _StubGenerator:
+    """A minimal stand-in for GenerationService with full control over
+    what generate_answer() returns or raises - lets the unit tests below
+    assert on exact rewrite logic without depending on the real fake
+    fixture's canned prompt-echo behavior."""
+    def __init__(self, answer=None, raises=None):
+        self._answer = answer
+        self._raises = raises
+        self.calls = []
+
+    def generate_answer(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._raises:
+            raise self._raises
+        return {"answer": self._answer, "provider_used": "gemini", "model_used": "gemini-3.6-flash", "usage": {"prompt_tokens": 10, "completion_tokens": 5}}
+
+
+# --- contextual_rewrite ---
+
+def test_contextual_rewrite_no_history_returns_original_query_no_call():
+    gen = _StubGenerator(answer="should never be used")
+    result, raw = contextual_rewrite(gen, "What about pricing?", history_prefix="")
+    assert result == "What about pricing?"
+    assert raw is None
+    assert len(gen.calls) == 0
+
+
+def test_contextual_rewrite_with_history_calls_generator_and_returns_rewrite():
+    gen = _StubGenerator(answer="What is RagLeap's pricing?")
+    result, raw = contextual_rewrite(gen, "What about pricing?", history_prefix="User: What is RagLeap?\n")
+    assert result == "What is RagLeap's pricing?"
+    assert raw is not None
+    assert len(gen.calls) == 1
+
+
+def test_contextual_rewrite_fails_open_on_generator_error():
+    gen = _StubGenerator(raises=RuntimeError("provider down"))
+    result, raw = contextual_rewrite(gen, "What about pricing?", history_prefix="some history")
+    assert result == "What about pricing?"  # falls back to original
+    assert raw is None
+
+
+def test_contextual_rewrite_empty_answer_falls_back_to_original():
+    gen = _StubGenerator(answer="")
+    result, raw = contextual_rewrite(gen, "What about pricing?", history_prefix="some history")
+    assert result == "What about pricing?"
+
+
+# --- hyde_document ---
+
+def test_hyde_document_returns_hypothetical_passage():
+    gen = _StubGenerator(answer="Paris is the capital of France, located on the Seine.")
+    result, raw = hyde_document(gen, "What is the capital of France?")
+    assert result == "Paris is the capital of France, located on the Seine."
+    assert raw is not None
+
+
+def test_hyde_document_fails_open_on_generator_error():
+    gen = _StubGenerator(raises=RuntimeError("provider down"))
+    result, raw = hyde_document(gen, "What is the capital of France?")
+    assert result == "What is the capital of France?"
+    assert raw is None
+
+
+# --- multi_query_variants ---
+
+def test_multi_query_variants_includes_original_first():
+    gen = _StubGenerator(answer="Which accounts support password changes?\nHow to change my login credentials?")
+    variants, raw = multi_query_variants(gen, "How do I reset my password?", n=3)
+    assert variants[0] == "How do I reset my password?"
+    assert len(variants) == 3
+    assert raw is not None
+
+
+def test_multi_query_variants_deduplicates_case_insensitively():
+    gen = _StubGenerator(answer="how do i reset my password?\nA genuinely different phrasing.")
+    variants, raw = multi_query_variants(gen, "How do I reset my password?", n=3)
+    # the case-insensitive duplicate of the original should be filtered out
+    assert variants.count("How do I reset my password?") == 1
+    assert "A genuinely different phrasing." in variants
+
+
+def test_multi_query_variants_fails_open_to_original_only():
+    gen = _StubGenerator(raises=RuntimeError("provider down"))
+    variants, raw = multi_query_variants(gen, "How do I reset my password?", n=3)
+    assert variants == ["How do I reset my password?"]
+    assert raw is None
+
+
+# --- reciprocal_rank_fusion ---
+
+def test_rrf_ranks_items_in_multiple_lists_higher():
+    list1 = [{"chunk_id": "a"}, {"chunk_id": "b"}]
+    list2 = [{"chunk_id": "b"}, {"chunk_id": "c"}]
+    merged = reciprocal_rank_fusion([list1, list2])
+    assert merged[0]["chunk_id"] == "b"  # appears in both lists, ranked highest
+
+
+def test_rrf_deduplicates_by_chunk_id():
+    list1 = [{"chunk_id": "a"}, {"chunk_id": "a"}]
+    merged = reciprocal_rank_fusion([list1])
+    assert len(merged) == 1
+
+
+def test_rrf_falls_back_to_document_id_chunk_index_when_no_chunk_id():
+    list1 = [{"document_id": "doc1", "chunk_index": 0}]
+    list2 = [{"document_id": "doc1", "chunk_index": 0}]
+    merged = reciprocal_rank_fusion([list1, list2])
+    assert len(merged) == 1  # correctly deduplicated via the fallback key
+
+
+def test_rrf_empty_lists_returns_empty():
+    assert reciprocal_rank_fusion([]) == []
+    assert reciprocal_rank_fusion([[], []]) == []
+
+
+# --- Plumbing tests: query_rewrite= flows through ask() correctly ---
+
+def test_ask_without_query_rewrite_has_no_query_rewrite_key():
+    rag = _make_rag()
+    rag.ingest_text("a.txt", "Some content about testing things.")
+    result = rag.ask("A question")
+    assert "query_rewrite" not in result
+
+
+def test_ask_with_contextual_rewrite_needs_session_id_to_do_anything():
+    """No session_id means no history means contextual_rewrite makes no
+    LLM call and query_rewrite_info still gets set (strategy recorded),
+    but rewritten_query equals the original since there's nothing to
+    rewrite against."""
+    rag = _make_rag()
+    rag.ingest_text("a.txt", "Some content about testing things.")
+    result = rag.ask("A question", query_rewrite="contextual")
+    assert result["query_rewrite"]["strategy"] == "contextual"
+    assert result["query_rewrite"]["rewritten_query"] == "A question"
+
+
+def test_ask_with_hyde_returns_hyde_document_field():
+    rag = _make_rag()
+    rag.ingest_text("a.txt", "Some content about testing things.")
+    result = rag.ask("A question", query_rewrite="hyde")
+    assert result["query_rewrite"]["strategy"] == "hyde"
+    assert "hyde_document" in result["query_rewrite"]
+    assert isinstance(result["query_rewrite"]["hyde_document"], str)
+    assert len(result["query_rewrite"]["hyde_document"]) > 0
+
+
+def test_ask_with_multi_query_returns_variants_and_retrieves():
+    rag = _make_rag()
+    rag.ingest_text("a.txt", "Some content about testing things.")
+    result = rag.ask("A question", query_rewrite="multi_query", multi_query_n=2)
+    assert result["query_rewrite"]["strategy"] == "multi_query"
+    assert isinstance(result["query_rewrite"]["query_variants"], list)
+    assert len(result["query_rewrite"]["query_variants"]) >= 1
+    assert result["query_rewrite"]["query_variants"][0] == "A question"
+    # the actual answer must still be grounded in real retrieval, not empty
+    assert result["chunks_sent"] >= 1
+
+
+def test_ask_final_answer_always_uses_original_query_not_rewritten():
+    """The rewrite only affects what gets retrieved, never what's shown
+    to the generation model as the actual question being answered -
+    this test locks in that contract."""
+    rag = _make_rag()
+    rag.ingest_text("a.txt", "Some content about testing things.")
+    result = rag.ask("What testing things exist?", query_rewrite="hyde")
+    # fake_call_provider echoes the prompt tail, so we can confirm the
+    # real user question (not the hyde passage) ended up in the final prompt
+    assert "What testing things exist?" in result["answer"]
+
+
+def test_ask_query_rewrite_cost_contributes_to_cumulative_spend():
+    """The extra rewrite LLM call should be recorded into cumulative
+    cost tracking, using the same CostTracker infrastructure as the
+    main answer-generation call."""
+    rag = _make_rag()
+    rag.ingest_text("a.txt", "Some content.")
+    rag.ask("A question", session_id="s1")  # seed history
+    without_rewrite = rag.ask("A question", session_id="s1")
+    with_rewrite = rag.ask("A follow-up question", session_id="s1", query_rewrite="contextual")
+    # two answer-generation calls' worth of cost plus one extra rewrite
+    # call's worth - cumulative after the rewrite call must exceed what
+    # it would be from answer-generation calls alone
+    assert with_rewrite["cost"]["cumulative_cost_usd"] > without_rewrite["cost"]["cumulative_cost_usd"]


### PR DESCRIPTION
…0.0)

- query_rewrite= on ask(): 'contextual' (resolves follow-up questions using session history), 'hyde' (Gao et al. 2022 - embeds a generated hypothetical answer instead of the raw query), 'multi_query' (Rackauckas 2023 RAG-Fusion - N alternative phrasings, retrieve each, merge via Reciprocal Rank Fusion)
- New ragleap.query_rewrite module: contextual_rewrite(), hyde_document(), multi_query_variants(), reciprocal_rank_fusion()
- LIVE-VERIFIED with real Gemini calls: contextual correctly resolved 'it' -> 'RagLeap', HyDE generated an on-topic hypothetical passage, multi_query produced 3 genuinely distinct phrasings all retrieving the correct chunk, RRF correctly ranked the doubly-retrieved chunk first. Full ask() integration verified end-to-end (real embeddings, real FAISS retrieval, real generation) for all 3 strategies plus the no-rewrite backward-compat path.
- Honest limitation documented: multi_query variants can be 'nearly identical and lacking in diversity' per the broader RAG-Fusion literature, and costs multi_query_n retrieval calls instead of one - contextual/hyde are the cheap, fast options
- Every strategy fails open: rewrite LLM call failure falls back to the original unmodified query, never breaks retrieval
- Final answer generation always uses the original query, never the rewritten form - rewriting only affects what gets retrieved
- Rewrite call cost recorded into existing CostTracker infrastructure
- Result gains query_rewrite field only when query_rewrite= is passed - absent otherwise, backward compatible
- Not supported on ask_stream()
- 19 new tests (159 -> 178 passing)

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
