### PR TITLE
ci: fix SBOM workflow push to protected main

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository
@@ -47,11 +48,24 @@ jobs:
           path: packages/ragleap-rag/sbom.json
           retention-days: 90
 
-      - name: Commit updated SBOM back to repo
+      - name: Check for SBOM changes
+        id: sbom_diff
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add packages/ragleap-rag/sbom.json
-          git diff --cached --quiet && echo "No SBOM changes to commit" && exit 0
-          git commit -m "chore: regenerate SBOM [skip ci]"
-          git push
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open PR with updated SBOM
+        if: steps.sbom_diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: regenerate SBOM"
+          branch: ci/sbom-update
+          delete-branch: true
+          title: "chore: regenerate SBOM"
+          body: "Automated SBOM regeneration (CycloneDX) reflecting current ragleap-rag dependencies. Triggered by ${{ github.event_name }}."
+          add-paths: |
+            packages/ragleap-rag/sbom.json


### PR DESCRIPTION
First SBOM run failed because main has branch protection requiring PRs. Switches to opening a PR (ci/sbom-update) via peter-evans/create-pull-request instead of direct push.