### PR TITLE
docs: fix README diagram to show real multi-modal ingestion

### DIFF
--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -615,8 +615,9 @@ See `examples/05_celery_background_tasks.py` for the full runnable version.
 
 ## How it fits together
              +------------------+
-             |   Your text or   |
-             |  .txt/.pdf/.docx |
+             | Text, 28 formats |
+             |  URLs, images,   |
+             |   audio, video   |
              +--------+---------+
                       |
              +--------v---------+


### PR DESCRIPTION
The 'How it fits together' architecture diagram's top box only mentioned .txt/.pdf/.docx, which undersells a real, verified capability: rag.ingest() supports 28 file formats, and there are dedicated methods for URLs, images (OCR + vision), audio, and video.

This is the actual PyPI-facing README (packages/ragleap-rag/README.md, confirmed via pyproject.toml's readme= field) - the monorepo-root README.md is a separate document, not what renders on the package page.