### PR TITLE
feat: WeaviateBackend, QdrantBackend, MilvusBackend (v0.11.0)

### DIFF
--- a/packages/ragleap-rag/CHANGELOG.md
+++ b/packages/ragleap-rag/CHANGELOG.md
@@ -8,6 +8,21 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `docs`: Celery integration guide + runnable example ([#57](https://github.com/antonyrag/ragleap-core/pull/57))
 - `test`: comprehensive pytest suite (67 tests) + CI integration — first automated testing this package has had ([#58](https://github.com/antonyrag/ragleap-core/pull/58))
 
+## [0.11.0]
+
+### Added
+
+- Three new vector backends completing the originally-planned roadmap: `WeaviateBackend`, `QdrantBackend`, `MilvusBackend` - all implementing the `VectorBackend` interface, following the same SQLite-sidecar-plus-remote-vector-store pattern as `PineconeBackend`.
+- New `[weaviate]`, `[qdrant]`, `[milvus]` extras.
+- **Not live-verified** against real instances of any of the three (no accounts were available) - same honest caveat as `PineconeBackend`. Every method signature, class field, and return-type structure used in all three implementations was introspected directly against each package's actual installed source code (`weaviate-client==4.22.0`, `qdrant-client==1.18.0`, `pymilvus==3.0.1`) during development - not assumed from documentation. This is the same rigor that caught a real pre-ship bug in `PineconeBackend` (v0.10.1); applying it up front here rather than discovering issues later.
+- `WeaviateBackend`: vectors are "self-provided" (`Configure.Vectors.self_provided()`) since ragleap-rag always brings its own embeddings. Weaviate assigns its own UUIDs on insert (can't supply an arbitrary string ID directly like Pinecone), so a deterministic UUID derived from `document_id:chunk_index` is used - re-running the same insert stays idempotent. Distance is converted to a similarity-style score (`1.0 - distance`) for consistency with the other backends, which all return higher-is-better values.
+- `QdrantBackend`: `PointStruct.id`'s type hint technically allows arbitrary strings, but real runtime validation requires string IDs to actually parse as valid UUIDs (a well-documented gap between the type system and the server's actual behavior) - deterministic UUIDs used here too, for the same reason as Weaviate.
+- `MilvusBackend`: unlike the other three, Milvus's `id_type="string"` genuinely accepts arbitrary string primary keys directly - no UUID workaround needed, `document_id:chunk_index` is used as-is. `enable_dynamic_field=True` (the client's own default) means the caller-supplied metadata dict can be inserted directly as extra fields without pre-declaring a schema for them.
+- All three, like `PineconeBackend`, require `persist_directory=` (not optional like `FAISSBackend`) - a remote/cloud vector store persists data regardless of local process state, so a persistent SQLite sidecar for chunk text is mandatory to avoid orphaned vectors after a restart.
+- `supports_sparse()` is `False` for all three, even though Weaviate/Qdrant/Milvus all natively support sparse vectors/BM25/hybrid search - implementing that natively for each is a real, valuable future enhancement, deliberately not attempted here to keep initial scope honest and verifiable rather than guessing at a larger untested surface area.
+- 40 new tests across three files (198 -> 238 passing): each backend gets constructor validation, pure helper-function tests, SQLite CRUD in isolation, and mocked-client interaction tests confirming the right SDK methods get called with the right arguments and attribute-access patterns.
+- This completes the originally-planned vector backend roadmap (Pinecone, Weaviate, Qdrant, Milvus) - `ragleap-rag` now supports 6 vector storage options total: pgvector, FAISS, Pinecone, Weaviate, Qdrant, Milvus.
+
 ## [0.10.1]
 
 ### Added

--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -63,9 +63,12 @@ Currently available:
 | `PgVectorBackend` (default) | none needed | Yes - real Postgres full-text search | Battle-tested, the original implementation |
 | `FAISSBackend` | `pip install ragleap-rag[faiss]` | No - `ask(hybrid=True)` gracefully degrades to dense-only | Local, in-process, no API key. Pass `persist_directory=` for data that survives restarts - without it, everything is in-memory and lost on process exit. Metadata filtering is a post-filter (over-fetch then filter), not an indexed query - fine for small-to-medium datasets, less efficient than pgvector's JSONB GIN index at large scale. |
 | `PineconeBackend` | `pip install ragleap-rag[pinecone]` | No - `ask(hybrid=True)` gracefully degrades to dense-only | Managed, serverless. **Not live-verified** - no Pinecone account was available during development; code-complete against the real installed SDK's actual source (not just docs), but treat as best-effort until confirmed live. `persist_directory=` is **required** (not optional like FAISS) - Pinecone vectors persist remotely regardless of local state, so a SQLite sidecar for chunk text is mandatory to avoid orphaned vectors after a restart. `metadata_filter` uses Pinecone's real native filtering, not a post-filter. |
+| `WeaviateBackend` | `pip install ragleap-rag[weaviate]` | No (Weaviate natively supports BM25/hybrid search, but that's not wired in yet - a real future enhancement) | Managed cloud or self-hosted. **Not live-verified** - same caveat as Pinecone. `persist_directory=` required, same reasoning. Vectors are "self-provided" (bring-your-own-embeddings) - Weaviate's built-in vectorizer integrations aren't used. |
+| `QdrantBackend` | `pip install ragleap-rag[qdrant]` | No (Qdrant natively supports sparse vectors/hybrid search, not wired in yet) | Managed cloud or self-hosted. **Not live-verified** - same caveat. `persist_directory=` required, same reasoning. |
+| `MilvusBackend` | `pip install ragleap-rag[milvus]` | No (Milvus natively supports sparse/BM25/hybrid search, not wired in yet) | Managed (Zilliz Cloud) or self-hosted. **Not live-verified** - same caveat. `persist_directory=` required, same reasoning. Unlike the other three, Milvus accepts arbitrary string primary keys directly - no UUID workaround needed. |
 
 ```python
-from ragleap.vectorstores import PineconeBackend
+from ragleap.vectorstores import PineconeBackend  # or WeaviateBackend, QdrantBackend, MilvusBackend
 
 rag = RagLeap(
     database_url="postgresql://user:pass@localhost/mydb",
@@ -75,7 +78,9 @@ rag = RagLeap(
 )
 ```
 
-More backends (Weaviate, Qdrant, Milvus) are planned - see the project roadmap. Building your own is straightforward: implement the `ragleap.vectorstores.VectorBackend` abstract interface (`init_schema`, `insert_document`, `insert_chunk`, `search_dense`, `list_documents`, `delete_document`, `get_document_filename`, and optionally `search_sparse`/`search_hybrid`/`supports_sparse` if your backend can do keyword search).
+**Live-verification status for Pinecone/Weaviate/Qdrant/Milvus**: none of the four have been tested against a real account - no accounts were available during development. Each was still built with real rigor: every SDK method signature, class field, and return type used was introspected directly against the actual installed client package's source code (not assumed from documentation or memory), which caught a real bug pre-ship for `PineconeBackend` (dict-style access that would have failed at runtime against the SDK's actual `msgspec.Struct`-based response objects). Treat all four as best-effort until confirmed live by someone with a real account - the same honest standard already applied to `mistral`/`together`/`cohere`/`voyage` in the embedding module.
+
+Building your own backend is straightforward: implement the `ragleap.vectorstores.VectorBackend` abstract interface (`init_schema`, `insert_document`, `insert_chunk`, `search_dense`, `list_documents`, `delete_document`, `get_document_filename`, and optionally `search_sparse`/`search_hybrid`/`supports_sparse` if your backend can do keyword search).
 
 ## The three things that matter
 

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.10.1"
+version = "0.11.0"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"
@@ -40,6 +40,9 @@ openai = ["openai>=1.40.0"]
 rerank = ["onnxruntime>=1.17.0", "tokenizers>=0.19.0", "huggingface_hub>=0.20.0"]
 faiss = ["faiss-cpu>=1.8.0"]
 pinecone = ["pinecone>=5.0.0"]
+weaviate = ["weaviate-client>=4.0.0"]
+qdrant = ["qdrant-client>=1.10.0"]
+milvus = ["pymilvus>=2.4.0"]
 structured = ["jsonschema>=4.0.0"]
 web = ["trafilatura>=1.6.0"]
 ocr = ["pytesseract>=0.3.10", "Pillow>=10.0.0"]
@@ -55,7 +58,7 @@ formats = [
     "pyyaml>=6.0",
     "pyarrow>=14.0.0",
 ]
-all = ["google-genai>=0.3.0", "anthropic>=0.34.0", "openai>=1.40.0", "onnxruntime>=1.17.0", "tokenizers>=0.19.0", "huggingface_hub>=0.20.0", "faiss-cpu>=1.8.0", "trafilatura>=1.6.0", "pytesseract>=0.3.10", "Pillow>=10.0.0", "redis>=5.0.0", "openpyxl>=3.1.0", "xlrd>=2.0.0", "python-pptx>=1.0.0", "odfpy>=1.4.0", "striprtf>=0.0.26", "beautifulsoup4>=4.12.0", "ebooklib>=0.18", "pyyaml>=6.0", "pyarrow>=14.0.0", "jsonschema>=4.0.0", "pinecone>=5.0.0"]
+all = ["google-genai>=0.3.0", "anthropic>=0.34.0", "openai>=1.40.0", "onnxruntime>=1.17.0", "tokenizers>=0.19.0", "huggingface_hub>=0.20.0", "faiss-cpu>=1.8.0", "trafilatura>=1.6.0", "pytesseract>=0.3.10", "Pillow>=10.0.0", "redis>=5.0.0", "openpyxl>=3.1.0", "xlrd>=2.0.0", "python-pptx>=1.0.0", "odfpy>=1.4.0", "striprtf>=0.0.26", "beautifulsoup4>=4.12.0", "ebooklib>=0.18", "pyyaml>=6.0", "pyarrow>=14.0.0", "jsonschema>=4.0.0", "pinecone>=5.0.0", "weaviate-client>=4.0.0", "qdrant-client>=1.10.0", "pymilvus>=2.4.0"]
 
 [project.urls]
 Homepage = "https://github.com/antonyrag/ragleap-core"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -45,7 +45,7 @@ from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.10.1"
+__version__ = "0.11.0"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult", "TranscriptionConfig", "VectorBackend", "PgVectorBackend"]
 
 

--- a/packages/ragleap-rag/src/ragleap/vectorstores/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/vectorstores/__init__.py
@@ -14,3 +14,21 @@ try:
     __all__.append("PineconeBackend")
 except ImportError:
     pass  # pinecone extra not installed - PineconeBackend simply unavailable, not an error
+
+try:
+    from ragleap.vectorstores.weaviate_backend import WeaviateBackend
+    __all__.append("WeaviateBackend")
+except ImportError:
+    pass  # weaviate extra not installed - WeaviateBackend simply unavailable, not an error
+
+try:
+    from ragleap.vectorstores.qdrant_backend import QdrantBackend
+    __all__.append("QdrantBackend")
+except ImportError:
+    pass  # qdrant extra not installed - QdrantBackend simply unavailable, not an error
+
+try:
+    from ragleap.vectorstores.milvus_backend import MilvusBackend
+    __all__.append("MilvusBackend")
+except ImportError:
+    pass  # milvus extra not installed - MilvusBackend simply unavailable, not an error

--- a/packages/ragleap-rag/src/ragleap/vectorstores/milvus_backend.py
+++ b/packages/ragleap-rag/src/ragleap/vectorstores/milvus_backend.py
@@ -1,0 +1,229 @@
+"""
+Milvus-backed vector storage for ragleap-rag.
+
+**NOT LIVE-VERIFIED** - no Milvus instance (Zilliz Cloud or self-
+hosted) was available to test against during development (same honest
+caveat as PineconeBackend/WeaviateBackend/QdrantBackend/mistral/
+cohere/voyage). Code-complete against the actual installed
+pymilvus==3.0.1 package's real source code (every method signature
+used below was introspected directly, not assumed from documentation)
+via the modern MilvusClient interface, not the older ORM-style API.
+Treat as best-effort until confirmed live.
+
+Design notes:
+- persist_directory= is REQUIRED - same reasoning as the other remote
+  backends: a Zilliz Cloud instance (or any remote Milvus) persists
+  vectors regardless of local process state, so a persistent SQLite
+  sidecar for chunk text is mandatory to avoid orphaned vectors.
+- Unlike Pinecone/Qdrant/Weaviate, Milvus's id_type="string" natively
+  accepts arbitrary string primary keys directly (max_length=512 set
+  explicitly here) - no deterministic-UUID workaround needed, since
+  Milvus doesn't have the same UUID-only constraint the others do.
+- enable_dynamic_field=True (MilvusClient's own default for its
+  simplified schema helper) means the caller-supplied metadata dict,
+  document_id, document_name, and chunk_index can all be inserted
+  directly as extra fields without pre-declaring a schema for them.
+- A SQLite sidecar still stores full chunk text and the document
+  registry, for consistency with every other backend in this project
+  and because Milvus's text/JSON field length limits make it a worse
+  fit for storing large amounts of full document text than a plain
+  relational sidecar.
+- supports_sparse() is False even though Milvus supports sparse
+  vectors/BM25/hybrid search - implementing that natively is a real,
+  valuable future enhancement, not done here to keep initial scope
+  honest and verifiable rather than guessing at untested surface area.
+"""
+import json
+import logging
+import os
+import sqlite3
+import threading
+from typing import Dict, List, Optional
+
+from ragleap.vectorstores.base import VectorBackend
+
+logger = logging.getLogger(__name__)
+
+
+class MilvusBackend(VectorBackend):
+    def __init__(
+        self,
+        persist_directory: str,
+        uri: Optional[str] = None,
+        token: Optional[str] = None,
+        collection_name: str = "ragleap",
+    ):
+        try:
+            import pymilvus  # noqa: F401
+        except ImportError as e:
+            raise ImportError(
+                "MilvusBackend requires the 'milvus' extra: pip install ragleap-rag[milvus]"
+            ) from e
+
+        if not persist_directory:
+            raise ValueError(
+                "MilvusBackend requires persist_directory= - a remote Milvus/Zilliz "
+                "Cloud instance persists vectors regardless of local process state, so "
+                "a persistent SQLite sidecar for chunk text is mandatory to avoid "
+                "orphaned vectors after a restart."
+            )
+
+        self.uri = uri or os.environ.get("MILVUS_URI")
+        if not self.uri:
+            raise ValueError(
+                "No uri for MilvusBackend. Pass uri= explicitly, or set MILVUS_URI "
+                "in your environment - e.g. a Zilliz Cloud endpoint or a self-hosted "
+                "Milvus instance's address."
+            )
+        self.token = token or os.environ.get("MILVUS_TOKEN")
+        self.collection_name = collection_name
+        self.persist_directory = persist_directory
+        self._client = None
+        self._dimensions = None
+        self._lock = threading.Lock()
+
+        os.makedirs(persist_directory, exist_ok=True)
+        self._sqlite_path = os.path.join(persist_directory, "milvus_meta.sqlite3")
+        self._conn = sqlite3.connect(self._sqlite_path, check_same_thread=False)
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS documents (
+                id TEXT PRIMARY KEY, filename TEXT NOT NULL, metadata TEXT NOT NULL, uploaded_at TEXT NOT NULL
+            )"""
+        )
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS chunks (
+                vector_key TEXT PRIMARY KEY, document_id TEXT NOT NULL,
+                document_name TEXT NOT NULL, chunk_index INTEGER NOT NULL,
+                text TEXT NOT NULL, token_count INTEGER, metadata TEXT NOT NULL
+            )"""
+        )
+        self._conn.commit()
+
+    def _vector_key(self, document_id: str, chunk_index: int) -> str:
+        return f"{document_id}:{chunk_index}"
+
+    def init_schema(self, dimensions: int) -> None:
+        from pymilvus import MilvusClient
+
+        self._dimensions = dimensions
+        self._client = MilvusClient(uri=self.uri, token=self.token or "")
+
+        if not self._client.has_collection(self.collection_name):
+            logger.info(f"MilvusBackend: creating collection '{self.collection_name}' (dimensions={dimensions})")
+            self._client.create_collection(
+                collection_name=self.collection_name,
+                dimension=dimensions,
+                id_type="string",
+                max_length=512,
+                metric_type="COSINE",
+            )
+        else:
+            logger.info(f"MilvusBackend: using existing collection '{self.collection_name}'")
+
+    def _build_filter_expr(self, metadata_filter: Optional[Dict]) -> str:
+        """Milvus filters are boolean expression strings, not a
+        structured object like the other backends - build a simple
+        AND-of-equalities expression."""
+        if not metadata_filter:
+            return ""
+        parts = []
+        for k, v in metadata_filter.items():
+            value_repr = f'"{v}"' if isinstance(v, str) else str(v)
+            parts.append(f'{k} == {value_repr}')
+        return " and ".join(parts)
+
+    def insert_document(self, document_id: str, filename: str, metadata: Dict) -> None:
+        import datetime
+        with self._lock:
+            self._conn.execute(
+                "INSERT INTO documents (id, filename, metadata, uploaded_at) VALUES (?, ?, ?, ?)",
+                (document_id, filename, json.dumps(metadata or {}), datetime.datetime.utcnow().isoformat()),
+            )
+            self._conn.commit()
+
+    def insert_chunk(
+        self, document_id: str, document_name: str, chunk_index: int,
+        text: str, token_count: int, embedding: List[float], metadata: Dict,
+    ) -> None:
+        vector_key = self._vector_key(document_id, chunk_index)
+
+        with self._lock:
+            self._conn.execute(
+                "INSERT INTO chunks (vector_key, document_id, document_name, chunk_index, text, token_count, metadata) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (vector_key, document_id, document_name, chunk_index, text, token_count, json.dumps(metadata or {})),
+            )
+            self._conn.commit()
+
+            row = {
+                "id": vector_key, "vector": embedding,
+                "document_id": document_id, "document_name": document_name,
+                "chunk_index": chunk_index, **(metadata or {}),
+            }
+            self._client.insert(collection_name=self.collection_name, data=[row])
+
+    def search_dense(self, embedding: List[float], top_k: int, metadata_filter: Optional[Dict] = None) -> List[Dict]:
+        if not embedding or self._client is None:
+            return []
+        if self._dimensions and len(embedding) != self._dimensions:
+            logger.warning(f"Query embedding dim={len(embedding)} != expected {self._dimensions}; skipping search")
+            return []
+
+        response = self._client.search(
+            collection_name=self.collection_name, data=[embedding], limit=top_k,
+            filter=self._build_filter_expr(metadata_filter),
+        )
+
+        results = []
+        # search() returns List[List[dict]] - one inner list per query
+        # vector; we always send exactly one, so response[0] is ours.
+        hits = response[0] if response else []
+        for hit in hits:
+            vector_key = hit.get("id")
+            distance = hit.get("distance")
+            row = self._conn.execute(
+                "SELECT document_id, document_name, chunk_index, text FROM chunks WHERE vector_key = ?",
+                (vector_key,),
+            ).fetchone()
+            if row is None:
+                logger.warning(f"MilvusBackend: point '{vector_key}' has no matching local text row, skipping")
+                continue
+            document_id, document_name, chunk_index, text = row
+            results.append({
+                "chunk_id": vector_key, "text": text,
+                "similarity_score": round(float(distance), 4) if distance is not None else None,
+                "document_id": document_id, "document_name": document_name, "chunk_index": chunk_index,
+            })
+        return results
+
+    def supports_sparse(self) -> bool:
+        return False
+
+    def list_documents(self, limit: int, offset: int) -> List[Dict]:
+        rows = self._conn.execute(
+            """SELECT d.id, d.filename, d.uploaded_at, d.metadata, COUNT(c.vector_key) AS chunk_count
+               FROM documents d LEFT JOIN chunks c ON c.document_id = d.id
+               GROUP BY d.id ORDER BY d.uploaded_at DESC LIMIT ? OFFSET ?""",
+            (limit, offset),
+        ).fetchall()
+        return [
+            {"document_id": r[0], "filename": r[1], "uploaded_at": r[2], "metadata": json.loads(r[3]), "chunk_count": r[4]}
+            for r in rows
+        ]
+
+    def delete_document(self, document_id: str) -> bool:
+        with self._lock:
+            vector_keys = [r[0] for r in self._conn.execute(
+                "SELECT vector_key FROM chunks WHERE document_id = ?", (document_id,)
+            ).fetchall()]
+            if vector_keys and self._client is not None:
+                self._client.delete(collection_name=self.collection_name, ids=vector_keys)
+            cur = self._conn.execute("DELETE FROM documents WHERE id = ?", (document_id,))
+            self._conn.execute("DELETE FROM chunks WHERE document_id = ?", (document_id,))
+            deleted = cur.rowcount > 0
+            self._conn.commit()
+        return deleted
+
+    def get_document_filename(self, document_id: str) -> Optional[str]:
+        row = self._conn.execute("SELECT filename FROM documents WHERE id = ?", (document_id,)).fetchone()
+        return row[0] if row else None

--- a/packages/ragleap-rag/src/ragleap/vectorstores/qdrant_backend.py
+++ b/packages/ragleap-rag/src/ragleap/vectorstores/qdrant_backend.py
@@ -1,0 +1,229 @@
+"""
+Qdrant-backed vector storage for ragleap-rag.
+
+**NOT LIVE-VERIFIED** - no Qdrant instance (cloud or local) was
+available to test against during development (same honest caveat as
+PineconeBackend/WeaviateBackend/mistral/cohere/voyage). Code-complete
+against the actual installed qdrant-client==1.18.0 package's real
+source code (every method signature and pydantic model field used
+below was introspected directly, not assumed from documentation).
+Treat as best-effort until confirmed live.
+
+Design notes (same reasoning as PineconeBackend/WeaviateBackend):
+- persist_directory= is REQUIRED - a remote/cloud Qdrant instance
+  persists vectors regardless of local process state, so a persistent
+  SQLite sidecar for chunk text is mandatory to avoid orphaned vectors.
+- A SQLite sidecar stores full chunk text, the document registry, and
+  a document_id/chunk_index -> Qdrant point UUID mapping. Qdrant's
+  PointStruct.id type hint technically allows arbitrary strings, but
+  its real runtime validation requires string IDs to actually parse as
+  valid UUIDs (a well-documented gap between the type system and the
+  server's actual behavior) - deterministic UUIDs are used here rather
+  than trusting the permissive type hint alone.
+- supports_sparse() is False even though Qdrant natively supports
+  sparse vectors and hybrid search - implementing that natively is a
+  real, valuable future enhancement, not done here to keep initial
+  scope honest and verifiable rather than guessing at untested surface.
+- Qdrant also supports a fully local, file-based mode (path= instead
+  of url=) with no server at all - useful for the same "no setup"
+  use case FAISSBackend covers, but not wired in here to keep this
+  backend's scope focused on the managed/remote use case Pinecone and
+  Weaviate's cloud offerings also cover; local Qdrant is a reasonable
+  future addition.
+"""
+import json
+import logging
+import os
+import sqlite3
+import threading
+import uuid as uuid_module
+from typing import Dict, List, Optional
+
+from ragleap.vectorstores.base import VectorBackend
+
+logger = logging.getLogger(__name__)
+
+
+class QdrantBackend(VectorBackend):
+    def __init__(
+        self,
+        persist_directory: str,
+        url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        collection_name: str = "ragleap",
+    ):
+        try:
+            import qdrant_client  # noqa: F401
+        except ImportError as e:
+            raise ImportError(
+                "QdrantBackend requires the 'qdrant' extra: pip install ragleap-rag[qdrant]"
+            ) from e
+
+        if not persist_directory:
+            raise ValueError(
+                "QdrantBackend requires persist_directory= - a remote Qdrant "
+                "instance persists vectors regardless of local process state, so a "
+                "persistent SQLite sidecar for chunk text is mandatory to avoid "
+                "orphaned vectors after a restart."
+            )
+
+        self.url = url or os.environ.get("QDRANT_URL")
+        if not self.url:
+            raise ValueError(
+                "No url for QdrantBackend. Pass url= explicitly, or set "
+                "QDRANT_URL in your environment - e.g. a Qdrant Cloud cluster URL "
+                "or a self-hosted instance's address."
+            )
+        self.api_key = api_key or os.environ.get("QDRANT_API_KEY")
+        self.collection_name = collection_name
+        self.persist_directory = persist_directory
+        self._client = None
+        self._dimensions = None
+        self._lock = threading.Lock()
+
+        os.makedirs(persist_directory, exist_ok=True)
+        self._sqlite_path = os.path.join(persist_directory, "qdrant_meta.sqlite3")
+        self._conn = sqlite3.connect(self._sqlite_path, check_same_thread=False)
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS documents (
+                id TEXT PRIMARY KEY, filename TEXT NOT NULL, metadata TEXT NOT NULL, uploaded_at TEXT NOT NULL
+            )"""
+        )
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS chunks (
+                vector_key TEXT PRIMARY KEY, qdrant_id TEXT NOT NULL, document_id TEXT NOT NULL,
+                document_name TEXT NOT NULL, chunk_index INTEGER NOT NULL,
+                text TEXT NOT NULL, token_count INTEGER, metadata TEXT NOT NULL
+            )"""
+        )
+        self._conn.commit()
+
+    def _vector_key(self, document_id: str, chunk_index: int) -> str:
+        return f"{document_id}:{chunk_index}"
+
+    def _deterministic_uuid(self, vector_key: str) -> str:
+        """Qdrant's PointStruct.id type hint technically allows any str,
+        but real runtime validation requires it to parse as a valid
+        UUID - deriving deterministically from vector_key also makes
+        re-running the same insert idempotent, matching Weaviate's
+        approach here for the same underlying reason."""
+        return str(uuid_module.uuid5(uuid_module.NAMESPACE_DNS, vector_key))
+
+    def init_schema(self, dimensions: int) -> None:
+        from qdrant_client import QdrantClient
+        from qdrant_client.http.models import VectorParams, Distance
+
+        self._dimensions = dimensions
+        self._client = QdrantClient(url=self.url, api_key=self.api_key)
+
+        if not self._client.collection_exists(self.collection_name):
+            logger.info(f"QdrantBackend: creating collection '{self.collection_name}' (dimensions={dimensions})")
+            self._client.create_collection(
+                collection_name=self.collection_name,
+                vectors_config=VectorParams(size=dimensions, distance=Distance.COSINE),
+            )
+        else:
+            logger.info(f"QdrantBackend: using existing collection '{self.collection_name}'")
+
+    def _build_filter(self, metadata_filter: Optional[Dict]):
+        if not metadata_filter:
+            return None
+        from qdrant_client.http.models import Filter, FieldCondition, MatchValue
+
+        conditions = [FieldCondition(key=k, match=MatchValue(value=v)) for k, v in metadata_filter.items()]
+        return Filter(must=conditions)
+
+    def insert_document(self, document_id: str, filename: str, metadata: Dict) -> None:
+        import datetime
+        with self._lock:
+            self._conn.execute(
+                "INSERT INTO documents (id, filename, metadata, uploaded_at) VALUES (?, ?, ?, ?)",
+                (document_id, filename, json.dumps(metadata or {}), datetime.datetime.utcnow().isoformat()),
+            )
+            self._conn.commit()
+
+    def insert_chunk(
+        self, document_id: str, document_name: str, chunk_index: int,
+        text: str, token_count: int, embedding: List[float], metadata: Dict,
+    ) -> None:
+        from qdrant_client.http.models import PointStruct
+
+        vector_key = self._vector_key(document_id, chunk_index)
+        qdrant_id = self._deterministic_uuid(vector_key)
+
+        with self._lock:
+            self._conn.execute(
+                "INSERT INTO chunks (vector_key, qdrant_id, document_id, document_name, chunk_index, text, token_count, metadata) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (vector_key, qdrant_id, document_id, document_name, chunk_index, text, token_count, json.dumps(metadata or {})),
+            )
+            self._conn.commit()
+
+            payload = {
+                "document_id": document_id, "document_name": document_name,
+                "chunk_index": chunk_index, **(metadata or {}),
+            }
+            self._client.upsert(
+                collection_name=self.collection_name,
+                points=[PointStruct(id=qdrant_id, vector=embedding, payload=payload)],
+            )
+
+    def search_dense(self, embedding: List[float], top_k: int, metadata_filter: Optional[Dict] = None) -> List[Dict]:
+        if not embedding or self._client is None:
+            return []
+        if self._dimensions and len(embedding) != self._dimensions:
+            logger.warning(f"Query embedding dim={len(embedding)} != expected {self._dimensions}; skipping search")
+            return []
+
+        response = self._client.query_points(
+            collection_name=self.collection_name, query=embedding, limit=top_k,
+            query_filter=self._build_filter(metadata_filter), with_payload=False,
+        )
+
+        results = []
+        for point in response.points:
+            row = self._conn.execute(
+                "SELECT document_id, document_name, chunk_index, text FROM chunks WHERE qdrant_id = ?",
+                (str(point.id),),
+            ).fetchone()
+            if row is None:
+                logger.warning(f"QdrantBackend: point '{point.id}' has no matching local text row, skipping")
+                continue
+            document_id, document_name, chunk_index, text = row
+            results.append({
+                "chunk_id": str(point.id), "text": text, "similarity_score": round(float(point.score), 4),
+                "document_id": document_id, "document_name": document_name, "chunk_index": chunk_index,
+            })
+        return results
+
+    def supports_sparse(self) -> bool:
+        return False
+
+    def list_documents(self, limit: int, offset: int) -> List[Dict]:
+        rows = self._conn.execute(
+            """SELECT d.id, d.filename, d.uploaded_at, d.metadata, COUNT(c.vector_key) AS chunk_count
+               FROM documents d LEFT JOIN chunks c ON c.document_id = d.id
+               GROUP BY d.id ORDER BY d.uploaded_at DESC LIMIT ? OFFSET ?""",
+            (limit, offset),
+        ).fetchall()
+        return [
+            {"document_id": r[0], "filename": r[1], "uploaded_at": r[2], "metadata": json.loads(r[3]), "chunk_count": r[4]}
+            for r in rows
+        ]
+
+    def delete_document(self, document_id: str) -> bool:
+        with self._lock:
+            qdrant_ids = [r[0] for r in self._conn.execute(
+                "SELECT qdrant_id FROM chunks WHERE document_id = ?", (document_id,)
+            ).fetchall()]
+            if qdrant_ids and self._client is not None:
+                self._client.delete(collection_name=self.collection_name, points_selector=qdrant_ids)
+            cur = self._conn.execute("DELETE FROM documents WHERE id = ?", (document_id,))
+            self._conn.execute("DELETE FROM chunks WHERE document_id = ?", (document_id,))
+            deleted = cur.rowcount > 0
+            self._conn.commit()
+        return deleted
+
+    def get_document_filename(self, document_id: str) -> Optional[str]:
+        row = self._conn.execute("SELECT filename FROM documents WHERE id = ?", (document_id,)).fetchone()
+        return row[0] if row else None

--- a/packages/ragleap-rag/src/ragleap/vectorstores/weaviate_backend.py
+++ b/packages/ragleap-rag/src/ragleap/vectorstores/weaviate_backend.py
@@ -1,0 +1,245 @@
+"""
+Weaviate-backed vector storage for ragleap-rag.
+
+**NOT LIVE-VERIFIED** - no Weaviate instance (cloud or local) was
+available to test against during development (same honest caveat as
+PineconeBackend/mistral/cohere/voyage). Code-complete against the
+actual installed weaviate-client==4.22.0 package's real source code
+(every method signature and return-type field used below was
+introspected directly, not assumed from documentation) - the current
+GA Python client (v3 is deprecated). Treat as best-effort until
+confirmed live.
+
+Design notes (same reasoning as PineconeBackend):
+- persist_directory= is REQUIRED - a Weaviate Cloud instance persists
+  vectors remotely regardless of local process state, so a persistent
+  SQLite sidecar for chunk text is mandatory to avoid orphaned vectors.
+- A SQLite sidecar stores full chunk text, the document registry, and
+  a document_id/chunk_index -> Weaviate UUID mapping (Weaviate assigns
+  its own UUIDs on insert - unlike Pinecone, you can't just supply a
+  custom string ID directly as the primary key).
+- Vectors are "self-provided" (Configure.Vectors.self_provided()) -
+  ragleap-rag always brings its own embeddings; Weaviate's built-in
+  vectorizer integrations are intentionally not used here, consistent
+  with this library's BYOK philosophy.
+- supports_sparse() is False even though Weaviate natively supports
+  BM25/hybrid search - implementing that natively is a real, valuable
+  future enhancement, not done here to keep initial scope honest and
+  verifiable rather than guessing at a larger untested surface area.
+"""
+import json
+import logging
+import os
+import sqlite3
+import threading
+import uuid as uuid_module
+from typing import Dict, List, Optional
+
+from ragleap.vectorstores.base import VectorBackend
+
+logger = logging.getLogger(__name__)
+
+
+class WeaviateBackend(VectorBackend):
+    def __init__(
+        self,
+        persist_directory: str,
+        cluster_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        collection_name: str = "RagleapChunk",
+    ):
+        try:
+            import weaviate  # noqa: F401
+        except ImportError as e:
+            raise ImportError(
+                "WeaviateBackend requires the 'weaviate' extra: pip install ragleap-rag[weaviate]"
+            ) from e
+
+        if not persist_directory:
+            raise ValueError(
+                "WeaviateBackend requires persist_directory= - a remote Weaviate "
+                "instance persists vectors regardless of local process state, so a "
+                "persistent SQLite sidecar for chunk text is mandatory to avoid "
+                "orphaned vectors after a restart."
+            )
+
+        self.cluster_url = cluster_url or os.environ.get("WEAVIATE_CLUSTER_URL")
+        self.api_key = api_key or os.environ.get("WEAVIATE_API_KEY")
+        # collection_name must start with an uppercase letter per Weaviate's
+        # naming convention - normalize rather than fail confusingly later.
+        self.collection_name = collection_name[0].upper() + collection_name[1:] if collection_name else "RagleapChunk"
+        self.persist_directory = persist_directory
+        self._client = None
+        self._collection = None
+        self._dimensions = None
+        self._lock = threading.Lock()
+
+        os.makedirs(persist_directory, exist_ok=True)
+        self._sqlite_path = os.path.join(persist_directory, "weaviate_meta.sqlite3")
+        self._conn = sqlite3.connect(self._sqlite_path, check_same_thread=False)
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS documents (
+                id TEXT PRIMARY KEY, filename TEXT NOT NULL, metadata TEXT NOT NULL, uploaded_at TEXT NOT NULL
+            )"""
+        )
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS chunks (
+                vector_key TEXT PRIMARY KEY, weaviate_uuid TEXT NOT NULL, document_id TEXT NOT NULL,
+                document_name TEXT NOT NULL, chunk_index INTEGER NOT NULL,
+                text TEXT NOT NULL, token_count INTEGER, metadata TEXT NOT NULL
+            )"""
+        )
+        self._conn.commit()
+
+    def _vector_key(self, document_id: str, chunk_index: int) -> str:
+        return f"{document_id}:{chunk_index}"
+
+    def _deterministic_uuid(self, vector_key: str) -> str:
+        """Weaviate requires its own UUID as the object identifier -
+        deriving it deterministically from our own vector_key (rather
+        than a random uuid4) means re-running the same insert is
+        idempotent at the Weaviate layer too, matching how FAISS/
+        Pinecone's IDs are derived from document_id+chunk_index."""
+        return str(uuid_module.uuid5(uuid_module.NAMESPACE_DNS, vector_key))
+
+    def init_schema(self, dimensions: int) -> None:
+        import weaviate
+        from weaviate.classes.init import Auth
+        from weaviate.classes.config import Configure
+
+        self._dimensions = dimensions
+
+        if self.cluster_url:
+            auth = Auth.api_key(self.api_key) if self.api_key else None
+            self._client = weaviate.connect_to_weaviate_cloud(cluster_url=self.cluster_url, auth_credentials=auth)
+        else:
+            self._client = weaviate.connect_to_local()
+
+        if not self._client.collections.exists(self.collection_name):
+            logger.info(f"WeaviateBackend: creating collection '{self.collection_name}' (dimensions={dimensions})")
+            self._client.collections.create(
+                name=self.collection_name,
+                vector_config=Configure.Vectors.self_provided(),
+            )
+        else:
+            logger.info(f"WeaviateBackend: using existing collection '{self.collection_name}'")
+
+        self._collection = self._client.collections.get(self.collection_name)
+
+    def _build_filter(self, metadata_filter: Optional[Dict]):
+        if not metadata_filter:
+            return None
+        from weaviate.classes.query import Filter
+
+        conditions = [Filter.by_property(k).equal(v) for k, v in metadata_filter.items()]
+        combined = conditions[0]
+        for cond in conditions[1:]:
+            combined = combined & cond
+        return combined
+
+    def insert_document(self, document_id: str, filename: str, metadata: Dict) -> None:
+        import datetime
+        with self._lock:
+            self._conn.execute(
+                "INSERT INTO documents (id, filename, metadata, uploaded_at) VALUES (?, ?, ?, ?)",
+                (document_id, filename, json.dumps(metadata or {}), datetime.datetime.utcnow().isoformat()),
+            )
+            self._conn.commit()
+
+    def insert_chunk(
+        self, document_id: str, document_name: str, chunk_index: int,
+        text: str, token_count: int, embedding: List[float], metadata: Dict,
+    ) -> None:
+        vector_key = self._vector_key(document_id, chunk_index)
+        weaviate_uuid = self._deterministic_uuid(vector_key)
+
+        with self._lock:
+            self._conn.execute(
+                "INSERT INTO chunks (vector_key, weaviate_uuid, document_id, document_name, chunk_index, text, token_count, metadata) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (vector_key, weaviate_uuid, document_id, document_name, chunk_index, text, token_count, json.dumps(metadata or {})),
+            )
+            self._conn.commit()
+
+            properties = {
+                "document_id": document_id, "document_name": document_name,
+                "chunk_index": chunk_index, **(metadata or {}),
+            }
+            self._collection.data.insert(properties=properties, vector=embedding, uuid=weaviate_uuid)
+
+    def search_dense(self, embedding: List[float], top_k: int, metadata_filter: Optional[Dict] = None) -> List[Dict]:
+        if not embedding or self._collection is None:
+            return []
+        if self._dimensions and len(embedding) != self._dimensions:
+            logger.warning(f"Query embedding dim={len(embedding)} != expected {self._dimensions}; skipping search")
+            return []
+
+        response = self._collection.query.near_vector(
+            near_vector=embedding, limit=top_k,
+            filters=self._build_filter(metadata_filter),
+            return_metadata=["distance"],
+        )
+
+        results = []
+        for obj in response.objects:
+            row = self._conn.execute(
+                "SELECT document_id, document_name, chunk_index, text FROM chunks WHERE weaviate_uuid = ?",
+                (str(obj.uuid),),
+            ).fetchone()
+            if row is None:
+                logger.warning(f"WeaviateBackend: object '{obj.uuid}' has no matching local text row, skipping")
+                continue
+            document_id, document_name, chunk_index, text = row
+            # Weaviate returns distance (lower = more similar), not a
+            # similarity score directly - convert to a similarity-style
+            # score for consistency with the other backends, which all
+            # return higher-is-better values.
+            distance = obj.metadata.distance if obj.metadata and obj.metadata.distance is not None else None
+            similarity_score = round(1.0 - distance, 4) if distance is not None else None
+            results.append({
+                "chunk_id": str(obj.uuid), "text": text, "similarity_score": similarity_score,
+                "document_id": document_id, "document_name": document_name, "chunk_index": chunk_index,
+            })
+        return results
+
+    def supports_sparse(self) -> bool:
+        return False
+
+    def list_documents(self, limit: int, offset: int) -> List[Dict]:
+        rows = self._conn.execute(
+            """SELECT d.id, d.filename, d.uploaded_at, d.metadata, COUNT(c.vector_key) AS chunk_count
+               FROM documents d LEFT JOIN chunks c ON c.document_id = d.id
+               GROUP BY d.id ORDER BY d.uploaded_at DESC LIMIT ? OFFSET ?""",
+            (limit, offset),
+        ).fetchall()
+        return [
+            {"document_id": r[0], "filename": r[1], "uploaded_at": r[2], "metadata": json.loads(r[3]), "chunk_count": r[4]}
+            for r in rows
+        ]
+
+    def delete_document(self, document_id: str) -> bool:
+        with self._lock:
+            weaviate_uuids = [r[0] for r in self._conn.execute(
+                "SELECT weaviate_uuid FROM chunks WHERE document_id = ?", (document_id,)
+            ).fetchall()]
+            if weaviate_uuids and self._collection is not None:
+                for wid in weaviate_uuids:
+                    self._collection.data.delete_by_id(wid)
+            cur = self._conn.execute("DELETE FROM documents WHERE id = ?", (document_id,))
+            self._conn.execute("DELETE FROM chunks WHERE document_id = ?", (document_id,))
+            deleted = cur.rowcount > 0
+            self._conn.commit()
+        return deleted
+
+    def get_document_filename(self, document_id: str) -> Optional[str]:
+        row = self._conn.execute("SELECT filename FROM documents WHERE id = ?", (document_id,)).fetchone()
+        return row[0] if row else None
+
+    def close(self) -> None:
+        """Weaviate's v4 client holds an open connection that should be
+        explicitly closed when done - unlike Pinecone's REST-based
+        client, this isn't automatic. Not called automatically by
+        RagLeap; callers managing WeaviateBackend's lifecycle directly
+        should call this when finished."""
+        if self._client is not None:
+            self._client.close()

--- a/packages/ragleap-rag/tests/test_milvus_backend.py
+++ b/packages/ragleap-rag/tests/test_milvus_backend.py
@@ -1,0 +1,161 @@
+"""Tests for MilvusBackend - NOT live-verified against a real Milvus/
+Zilliz Cloud instance (same honest caveat as the other new vector
+backends this session). Mocks the actual pymilvus MilvusClient
+entirely; every method signature used was verified against the actual
+installed pymilvus==3.0.1 package's real source during development
+(including that id_type="string" is a genuinely supported primary key
+type, not assumed from documentation alone)."""
+import pytest
+from unittest.mock import MagicMock
+
+pymilvus_available = True
+try:
+    import pymilvus  # noqa: F401
+except ImportError:
+    pymilvus_available = False
+
+pytestmark = pytest.mark.skipif(not pymilvus_available, reason="pymilvus not installed")
+
+
+def _make_backend(tmp_path, **kwargs):
+    from ragleap.vectorstores.milvus_backend import MilvusBackend
+    return MilvusBackend(persist_directory=str(tmp_path / "mv_data"), uri="https://fake.zillizcloud.com", token="fake-token", **kwargs)
+
+
+def test_requires_persist_directory():
+    from ragleap.vectorstores.milvus_backend import MilvusBackend
+    with pytest.raises(ValueError, match="requires persist_directory"):
+        MilvusBackend(persist_directory="", uri="https://fake.zillizcloud.com")
+
+
+def test_requires_uri(tmp_path):
+    from ragleap.vectorstores.milvus_backend import MilvusBackend
+    with pytest.raises(ValueError, match="No uri"):
+        MilvusBackend(persist_directory=str(tmp_path / "mv_data"), uri=None)
+
+
+def test_uri_from_env_var(tmp_path, monkeypatch):
+    monkeypatch.setenv("MILVUS_URI", "https://env-configured.zillizcloud.com")
+    from ragleap.vectorstores.milvus_backend import MilvusBackend
+    backend = MilvusBackend(persist_directory=str(tmp_path / "mv_data"))
+    assert backend.uri == "https://env-configured.zillizcloud.com"
+
+
+def test_vector_key_construction(tmp_path):
+    backend = _make_backend(tmp_path)
+    assert backend._vector_key("doc1", 0) == "doc1:0"
+    # Unlike Pinecone/Qdrant/Weaviate, Milvus uses the raw vector_key
+    # directly as its string primary key - no UUID indirection needed.
+
+
+def test_build_filter_expr_single_condition(tmp_path):
+    backend = _make_backend(tmp_path)
+    expr = backend._build_filter_expr({"tenant": "acme"})
+    assert expr == 'tenant == "acme"'
+
+
+def test_build_filter_expr_multiple_conditions_anded(tmp_path):
+    backend = _make_backend(tmp_path)
+    expr = backend._build_filter_expr({"tenant": "acme", "region": "us"})
+    assert " and " in expr
+    assert 'tenant == "acme"' in expr
+    assert 'region == "us"' in expr
+
+
+def test_build_filter_expr_numeric_value_not_quoted(tmp_path):
+    backend = _make_backend(tmp_path)
+    expr = backend._build_filter_expr({"chunk_index": 5})
+    assert expr == "chunk_index == 5"
+
+
+def test_build_filter_expr_empty_when_no_filter(tmp_path):
+    backend = _make_backend(tmp_path)
+    assert backend._build_filter_expr(None) == ""
+    assert backend._build_filter_expr({}) == ""
+
+
+def test_insert_document_and_list_documents(tmp_path):
+    backend = _make_backend(tmp_path)
+    backend.insert_document("doc1", "test.txt", {"tenant": "acme"})
+    docs = backend.list_documents(limit=10, offset=0)
+    assert len(docs) == 1
+    assert docs[0]["metadata"] == {"tenant": "acme"}
+
+
+def test_insert_chunk_calls_insert_with_correct_row(tmp_path):
+    backend = _make_backend(tmp_path)
+    backend._client = MagicMock()
+
+    backend.insert_chunk(
+        document_id="doc1", document_name="test.txt", chunk_index=0,
+        text="chunk text", token_count=5, embedding=[0.1, 0.2], metadata={"tenant": "acme"},
+    )
+
+    backend._client.insert.assert_called_once()
+    call_kwargs = backend._client.insert.call_args.kwargs
+    data = call_kwargs["data"]
+    assert len(data) == 1
+    assert data[0]["id"] == "doc1:0"
+    assert data[0]["vector"] == [0.1, 0.2]
+    assert data[0]["tenant"] == "acme"
+
+    row = backend._conn.execute("SELECT text FROM chunks WHERE vector_key = ?", ("doc1:0",)).fetchone()
+    assert row[0] == "chunk text"
+
+
+def test_search_dense_returns_chunks_with_text_from_sqlite(tmp_path):
+    backend = _make_backend(tmp_path)
+    backend._dimensions = 2
+    backend._client = MagicMock()
+
+    backend._conn.execute(
+        "INSERT INTO chunks (vector_key, document_id, document_name, chunk_index, text, token_count, metadata) "
+        "VALUES ('doc1:0', 'doc1', 'test.txt', 0, 'real text', 5, '{}')"
+    )
+    backend._conn.commit()
+
+    # search() returns List[List[dict]] - list per query vector
+    backend._client.search.return_value = [[{"id": "doc1:0", "distance": 0.87}]]
+
+    results = backend.search_dense(embedding=[0.1, 0.2], top_k=5)
+
+    assert len(results) == 1
+    assert results[0]["text"] == "real text"
+    assert results[0]["similarity_score"] == 0.87
+
+
+def test_search_dense_skips_orphaned_hits(tmp_path):
+    backend = _make_backend(tmp_path)
+    backend._dimensions = 2
+    backend._client = MagicMock()
+
+    backend._client.search.return_value = [[{"id": "orphaned-not-in-sqlite", "distance": 0.5}]]
+
+    results = backend.search_dense(embedding=[0.1, 0.2], top_k=5)
+    assert results == []
+
+
+def test_delete_document_calls_delete_with_vector_keys(tmp_path):
+    backend = _make_backend(tmp_path)
+    backend._client = MagicMock()
+
+    backend.insert_document("doc1", "test.txt", {})
+    backend._conn.execute(
+        "INSERT INTO chunks (vector_key, document_id, document_name, chunk_index, text, token_count, metadata) "
+        "VALUES ('doc1:0', 'doc1', 'test.txt', 0, 'text', 5, '{}')"
+    )
+    backend._conn.commit()
+
+    deleted = backend.delete_document("doc1")
+    assert deleted is True
+    backend._client.delete.assert_called_once_with(collection_name=backend.collection_name, ids=["doc1:0"])
+
+
+def test_supports_sparse_is_false(tmp_path):
+    backend = _make_backend(tmp_path)
+    assert backend.supports_sparse() is False
+
+
+def test_milvus_backend_importable_from_vectorstores():
+    from ragleap.vectorstores import MilvusBackend
+    assert MilvusBackend is not None

--- a/packages/ragleap-rag/tests/test_qdrant_backend.py
+++ b/packages/ragleap-rag/tests/test_qdrant_backend.py
@@ -1,0 +1,164 @@
+"""Tests for QdrantBackend - NOT live-verified against a real Qdrant
+instance (same honest caveat as PineconeBackend/WeaviateBackend).
+Mocks the actual Qdrant client entirely; every method signature and
+pydantic model field used was verified against the actual installed
+qdrant-client==1.18.0 package's real source during development."""
+import pytest
+from unittest.mock import MagicMock
+
+qdrant_available = True
+try:
+    import qdrant_client  # noqa: F401
+except ImportError:
+    qdrant_available = False
+
+pytestmark = pytest.mark.skipif(not qdrant_available, reason="qdrant-client not installed")
+
+
+def _make_backend(tmp_path, **kwargs):
+    from ragleap.vectorstores.qdrant_backend import QdrantBackend
+    return QdrantBackend(persist_directory=str(tmp_path / "qd_data"), url="https://fake.qdrant.cloud", api_key="fake-key", **kwargs)
+
+
+def test_requires_persist_directory():
+    from ragleap.vectorstores.qdrant_backend import QdrantBackend
+    with pytest.raises(ValueError, match="requires persist_directory"):
+        QdrantBackend(persist_directory="", url="https://fake.qdrant.cloud")
+
+
+def test_requires_url(tmp_path):
+    from ragleap.vectorstores.qdrant_backend import QdrantBackend
+    with pytest.raises(ValueError, match="No url"):
+        QdrantBackend(persist_directory=str(tmp_path / "qd_data"), url=None)
+
+
+def test_url_from_env_var(tmp_path, monkeypatch):
+    monkeypatch.setenv("QDRANT_URL", "https://env-configured.qdrant.cloud")
+    from ragleap.vectorstores.qdrant_backend import QdrantBackend
+    backend = QdrantBackend(persist_directory=str(tmp_path / "qd_data"))
+    assert backend.url == "https://env-configured.qdrant.cloud"
+
+
+def test_vector_key_construction(tmp_path):
+    backend = _make_backend(tmp_path)
+    assert backend._vector_key("doc1", 0) == "doc1:0"
+
+
+def test_deterministic_uuid_is_stable(tmp_path):
+    backend = _make_backend(tmp_path)
+    uuid1 = backend._deterministic_uuid("doc1:0")
+    uuid2 = backend._deterministic_uuid("doc1:0")
+    assert uuid1 == uuid2
+
+
+def test_build_filter_translates_correctly(tmp_path):
+    backend = _make_backend(tmp_path)
+    result = backend._build_filter({"tenant": "acme"})
+    assert result is not None
+    assert len(result.must) == 1
+    assert result.must[0].key == "tenant"
+    assert result.must[0].match.value == "acme"
+
+
+def test_build_filter_none_when_empty(tmp_path):
+    backend = _make_backend(tmp_path)
+    assert backend._build_filter(None) is None
+    assert backend._build_filter({}) is None
+
+
+def test_insert_document_and_list_documents(tmp_path):
+    backend = _make_backend(tmp_path)
+    backend.insert_document("doc1", "test.txt", {"tenant": "acme"})
+    docs = backend.list_documents(limit=10, offset=0)
+    assert len(docs) == 1
+    assert docs[0]["metadata"] == {"tenant": "acme"}
+
+
+def test_insert_chunk_calls_upsert_with_correct_point(tmp_path):
+    backend = _make_backend(tmp_path)
+    backend._client = MagicMock()
+
+    backend.insert_chunk(
+        document_id="doc1", document_name="test.txt", chunk_index=0,
+        text="chunk text", token_count=5, embedding=[0.1, 0.2], metadata={"tenant": "acme"},
+    )
+
+    backend._client.upsert.assert_called_once()
+    call_kwargs = backend._client.upsert.call_args.kwargs
+    points = call_kwargs["points"]
+    assert len(points) == 1
+    assert points[0].vector == [0.1, 0.2]
+    assert points[0].payload["document_id"] == "doc1"
+
+    row = backend._conn.execute("SELECT text FROM chunks WHERE vector_key = ?", ("doc1:0",)).fetchone()
+    assert row[0] == "chunk text"
+
+
+def test_search_dense_returns_chunks_with_text_from_sqlite(tmp_path):
+    backend = _make_backend(tmp_path)
+    backend._dimensions = 2
+    backend._client = MagicMock()
+
+    qdrant_id = backend._deterministic_uuid("doc1:0")
+    backend._conn.execute(
+        "INSERT INTO chunks (vector_key, qdrant_id, document_id, document_name, chunk_index, text, token_count, metadata) "
+        "VALUES ('doc1:0', ?, 'doc1', 'test.txt', 0, 'real text', 5, '{}')",
+        (qdrant_id,),
+    )
+    backend._conn.commit()
+
+    mock_point = MagicMock()
+    mock_point.id = qdrant_id
+    mock_point.score = 0.95
+    mock_response = MagicMock()
+    mock_response.points = [mock_point]
+    backend._client.query_points.return_value = mock_response
+
+    results = backend.search_dense(embedding=[0.1, 0.2], top_k=5)
+
+    assert len(results) == 1
+    assert results[0]["text"] == "real text"
+    assert results[0]["similarity_score"] == 0.95
+
+
+def test_search_dense_skips_orphaned_points(tmp_path):
+    backend = _make_backend(tmp_path)
+    backend._dimensions = 2
+    backend._client = MagicMock()
+
+    mock_point = MagicMock()
+    mock_point.id = "orphaned-id-not-in-sqlite"
+    mock_response = MagicMock()
+    mock_response.points = [mock_point]
+    backend._client.query_points.return_value = mock_response
+
+    results = backend.search_dense(embedding=[0.1, 0.2], top_k=5)
+    assert results == []
+
+
+def test_delete_document_calls_delete_with_point_ids(tmp_path):
+    backend = _make_backend(tmp_path)
+    backend._client = MagicMock()
+
+    backend.insert_document("doc1", "test.txt", {})
+    qdrant_id = backend._deterministic_uuid("doc1:0")
+    backend._conn.execute(
+        "INSERT INTO chunks (vector_key, qdrant_id, document_id, document_name, chunk_index, text, token_count, metadata) "
+        "VALUES ('doc1:0', ?, 'doc1', 'test.txt', 0, 'text', 5, '{}')",
+        (qdrant_id,),
+    )
+    backend._conn.commit()
+
+    deleted = backend.delete_document("doc1")
+    assert deleted is True
+    backend._client.delete.assert_called_once_with(collection_name=backend.collection_name, points_selector=[qdrant_id])
+
+
+def test_supports_sparse_is_false(tmp_path):
+    backend = _make_backend(tmp_path)
+    assert backend.supports_sparse() is False
+
+
+def test_qdrant_backend_importable_from_vectorstores():
+    from ragleap.vectorstores import QdrantBackend
+    assert QdrantBackend is not None

--- a/packages/ragleap-rag/tests/test_weaviate_backend.py
+++ b/packages/ragleap-rag/tests/test_weaviate_backend.py
@@ -1,0 +1,146 @@
+"""Tests for WeaviateBackend - NOT live-verified against a real
+Weaviate instance (same honest caveat as PineconeBackend). Mocks the
+actual Weaviate client entirely; every attribute path verified against
+the actual installed weaviate-client==4.22.0 package's real source
+during development (self.collections/self.data/self.query are real
+instance attributes set in __init__, not class-level methods -
+confirmed by reading the actual source, not assumed)."""
+import pytest
+from unittest.mock import MagicMock, patch
+
+weaviate_available = True
+try:
+    import weaviate  # noqa: F401
+except ImportError:
+    weaviate_available = False
+
+pytestmark = pytest.mark.skipif(not weaviate_available, reason="weaviate-client not installed")
+
+
+def _make_backend(tmp_path, **kwargs):
+    from ragleap.vectorstores.weaviate_backend import WeaviateBackend
+    return WeaviateBackend(persist_directory=str(tmp_path / "wv_data"), cluster_url="https://fake.weaviate.cloud", api_key="fake-key", **kwargs)
+
+
+def test_requires_persist_directory():
+    from ragleap.vectorstores.weaviate_backend import WeaviateBackend
+    with pytest.raises(ValueError, match="requires persist_directory"):
+        WeaviateBackend(persist_directory="", cluster_url="https://fake.weaviate.cloud")
+
+
+def test_collection_name_normalized_to_uppercase_first_letter(tmp_path):
+    backend = _make_backend(tmp_path, collection_name="myCollection")
+    assert backend.collection_name == "MyCollection"
+
+
+def test_vector_key_construction(tmp_path):
+    backend = _make_backend(tmp_path)
+    assert backend._vector_key("doc1", 0) == "doc1:0"
+
+
+def test_deterministic_uuid_is_stable(tmp_path):
+    backend = _make_backend(tmp_path)
+    uuid1 = backend._deterministic_uuid("doc1:0")
+    uuid2 = backend._deterministic_uuid("doc1:0")
+    uuid3 = backend._deterministic_uuid("doc1:1")
+    assert uuid1 == uuid2  # same input -> same UUID, idempotent
+    assert uuid1 != uuid3
+
+
+def test_insert_document_and_list_documents(tmp_path):
+    backend = _make_backend(tmp_path)
+    backend.insert_document("doc1", "test.txt", {"tenant": "acme"})
+    docs = backend.list_documents(limit=10, offset=0)
+    assert len(docs) == 1
+    assert docs[0]["document_id"] == "doc1"
+    assert docs[0]["metadata"] == {"tenant": "acme"}
+
+
+def test_insert_chunk_calls_data_insert_with_correct_args(tmp_path):
+    backend = _make_backend(tmp_path)
+    backend._collection = MagicMock()
+
+    backend.insert_chunk(
+        document_id="doc1", document_name="test.txt", chunk_index=0,
+        text="chunk text", token_count=5, embedding=[0.1, 0.2], metadata={"tenant": "acme"},
+    )
+
+    backend._collection.data.insert.assert_called_once()
+    call_kwargs = backend._collection.data.insert.call_args.kwargs
+    assert call_kwargs["vector"] == [0.1, 0.2]
+    assert call_kwargs["properties"]["document_id"] == "doc1"
+    assert call_kwargs["properties"]["tenant"] == "acme"
+    assert "uuid" in call_kwargs
+
+    row = backend._conn.execute("SELECT text FROM chunks WHERE vector_key = ?", ("doc1:0",)).fetchone()
+    assert row[0] == "chunk text"
+
+
+def test_search_dense_converts_distance_to_similarity_score(tmp_path):
+    backend = _make_backend(tmp_path)
+    backend._dimensions = 2
+    backend._collection = MagicMock()
+
+    weaviate_uuid = backend._deterministic_uuid("doc1:0")
+    backend._conn.execute(
+        "INSERT INTO chunks (vector_key, weaviate_uuid, document_id, document_name, chunk_index, text, token_count, metadata) "
+        "VALUES ('doc1:0', ?, 'doc1', 'test.txt', 0, 'real text', 5, '{}')",
+        (weaviate_uuid,),
+    )
+    backend._conn.commit()
+
+    mock_obj = MagicMock()
+    mock_obj.uuid = weaviate_uuid
+    mock_obj.metadata.distance = 0.2  # distance 0.2 -> similarity 0.8
+    mock_response = MagicMock()
+    mock_response.objects = [mock_obj]
+    backend._collection.query.near_vector.return_value = mock_response
+
+    results = backend.search_dense(embedding=[0.1, 0.2], top_k=5)
+
+    assert len(results) == 1
+    assert results[0]["text"] == "real text"
+    assert results[0]["similarity_score"] == 0.8
+
+
+def test_search_dense_skips_orphaned_objects(tmp_path):
+    backend = _make_backend(tmp_path)
+    backend._dimensions = 2
+    backend._collection = MagicMock()
+
+    mock_obj = MagicMock()
+    mock_obj.uuid = "orphaned-uuid-not-in-sqlite"
+    mock_response = MagicMock()
+    mock_response.objects = [mock_obj]
+    backend._collection.query.near_vector.return_value = mock_response
+
+    results = backend.search_dense(embedding=[0.1, 0.2], top_k=5)
+    assert results == []
+
+
+def test_delete_document_calls_delete_by_id_for_each_chunk(tmp_path):
+    backend = _make_backend(tmp_path)
+    backend._collection = MagicMock()
+
+    backend.insert_document("doc1", "test.txt", {})
+    weaviate_uuid = backend._deterministic_uuid("doc1:0")
+    backend._conn.execute(
+        "INSERT INTO chunks (vector_key, weaviate_uuid, document_id, document_name, chunk_index, text, token_count, metadata) "
+        "VALUES ('doc1:0', ?, 'doc1', 'test.txt', 0, 'text', 5, '{}')",
+        (weaviate_uuid,),
+    )
+    backend._conn.commit()
+
+    deleted = backend.delete_document("doc1")
+    assert deleted is True
+    backend._collection.data.delete_by_id.assert_called_once_with(weaviate_uuid)
+
+
+def test_supports_sparse_is_false(tmp_path):
+    backend = _make_backend(tmp_path)
+    assert backend.supports_sparse() is False
+
+
+def test_weaviate_backend_importable_from_vectorstores():
+    from ragleap.vectorstores import WeaviateBackend
+    assert WeaviateBackend is not None


### PR DESCRIPTION
Completes the originally-planned vector backend roadmap.

- Three new backends implementing VectorBackend, following the same SQLite-sidecar-plus-remote-vector-store pattern as PineconeBackend
- New [weaviate]/[qdrant]/[milvus] extras
- NOT live-verified against real instances (no accounts available) - same honest caveat as PineconeBackend. Every method signature, class field, and return-type structure was introspected directly against each package's actual installed source code (weaviate-client==4.22.0, qdrant-client==1.18.0, pymilvus==3.0.1), not assumed from docs - same rigor that caught a real pre-ship bug in PineconeBackend
- WeaviateBackend: self-provided vectors (BYOK embeddings), Weaviate assigns its own UUIDs so a deterministic UUID is derived from document_id:chunk_index; distance converted to similarity score (1.0 - distance) for consistency with other backends
- QdrantBackend: PointStruct.id's type hint allows any str, but real runtime validation requires string IDs to parse as valid UUIDs (a documented type-hint/runtime gap) - deterministic UUIDs used here too
- MilvusBackend: unlike the other three, id_type='string' genuinely accepts arbitrary string primary keys directly - no UUID workaround needed. enable_dynamic_field=True means metadata inserts directly without pre-declared schema
- All three require persist_directory= (not optional like FAISS) - same orphaned-vector-after-restart reasoning as PineconeBackend
- supports_sparse() is False for all three even though each natively supports sparse/BM25/hybrid search - real future enhancement, not attempted here to keep scope honest and verifiable
- 40 new tests across 3 files (198 -> 238 passing)
- ragleap-rag now supports 6 vector storage options: pgvector, FAISS, Pinecone, Weaviate, Qdrant, Milvus

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
