### PR TITLE
docs: fix stale architecture diagram + bump to 0.11.1

### DIFF
--- a/packages/ragleap-rag/CHANGELOG.md
+++ b/packages/ragleap-rag/CHANGELOG.md
@@ -8,6 +8,11 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `docs`: Celery integration guide + runnable example ([#57](https://github.com/antonyrag/ragleap-core/pull/57))
 - `test`: comprehensive pytest suite (67 tests) + CI integration — first automated testing this package has had ([#58](https://github.com/antonyrag/ragleap-core/pull/58))
 
+## [0.11.1]
+
+### Fixed
+- README's "How it fits together" architecture diagram was stale - hardcoded "PostgreSQL + pgvector" as the only storage layer (predates vector backend pluggability), and showed nothing about query rewriting, structured output, or cost tracking, all of which now sit in the actual request flow. Updated to reflect the real current architecture.
+
 ## [0.11.0]
 
 ### Added

--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -624,19 +624,34 @@ See `examples/05_celery_background_tasks.py` for the full runnable version.
              +--------+---------+
                       |
              +--------v---------+
-             |  PostgreSQL +     |
-             |  pgvector         |
+             |  Vector backend   |   pgvector (default), or FAISS/Pinecone/
+             |  (pluggable)      |   Weaviate/Qdrant/Milvus via vector_backend=
              +--------+---------+
                       |
              +--------v---------+
-             |   rag.ask(...)    |   hybrid retrieve (dense + sparse, RRF)
+             |   rag.ask(...)    |
+             +--------+---------+
+                      |
+             +--------v---------+
+             | query_rewrite=    |   optional: "contextual"/"hyde"/"multi_query"
+             | (optional)        |   transforms the query before retrieval
+             +--------+---------+
+                      |
+             +--------v---------+
+             |  Hybrid retrieve  |   dense + sparse (RRF) - degrades to
+             |                   |   dense-only if the backend can't do sparse
              +--------+---------+          |
                       |                     v
              +--------v---------+   +---------------+
              |   Generation      |-->| Fallback chain |
              |  (temp/prompt/    |   | (if primary    |
-             |   max_tokens)     |   |  fails)        |
+             |   response_format)|   |  fails)        |
              +--------+---------+   +---------------+
+                      |
+             +--------v---------+
+             |  Cost tracking +  |   real token usage -> cost_usd; output
+             |  guardrails       |   guardrails run on the answer
+             +--------+---------+
                       |
              +--------v---------+
              |  Conversation     |   optional: session_id ->

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.11.0"
+version = "0.11.1"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -45,7 +45,7 @@ from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult", "TranscriptionConfig", "VectorBackend", "PgVectorBackend"]
 
 


### PR DESCRIPTION
README's 'How it fits together' diagram hardcoded PostgreSQL + pgvector as the only storage layer and showed nothing about query rewriting, structured output, or cost tracking - all real parts of the current request flow. Diagram updated. Docs-only change, no code changes.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
