### PR TITLE
release: v0.11.2

### DIFF
--- a/packages/ragleap-rag/CHANGELOG.md
+++ b/packages/ragleap-rag/CHANGELOG.md
@@ -5,8 +5,17 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-- `docs`: Celery integration guide + runnable example ([#57](https://github.com/antonyrag/ragleap-core/pull/57))
-- `test`: comprehensive pytest suite (67 tests) + CI integration — first automated testing this package has had ([#58](https://github.com/antonyrag/ragleap-core/pull/58))
+## [0.11.2] - 2026-08-04
+
+### Fixed
+- The README's "How it fits together" diagram fix in v0.11.1 was incomplete: the ingestion box still only listed `.txt/.pdf/.docx`, omitting the real 28-format + URL + image + audio + video ingestion support that already exists (`ingest()`, `ingest_url()`, `ingest_image()`, `ingest_audio()`, `ingest_video()`). Corrected to reflect actual ingestion breadth.
+- The separate Celery background-task architecture diagram showed "PostgreSQL + pgvector" as if it were required for background/async usage. Clarified that this reflects only the example's default (it omits `vector_backend=`) — any of the 6 supported backends works identically in the same Celery pattern.
+
+### Documentation
+- Celery integration guide + runnable example ([#57](https://github.com/antonyrag/ragleap-core/pull/57))
+
+### Testing
+- Comprehensive pytest suite (67 tests) + CI integration — first automated testing this package has had ([#58](https://github.com/antonyrag/ragleap-core/pull/58))
 
 ## [0.11.1]
 

--- a/packages/ragleap-rag/benchmark/run_benchmark.py
+++ b/packages/ragleap-rag/benchmark/run_benchmark.py
@@ -31,7 +31,7 @@ from ragleap.vectorstores import PgVectorBackend, FAISSBackend
 # ---------------------------------------------------------------------------
 # Config — adjust these if your environment differs
 # ---------------------------------------------------------------------------
-PG_DSN_MAIN = "postgresql://ragleap_test_user:ragleap_test_pass@127.0.0.1:5432/ragleap_test"
+PG_DSN_MAIN = "postgresql://ragleap_test_user:ragleap_test_pass@127.0.0.1:5432/ragleap_bench_gemini"
 PG_DSN_OLLAMA = "postgresql://ragleap_test_user:ragleap_test_pass@127.0.0.1:5432/ragleap_bench_ollama"
 FAISS_DIR = "/tmp/ragleap_bench_faiss"
 

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.11.1"
+version = "0.11.2"
 description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -45,7 +45,7 @@ from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.11.1"
+__version__ = "0.11.2"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult", "TranscriptionConfig", "VectorBackend", "PgVectorBackend"]
 
 


### PR DESCRIPTION
Patch release completing the README diagram fix work.

## Fixed
- README diagram fix from v0.11.1 was incomplete - two more stale-architecture instances found and corrected (ingestion box, Celery example diagram)

## Fixed (infra)
- run_benchmark.py was pointed at ragleap_test, the same database pytest uses. A benchmark run overwrote the test suite's table schema with real 3072-dim embeddings, breaking 86 tests until manually caught and fixed. Now uses a dedicated ragleap_bench_gemini database.

## Verified
- Full test suite: 238/238 passing after the DB isolation fix
- This is the incident that prompted the fix: caught via a full pytest run before this release, not discovered after publish