### PR TITLE
ci: use PAT for SBOM PR to satisfy required checks

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -62,6 +62,7 @@ jobs:
         if: steps.sbom_diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
+          token: ${{ secrets.SBOM_PR_TOKEN }}
           commit-message: "chore: regenerate SBOM"
           branch: ci/sbom-update
           delete-branch: true


### PR DESCRIPTION
The default GITHUB_TOKEN doesn't trigger workflows on its own pushes (GitHub's loop-prevention), so the auto-generated SBOM PR had zero status checks and couldn't merge under our required-checks ruleset. Switches to a repo-scoped fine-grained PAT (SBOM_PR_TOKEN secret) so the SBOM PR triggers CI normally, like a human push would.