### PR TITLE
feat: PineconeBackend - real implementation, not a claim (v0.10.1)

### DIFF
--- a/packages/ragleap-rag/CHANGELOG.md
+++ b/packages/ragleap-rag/CHANGELOG.md
@@ -8,6 +8,21 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `docs`: Celery integration guide + runnable example ([#57](https://github.com/antonyrag/ragleap-core/pull/57))
 - `test`: comprehensive pytest suite (67 tests) + CI integration — first automated testing this package has had ([#58](https://github.com/antonyrag/ragleap-core/pull/58))
 
+## [0.10.1]
+
+### Added
+
+- `PineconeBackend` - a real, working implementation of the `VectorBackend` interface for Pinecone's managed serverless vector database, following the same SQLite-sidecar pattern as `FAISSBackend`. New `[pinecone]` extra.
+- Every attribute path used (`IndexList.names`, `IndexStatus.ready`, `ScoredVector.id`/`.score`, `Pinecone.Index(host=...)`) was verified directly against the actual installed `pinecone==9.1.0` package's real source code during development - not assumed from documentation or memory. This caught a real bug before it shipped: an early draft used dict-style access (`idx["name"]`, `status.get("ready")`) that would have failed at runtime, since the SDK's response objects are `msgspec.Struct`s requiring attribute access throughout, not dicts.
+- **Not live-verified** against a real Pinecone account (none was available) - 20 tests cover constructor validation, pure helper functions, SQLite CRUD in isolation, and mocked-client interaction tests (confirming the right SDK methods get called with the right arguments), but none of this is a substitute for a real end-to-end run against Pinecone's actual service.
+- Deliberate design choice: `persist_directory=` is **required**, not optional like `FAISSBackend`'s - Pinecone vectors persist remotely regardless of local process state, so an in-memory-only SQLite sidecar would create orphaned vectors (searchable in Pinecone, with no matching text) the instant the process restarts.
+- `metadata_filter` uses Pinecone's real native filtering (translated to its `$eq` syntax), not a post-filter like `FAISSBackend` has to do - the caller-supplied metadata dict is stored in Pinecone's own vector metadata, not just SQLite.
+- Serverless index creation readiness is polled with a 60s timeout - a well-documented Pinecone requirement (indexes aren't instantly queryable after creation) that's easy to miss.
+
+### Corrected
+
+- Prior CHANGELOG entries (v0.7.0) and README text referenced "the same caveat already attached to the Pinecone vector backend" - **this was inaccurate**. No Pinecone backend existed in the codebase at that time; the phrase was carried over from an earlier, unverified project-planning document (the original session handoff) that had incorrectly described Pinecone as "code-complete but unverified" when it had, in fact, never been built. Historical CHANGELOG entries are left as-written (a changelog is a historical record, not silently rewritten after the fact), but README.md - being living documentation, not a historical record - has been corrected to reflect that `PineconeBackend` now genuinely exists as of this release.
+
 ## [0.10.0]
 
 ### Added

--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -62,8 +62,20 @@ Currently available:
 |---|---|---|---|
 | `PgVectorBackend` (default) | none needed | Yes - real Postgres full-text search | Battle-tested, the original implementation |
 | `FAISSBackend` | `pip install ragleap-rag[faiss]` | No - `ask(hybrid=True)` gracefully degrades to dense-only | Local, in-process, no API key. Pass `persist_directory=` for data that survives restarts - without it, everything is in-memory and lost on process exit. Metadata filtering is a post-filter (over-fetch then filter), not an indexed query - fine for small-to-medium datasets, less efficient than pgvector's JSONB GIN index at large scale. |
+| `PineconeBackend` | `pip install ragleap-rag[pinecone]` | No - `ask(hybrid=True)` gracefully degrades to dense-only | Managed, serverless. **Not live-verified** - no Pinecone account was available during development; code-complete against the real installed SDK's actual source (not just docs), but treat as best-effort until confirmed live. `persist_directory=` is **required** (not optional like FAISS) - Pinecone vectors persist remotely regardless of local state, so a SQLite sidecar for chunk text is mandatory to avoid orphaned vectors after a restart. `metadata_filter` uses Pinecone's real native filtering, not a post-filter. |
 
-More backends (Pinecone, Weaviate, Qdrant, Milvus) are planned - see the project roadmap. Building your own is straightforward: implement the `ragleap.vectorstores.VectorBackend` abstract interface (`init_schema`, `insert_document`, `insert_chunk`, `search_dense`, `list_documents`, `delete_document`, `get_document_filename`, and optionally `search_sparse`/`search_hybrid`/`supports_sparse` if your backend can do keyword search).
+```python
+from ragleap.vectorstores import PineconeBackend
+
+rag = RagLeap(
+    database_url="postgresql://user:pass@localhost/mydb",
+    vector_backend=PineconeBackend(persist_directory="./pinecone_meta", api_key="...", index_name="my-index"),
+    embedder=EmbeddingConfig(provider="gemini", model="models/gemini-embedding-001", dimensions=3072, api_key="..."),
+    primary=ProviderConfig(provider="gemini", model="gemini-3.6-flash", api_key="..."),
+)
+```
+
+More backends (Weaviate, Qdrant, Milvus) are planned - see the project roadmap. Building your own is straightforward: implement the `ragleap.vectorstores.VectorBackend` abstract interface (`init_schema`, `insert_document`, `insert_chunk`, `search_dense`, `list_documents`, `delete_document`, `get_document_filename`, and optionally `search_sparse`/`search_hybrid`/`supports_sparse` if your backend can do keyword search).
 
 ## The three things that matter
 
@@ -652,7 +664,7 @@ Gemini, OpenAI, Mistral, Together, and Ollama (all OpenAI-compatible under the h
 
 **`model=` and `dimensions=` are always required** for every embedding provider (constructor arg or env var, e.g. `GEMINI_EMBEDDING_MODEL`/`EMBEDDING_DIMENSIONS`) - same reasoning as generation providers above. `dimensions=` in particular can't be safely inferred without assuming a specific model, so it's mandatory everywhere now, not just for `together` (which set this precedent from the start).
 
-**Live-verification status**, following this project's own standard of testing against real infrastructure before calling anything done: `gemini` and `openai` are long-verified. `ollama` was live-verified this release — fully local, no API key, tested end-to-end through real ingestion + real FAISS retrieval. `mistral`, `together`, `cohere`, and `voyage` are code-complete based on public API documentation but **not live-verified** against a real account (the same caveat already attached to the Pinecone vector backend).
+**Live-verification status**, following this project's own standard of testing against real infrastructure before calling anything done: `gemini` and `openai` are long-verified. `ollama` was live-verified this release — fully local, no API key, tested end-to-end through real ingestion + real FAISS retrieval. `mistral`, `together`, `cohere`, and `voyage` are code-complete based on public API documentation but **not live-verified** against a real account - the same category of caveat as the `PineconeBackend` vector backend (see Vector backends above).
 
 `provider="custom"` + `base_url=...` reaches any OpenAI-compatible embeddings endpoint not otherwise named above - a self-hosted server (vLLM, LM Studio, etc.), or a provider without dedicated code here yet. Several Chinese providers - Qwen/DashScope, Zhipu/GLM, Moonshot/Kimi - ship OpenAI-compatible modes and work via this path today. Mirrors `generation.py`'s existing `provider="custom"` support for chat models.
 

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.10.0"
+version = "0.10.1"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"
@@ -39,6 +39,7 @@ anthropic = ["anthropic>=0.34.0"]
 openai = ["openai>=1.40.0"]
 rerank = ["onnxruntime>=1.17.0", "tokenizers>=0.19.0", "huggingface_hub>=0.20.0"]
 faiss = ["faiss-cpu>=1.8.0"]
+pinecone = ["pinecone>=5.0.0"]
 structured = ["jsonschema>=4.0.0"]
 web = ["trafilatura>=1.6.0"]
 ocr = ["pytesseract>=0.3.10", "Pillow>=10.0.0"]
@@ -54,7 +55,7 @@ formats = [
     "pyyaml>=6.0",
     "pyarrow>=14.0.0",
 ]
-all = ["google-genai>=0.3.0", "anthropic>=0.34.0", "openai>=1.40.0", "onnxruntime>=1.17.0", "tokenizers>=0.19.0", "huggingface_hub>=0.20.0", "faiss-cpu>=1.8.0", "trafilatura>=1.6.0", "pytesseract>=0.3.10", "Pillow>=10.0.0", "redis>=5.0.0", "openpyxl>=3.1.0", "xlrd>=2.0.0", "python-pptx>=1.0.0", "odfpy>=1.4.0", "striprtf>=0.0.26", "beautifulsoup4>=4.12.0", "ebooklib>=0.18", "pyyaml>=6.0", "pyarrow>=14.0.0", "jsonschema>=4.0.0"]
+all = ["google-genai>=0.3.0", "anthropic>=0.34.0", "openai>=1.40.0", "onnxruntime>=1.17.0", "tokenizers>=0.19.0", "huggingface_hub>=0.20.0", "faiss-cpu>=1.8.0", "trafilatura>=1.6.0", "pytesseract>=0.3.10", "Pillow>=10.0.0", "redis>=5.0.0", "openpyxl>=3.1.0", "xlrd>=2.0.0", "python-pptx>=1.0.0", "odfpy>=1.4.0", "striprtf>=0.0.26", "beautifulsoup4>=4.12.0", "ebooklib>=0.18", "pyyaml>=6.0", "pyarrow>=14.0.0", "jsonschema>=4.0.0", "pinecone>=5.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/antonyrag/ragleap-core"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -45,7 +45,7 @@ from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult", "TranscriptionConfig", "VectorBackend", "PgVectorBackend"]
 
 

--- a/packages/ragleap-rag/src/ragleap/vectorstores/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/vectorstores/__init__.py
@@ -8,3 +8,9 @@ try:
     __all__.append("FAISSBackend")
 except ImportError:
     pass  # faiss extra not installed - FAISSBackend simply unavailable, not an error
+
+try:
+    from ragleap.vectorstores.pinecone_backend import PineconeBackend
+    __all__.append("PineconeBackend")
+except ImportError:
+    pass  # pinecone extra not installed - PineconeBackend simply unavailable, not an error

--- a/packages/ragleap-rag/src/ragleap/vectorstores/pinecone_backend.py
+++ b/packages/ragleap-rag/src/ragleap/vectorstores/pinecone_backend.py
@@ -1,0 +1,240 @@
+"""
+Pinecone-backed vector storage for ragleap-rag - a managed, serverless
+vector database.
+
+**NOT LIVE-VERIFIED** - no Pinecone account was available to test
+against during development (same honest caveat already applied to
+Mistral/Together/Cohere/Voyage AI in the embedding module). This is
+code-complete based on Pinecone's public Python SDK v3 documentation,
+confirmed current via live web search during development (not from
+possibly-stale training data - Pinecone's SDK has changed significantly
+across versions: pod-based -> serverless, multiple client rewrites).
+Treat this backend as best-effort until confirmed live by someone with
+a real account.
+
+Design notes:
+- Like FAISSBackend, a SQLite sidecar stores full chunk text and the
+  document registry - Pinecone caps vector metadata at 40KB and has no
+  native "list all documents" query, so full text was never a good fit
+  for Pinecone metadata anyway.
+- Unlike FAISSBackend, persist_directory= is REQUIRED, not optional.
+  Pinecone vectors persist remotely regardless of local process state -
+  an in-memory-only SQLite sidecar would create orphaned vectors
+  (searchable in Pinecone, but with no matching text) the moment the
+  process restarts. Requiring persistence here avoids that footgun.
+- The caller-supplied metadata dict is stored natively in Pinecone's
+  vector metadata (not just SQLite), so metadata_filter uses Pinecone's
+  real native filtering - not a post-filter like FAISSBackend has to do.
+- Serverless indexes are not instantly queryable after creation -
+  init_schema() polls readiness with a timeout, a well-documented
+  Pinecone requirement that's easy to miss and would cause confusing
+  failures on first use if skipped.
+"""
+import json
+import logging
+import os
+import sqlite3
+import threading
+import time
+from typing import Dict, List, Optional
+
+from ragleap.vectorstores.base import VectorBackend
+
+logger = logging.getLogger(__name__)
+
+
+class PineconeBackend(VectorBackend):
+    def __init__(
+        self,
+        persist_directory: str,
+        api_key: Optional[str] = None,
+        index_name: str = "ragleap",
+        cloud: str = "aws",
+        region: str = "us-east-1",
+    ):
+        try:
+            import pinecone  # noqa: F401
+        except ImportError as e:
+            raise ImportError(
+                "PineconeBackend requires the 'pinecone' extra: pip install ragleap-rag[pinecone]"
+            ) from e
+
+        if not persist_directory:
+            raise ValueError(
+                "PineconeBackend requires persist_directory= - unlike FAISSBackend, "
+                "this cannot be optional. Pinecone vectors persist remotely regardless "
+                "of local state; without a persistent SQLite sidecar for chunk text, "
+                "a process restart would leave searchable vectors with no matching text."
+            )
+
+        self.api_key = api_key or os.environ.get("PINECONE_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "No API key for PineconeBackend. Pass api_key= explicitly, or set "
+                "PINECONE_API_KEY in your environment."
+            )
+
+        self.index_name = index_name
+        self.cloud = cloud
+        self.region = region
+        self.persist_directory = persist_directory
+        self._pc = None
+        self._index = None
+        self._dimensions = None
+        self._lock = threading.Lock()
+
+        os.makedirs(persist_directory, exist_ok=True)
+        self._sqlite_path = os.path.join(persist_directory, "pinecone_meta.sqlite3")
+        self._conn = sqlite3.connect(self._sqlite_path, check_same_thread=False)
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS documents (
+                id TEXT PRIMARY KEY, filename TEXT NOT NULL, metadata TEXT NOT NULL, uploaded_at TEXT NOT NULL
+            )"""
+        )
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS chunks (
+                vector_id TEXT PRIMARY KEY, document_id TEXT NOT NULL,
+                document_name TEXT NOT NULL, chunk_index INTEGER NOT NULL,
+                text TEXT NOT NULL, token_count INTEGER, metadata TEXT NOT NULL
+            )"""
+        )
+        self._conn.commit()
+
+    def init_schema(self, dimensions: int) -> None:
+        from pinecone import Pinecone, ServerlessSpec
+
+        self._dimensions = dimensions
+        self._pc = Pinecone(api_key=self.api_key)
+
+        # IndexList.names is the real field (verified against the installed
+        # pinecone SDK's actual source - list_indexes() returns a msgspec
+        # Struct, not a plain list of dicts, and attribute access is
+        # required throughout, not .get()/dict-subscript).
+        existing = self._pc.list_indexes().names
+        if self.index_name not in existing:
+            logger.info(f"PineconeBackend: creating serverless index '{self.index_name}' (dimensions={dimensions})")
+            self._pc.create_index(
+                name=self.index_name,
+                dimension=dimensions,
+                metric="cosine",
+                spec=ServerlessSpec(cloud=self.cloud, region=self.region),
+            )
+            # Serverless indexes are not instantly queryable - poll readiness,
+            # a well-documented Pinecone requirement, not optional. status is
+            # an IndexStatus struct with a real .ready attribute.
+            deadline = time.time() + 60
+            while time.time() < deadline:
+                status = self._pc.describe_index(self.index_name).status
+                if status.ready:
+                    break
+                time.sleep(2)
+            else:
+                logger.warning(
+                    f"PineconeBackend: index '{self.index_name}' did not report ready "
+                    f"within 60s - proceeding anyway, but early queries may fail."
+                )
+        else:
+            logger.info(f"PineconeBackend: using existing index '{self.index_name}'")
+
+        host = self._pc.describe_index(self.index_name).host
+        self._index = self._pc.Index(host=host)
+
+    def _vector_id(self, document_id: str, chunk_index: int) -> str:
+        return f"{document_id}:{chunk_index}"
+
+    def _build_filter(self, metadata_filter: Optional[Dict]) -> Optional[Dict]:
+        if not metadata_filter:
+            return None
+        return {k: {"$eq": v} for k, v in metadata_filter.items()}
+
+    def insert_document(self, document_id: str, filename: str, metadata: Dict) -> None:
+        import datetime
+        with self._lock:
+            self._conn.execute(
+                "INSERT INTO documents (id, filename, metadata, uploaded_at) VALUES (?, ?, ?, ?)",
+                (document_id, filename, json.dumps(metadata or {}), datetime.datetime.utcnow().isoformat()),
+            )
+            self._conn.commit()
+
+    def insert_chunk(
+        self, document_id: str, document_name: str, chunk_index: int,
+        text: str, token_count: int, embedding: List[float], metadata: Dict,
+    ) -> None:
+        vector_id = self._vector_id(document_id, chunk_index)
+        with self._lock:
+            self._conn.execute(
+                "INSERT INTO chunks (vector_id, document_id, document_name, chunk_index, text, token_count, metadata) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (vector_id, document_id, document_name, chunk_index, text, token_count, json.dumps(metadata or {})),
+            )
+            self._conn.commit()
+
+            pinecone_metadata = {
+                "document_id": document_id, "document_name": document_name,
+                "chunk_index": chunk_index, **(metadata or {}),
+            }
+            self._index.upsert(vectors=[(vector_id, embedding, pinecone_metadata)])
+
+    def search_dense(self, embedding: List[float], top_k: int, metadata_filter: Optional[Dict] = None) -> List[Dict]:
+        if not embedding or self._index is None:
+            return []
+        if self._dimensions and len(embedding) != self._dimensions:
+            logger.warning(f"Query embedding dim={len(embedding)} != expected {self._dimensions}; skipping search")
+            return []
+
+        response = self._index.query(
+            vector=embedding, top_k=top_k, include_metadata=False,
+            filter=self._build_filter(metadata_filter),
+        )
+
+        results = []
+        for match in response.matches:
+            row = self._conn.execute(
+                "SELECT document_id, document_name, chunk_index, text FROM chunks WHERE vector_id = ?",
+                (match.id,),
+            ).fetchone()
+            if row is None:
+                # Orphaned vector - present in Pinecone but its text row is
+                # missing locally (e.g. SQLite sidecar was deleted/moved
+                # without also clearing the remote index). Skip rather than
+                # crash or return a chunk with no text.
+                logger.warning(f"PineconeBackend: vector '{match.id}' has no matching local text row, skipping")
+                continue
+            document_id, document_name, chunk_index, text = row
+            results.append({
+                "chunk_id": match.id, "text": text, "similarity_score": round(float(match.score), 4),
+                "document_id": document_id, "document_name": document_name, "chunk_index": chunk_index,
+            })
+        return results
+
+    def supports_sparse(self) -> bool:
+        return False
+
+    def list_documents(self, limit: int, offset: int) -> List[Dict]:
+        rows = self._conn.execute(
+            """SELECT d.id, d.filename, d.uploaded_at, d.metadata, COUNT(c.vector_id) AS chunk_count
+               FROM documents d LEFT JOIN chunks c ON c.document_id = d.id
+               GROUP BY d.id ORDER BY d.uploaded_at DESC LIMIT ? OFFSET ?""",
+            (limit, offset),
+        ).fetchall()
+        return [
+            {"document_id": r[0], "filename": r[1], "uploaded_at": r[2], "metadata": json.loads(r[3]), "chunk_count": r[4]}
+            for r in rows
+        ]
+
+    def delete_document(self, document_id: str) -> bool:
+        with self._lock:
+            vector_ids = [r[0] for r in self._conn.execute(
+                "SELECT vector_id FROM chunks WHERE document_id = ?", (document_id,)
+            ).fetchall()]
+            if vector_ids and self._index is not None:
+                self._index.delete(ids=vector_ids)
+            cur = self._conn.execute("DELETE FROM documents WHERE id = ?", (document_id,))
+            self._conn.execute("DELETE FROM chunks WHERE document_id = ?", (document_id,))
+            deleted = cur.rowcount > 0
+            self._conn.commit()
+        return deleted
+
+    def get_document_filename(self, document_id: str) -> Optional[str]:
+        row = self._conn.execute("SELECT filename FROM documents WHERE id = ?", (document_id,)).fetchone()
+        return row[0] if row else None

--- a/packages/ragleap-rag/tests/test_pinecone_backend.py
+++ b/packages/ragleap-rag/tests/test_pinecone_backend.py
@@ -1,0 +1,267 @@
+"""Tests for PineconeBackend - NOT live-verified against a real Pinecone
+account (same honest caveat as mistral/together/cohere/voyage embedding
+providers). These tests mock the actual Pinecone client entirely and
+verify: (1) constructor validation, (2) pure helper functions, (3) the
+SQLite sidecar's CRUD correctness in isolation, and (4) that the right
+Pinecone SDK methods get called with the right arguments and the right
+attribute-access pattern (not dict-style) - every attribute path used
+here (IndexList.names, IndexStatus.ready, ScoredVector.id/.score) was
+verified against the actual installed pinecone==9.1.0 package's real
+source code during development, not assumed from documentation alone."""
+import pytest
+from unittest.mock import MagicMock, patch
+
+pinecone_available = True
+try:
+    import pinecone  # noqa: F401
+except ImportError:
+    pinecone_available = False
+
+pytestmark = pytest.mark.skipif(not pinecone_available, reason="pinecone package not installed")
+
+
+# --- Constructor validation ---
+
+def test_requires_persist_directory(tmp_path):
+    from ragleap.vectorstores.pinecone_backend import PineconeBackend
+    with pytest.raises(ValueError, match="requires persist_directory"):
+        PineconeBackend(persist_directory="", api_key="fake-key")
+
+
+def test_requires_api_key(tmp_path):
+    from ragleap.vectorstores.pinecone_backend import PineconeBackend
+    with pytest.raises(ValueError, match="No API key"):
+        PineconeBackend(persist_directory=str(tmp_path / "pc_data"), api_key=None)
+
+
+def test_api_key_from_env_var(tmp_path, monkeypatch):
+    monkeypatch.setenv("PINECONE_API_KEY", "env-key")
+    from ragleap.vectorstores.pinecone_backend import PineconeBackend
+    backend = PineconeBackend(persist_directory=str(tmp_path / "pc_data"))
+    assert backend.api_key == "env-key"
+
+
+def test_default_index_name_and_region():
+    from ragleap.vectorstores.pinecone_backend import PineconeBackend
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        backend = PineconeBackend(persist_directory=d, api_key="fake-key")
+        assert backend.index_name == "ragleap"
+        assert backend.cloud == "aws"
+        assert backend.region == "us-east-1"
+
+
+def test_creates_sqlite_tables_on_init(tmp_path):
+    from ragleap.vectorstores.pinecone_backend import PineconeBackend
+    backend = PineconeBackend(persist_directory=str(tmp_path / "pc_data"), api_key="fake-key")
+    tables = backend._conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    table_names = {t[0] for t in tables}
+    assert "documents" in table_names
+    assert "chunks" in table_names
+
+
+# --- Pure helper functions ---
+
+def test_vector_id_construction(tmp_path):
+    from ragleap.vectorstores.pinecone_backend import PineconeBackend
+    backend = PineconeBackend(persist_directory=str(tmp_path / "pc_data"), api_key="fake-key")
+    assert backend._vector_id("doc1", 0) == "doc1:0"
+    assert backend._vector_id("doc1", 5) == "doc1:5"
+
+
+def test_build_filter_none_when_no_filter(tmp_path):
+    from ragleap.vectorstores.pinecone_backend import PineconeBackend
+    backend = PineconeBackend(persist_directory=str(tmp_path / "pc_data"), api_key="fake-key")
+    assert backend._build_filter(None) is None
+    assert backend._build_filter({}) is None
+
+
+def test_build_filter_translates_to_pinecone_eq_syntax(tmp_path):
+    from ragleap.vectorstores.pinecone_backend import PineconeBackend
+    backend = PineconeBackend(persist_directory=str(tmp_path / "pc_data"), api_key="fake-key")
+    result = backend._build_filter({"tenant": "acme", "region": "us"})
+    assert result == {"tenant": {"$eq": "acme"}, "region": {"$eq": "us"}}
+
+
+# --- SQLite sidecar CRUD (no Pinecone network calls involved) ---
+
+def test_insert_document_and_list_documents(tmp_path):
+    from ragleap.vectorstores.pinecone_backend import PineconeBackend
+    backend = PineconeBackend(persist_directory=str(tmp_path / "pc_data"), api_key="fake-key")
+    backend.insert_document("doc1", "test.txt", {"tenant": "acme"})
+    docs = backend.list_documents(limit=10, offset=0)
+    assert len(docs) == 1
+    assert docs[0]["document_id"] == "doc1"
+    assert docs[0]["filename"] == "test.txt"
+    assert docs[0]["metadata"] == {"tenant": "acme"}
+    assert docs[0]["chunk_count"] == 0
+
+
+def test_get_document_filename(tmp_path):
+    from ragleap.vectorstores.pinecone_backend import PineconeBackend
+    backend = PineconeBackend(persist_directory=str(tmp_path / "pc_data"), api_key="fake-key")
+    backend.insert_document("doc1", "test.txt", {})
+    assert backend.get_document_filename("doc1") == "test.txt"
+    assert backend.get_document_filename("nonexistent") is None
+
+
+# --- Interaction tests: mocked Pinecone client, verifying correct calls ---
+
+def _make_backend_with_mock_pinecone(tmp_path):
+    from ragleap.vectorstores.pinecone_backend import PineconeBackend
+    backend = PineconeBackend(persist_directory=str(tmp_path / "pc_data"), api_key="fake-key", index_name="test-idx")
+    return backend
+
+
+def test_init_schema_creates_index_when_not_existing(tmp_path):
+    backend = _make_backend_with_mock_pinecone(tmp_path)
+
+    mock_pc = MagicMock()
+    mock_pc.list_indexes.return_value.names = []  # no existing indexes
+    mock_status = MagicMock()
+    mock_status.ready = True
+    mock_pc.describe_index.return_value.status = mock_status
+    mock_pc.describe_index.return_value.host = "fake-host.pinecone.io"
+
+    with patch("pinecone.Pinecone", return_value=mock_pc):
+        backend.init_schema(dimensions=768)
+
+    mock_pc.create_index.assert_called_once()
+    call_kwargs = mock_pc.create_index.call_args.kwargs
+    assert call_kwargs["name"] == "test-idx"
+    assert call_kwargs["dimension"] == 768
+    assert call_kwargs["metric"] == "cosine"
+    mock_pc.Index.assert_called_once_with(host="fake-host.pinecone.io")
+
+
+def test_init_schema_skips_create_when_index_exists(tmp_path):
+    backend = _make_backend_with_mock_pinecone(tmp_path)
+
+    mock_pc = MagicMock()
+    mock_pc.list_indexes.return_value.names = ["test-idx"]  # already exists
+    mock_pc.describe_index.return_value.host = "fake-host.pinecone.io"
+
+    with patch("pinecone.Pinecone", return_value=mock_pc):
+        backend.init_schema(dimensions=768)
+
+    mock_pc.create_index.assert_not_called()
+    mock_pc.Index.assert_called_once_with(host="fake-host.pinecone.io")
+
+
+def test_insert_chunk_upserts_to_pinecone_with_correct_id_and_metadata(tmp_path):
+    backend = _make_backend_with_mock_pinecone(tmp_path)
+    backend._index = MagicMock()
+
+    backend.insert_chunk(
+        document_id="doc1", document_name="test.txt", chunk_index=2,
+        text="some text", token_count=5, embedding=[0.1, 0.2, 0.3],
+        metadata={"tenant": "acme"},
+    )
+
+    backend._index.upsert.assert_called_once()
+    call_kwargs = backend._index.upsert.call_args.kwargs
+    vectors = call_kwargs["vectors"]
+    assert len(vectors) == 1
+    vector_id, embedding, metadata = vectors[0]
+    assert vector_id == "doc1:2"
+    assert embedding == [0.1, 0.2, 0.3]
+    assert metadata["document_id"] == "doc1"
+    assert metadata["tenant"] == "acme"
+
+    # Also confirms SQLite got the full text (Pinecone metadata never does)
+    row = backend._conn.execute("SELECT text FROM chunks WHERE vector_id = ?", ("doc1:2",)).fetchone()
+    assert row[0] == "some text"
+
+
+def test_search_dense_returns_chunks_with_text_from_sqlite(tmp_path):
+    backend = _make_backend_with_mock_pinecone(tmp_path)
+    backend._dimensions = 3
+    backend._index = MagicMock()
+
+    backend.insert_document("doc1", "test.txt", {})
+    backend._conn.execute(
+        "INSERT INTO chunks (vector_id, document_id, document_name, chunk_index, text, token_count, metadata) "
+        "VALUES ('doc1:0', 'doc1', 'test.txt', 0, 'real chunk text', 5, '{}')"
+    )
+    backend._conn.commit()
+
+    mock_match = MagicMock()
+    mock_match.id = "doc1:0"
+    mock_match.score = 0.95
+    mock_response = MagicMock()
+    mock_response.matches = [mock_match]
+    backend._index.query.return_value = mock_response
+
+    results = backend.search_dense(embedding=[0.1, 0.2, 0.3], top_k=5)
+
+    assert len(results) == 1
+    assert results[0]["text"] == "real chunk text"
+    assert results[0]["chunk_id"] == "doc1:0"
+    assert results[0]["similarity_score"] == 0.95
+    backend._index.query.assert_called_once()
+    assert backend._index.query.call_args.kwargs["vector"] == [0.1, 0.2, 0.3]
+
+
+def test_search_dense_skips_orphaned_vectors(tmp_path):
+    """A vector exists in Pinecone (per the mocked response) but has no
+    matching row in the local SQLite sidecar - must skip it gracefully,
+    never crash or return a chunk with missing text."""
+    backend = _make_backend_with_mock_pinecone(tmp_path)
+    backend._dimensions = 3
+    backend._index = MagicMock()
+
+    mock_match = MagicMock()
+    mock_match.id = "orphaned-vector-id"
+    mock_match.score = 0.9
+    mock_response = MagicMock()
+    mock_response.matches = [mock_match]
+    backend._index.query.return_value = mock_response
+
+    results = backend.search_dense(embedding=[0.1, 0.2, 0.3], top_k=5)
+    assert results == []
+
+
+def test_search_dense_wrong_dimensions_returns_empty(tmp_path):
+    backend = _make_backend_with_mock_pinecone(tmp_path)
+    backend._dimensions = 768
+    backend._index = MagicMock()
+
+    results = backend.search_dense(embedding=[0.1, 0.2, 0.3], top_k=5)  # only 3 dims, not 768
+    assert results == []
+    backend._index.query.assert_not_called()
+
+
+def test_delete_document_deletes_from_pinecone_and_sqlite(tmp_path):
+    backend = _make_backend_with_mock_pinecone(tmp_path)
+    backend._index = MagicMock()
+
+    backend.insert_document("doc1", "test.txt", {})
+    backend._conn.execute(
+        "INSERT INTO chunks (vector_id, document_id, document_name, chunk_index, text, token_count, metadata) "
+        "VALUES ('doc1:0', 'doc1', 'test.txt', 0, 'text', 5, '{}')"
+    )
+    backend._conn.commit()
+
+    deleted = backend.delete_document("doc1")
+
+    assert deleted is True
+    backend._index.delete.assert_called_once_with(ids=["doc1:0"])
+    assert backend.get_document_filename("doc1") is None
+
+
+def test_delete_document_returns_false_when_not_found(tmp_path):
+    backend = _make_backend_with_mock_pinecone(tmp_path)
+    backend._index = MagicMock()
+    assert backend.delete_document("nonexistent") is False
+
+
+def test_supports_sparse_is_false(tmp_path):
+    backend = _make_backend_with_mock_pinecone(tmp_path)
+    assert backend.supports_sparse() is False
+
+
+def test_pinecone_backend_importable_from_vectorstores():
+    """Confirms it's actually wired into vectorstores/__init__.py, not
+    just existing as an orphaned file."""
+    from ragleap.vectorstores import PineconeBackend
+    assert PineconeBackend is not None


### PR DESCRIPTION
- Found during work on this item: no Pinecone backend existed anywhere in the codebase, despite prior CHANGELOG/README text (carried over from an earlier, unverified planning doc) claiming it was 'code-complete but unverified'. That claim was false - it had never been built. This commit builds the real thing.
- New PineconeBackend implementing VectorBackend, following the same SQLite-sidecar pattern as FAISSBackend (full text/document registry in SQLite, since Pinecone caps metadata at 40KB and has no native 'list all documents' query)
- Every attribute path used (IndexList.names, IndexStatus.ready, ScoredVector.id/.score, Pinecone.Index(host=...)) verified directly against the actual installed pinecone==9.1.0 package's real source code, not assumed from docs/memory. Caught a real bug pre-ship: an early draft used dict-style access (idx['name'], status.get('ready')) that would have failed at runtime - the SDK's response objects are msgspec Structs requiring attribute access throughout.
- NOT live-verified against a real Pinecone account (none available) - 20 tests cover constructor validation, pure helpers, SQLite CRUD, and mocked-client interaction tests confirming correct SDK calls, but this is not a substitute for a real end-to-end run.
- persist_directory= is REQUIRED (unlike FAISS's optional) - Pinecone vectors persist remotely regardless of local state, so an in-memory sidecar would create orphaned vectors after any restart.
- metadata_filter uses Pinecone's real native filtering, not a post-filter like FAISSBackend - caller metadata stored in Pinecone's own vector metadata directly.
- New [pinecone] extra (pinecone>=5.0.0).
- README corrected: 'Pinecone, Weaviate, Qdrant, Milvus... planned' updated now that Pinecone genuinely exists; the stale already-attached-caveat cross-reference fixed. CHANGELOG's historical 0.7.0 entry left as-written (historical record), with an explicit Corrected section added to this entry instead.
- 20 new tests (178 -> 198 passing)

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
