### PR TITLE
feat: ragleap-rag v0.12.0/v0.12.1 - RagLeap.retrieve() + PyPI metadat…

### DIFF
--- a/packages/ragleap-rag/CHANGELOG.md
+++ b/packages/ragleap-rag/CHANGELOG.md
@@ -5,6 +5,19 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-08-08
+
+### Fixed
+- PyPI metadata (description, keywords) corrected. The previous draft description claimed "knowledge-graph integration via ragleap-graph" - backwards: ragleap-rag has zero dependency on or awareness of ragleap-graph; it is the other way around (ragleap-graph optionally depends on ragleap-rag, per retrieval.py's own docstring: "No knowledge-graph coupling here by design"). Corrected to describe ragleap-rag's real, standalone feature set accurately, with ragleap-graph mentioned only as an optional composable package - not an integration ragleap-rag itself has. Also removed the "neo4j" keyword, which implied a dependency that does not exist.
+
+## [0.12.0] - 2026-08-08
+
+### Added
+- `RagLeap.retrieve(query, top_k=5, hybrid=True, rerank=False, metadata_filter=None)` - retrieves chunks using the same embed -> search -> (optional rerank) pipeline as `ask()`, stopping before generation. Returns raw chunks, not an answer.
+- Added to give external callers a real, public, tested entry point to retrieval-only results, instead of needing an LLM generation call they don't want, or reaching into private internals (`_vector_backend`, `_embed_query_cached()`) across a package boundary. First concrete consumer: `ragleap-graph`'s upcoming `GraphRetriever` (v0.3.0), which combines this with graph traversal.
+- Does not support `query_rewrite=` or `session_id=` - those involve LLM calls and conversation-history orchestration that `ask()` owns; pass an already-rewritten query string directly if needed.
+- 6 new tests covering top_k, metadata_filter, hybrid/dense-only mode, rerank plumbing, empty-corpus behavior, and (critically) that `retrieve()` never triggers generation - verified via a test that makes the generator explode if called, so a future regression back to invoking `generate_answer()` fails loudly rather than just costing unnoticed extra tokens.
+
 ## [0.11.2] - 2026-08-04
 
 ### Fixed

--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -117,6 +117,24 @@ Every `ask()` response tells you which provider actually answered
 (`answer["usage"]`) — real numbers pulled from the provider's own
 response, not an estimate.
 
+## Retrieval-only
+
+Need chunks without paying for or waiting on a generation call?
+`retrieve()` runs the same embed -> search -> (optional rerank)
+pipeline `ask()` uses, and stops before generation:
+
+```python
+chunks = rag.retrieve("pricing plans", top_k=5, hybrid=True)
+# [{"chunk_id": ..., "text": ..., "document_name": ..., "similarity_score": ...}, ...]
+```
+
+Useful for building your own retrieval logic on top of ragleap-rag's
+tested pipeline — for example, `ragleap-graph`'s `GraphRetriever`
+combines this with knowledge-graph traversal. Does not support
+`query_rewrite=` or `session_id=` (those involve LLM calls and
+conversation-history orchestration that `ask()` owns) — pass an
+already-rewritten query string directly if you need that.
+
 ## Streaming
 
 ```python
@@ -714,8 +732,8 @@ retrieval is.
 `ragleap-rag` is the foundation layer of
 [ragleap-core](https://github.com/antonyrag/ragleap-core), a larger
 open-source, self-hosted AI platform (channels, knowledge graph,
-language detection, business integrations). Companion packages
-(`ragleap-graph`, `ragleap-integrations`) are in progress.
+language detection, business integrations). Companion package `ragleap-graph` (knowledge-graph-augmented
+retrieval) is published; `ragleap-integrations` is in progress.
 
 ## Status
 

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,15 +4,15 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.11.2"
-description = "A fast, honest, self-hosted RAG engine — hybrid dense+sparse retrieval, streaming, provider fallback, and real token usage reporting. BYOK, no vendor lock-in."
+version = "0.12.1"
+description = "Self-hosted RAG engine: hybrid dense+sparse retrieval, 28-format ingestion (docs, URLs, images, audio, video), 6 vector backends, 8 embedding providers, 12+ generation providers with automatic fallback, query rewriting (HyDE/contextual/multi-query), structured JSON output, real per-call cost tracking, and standalone retrieval via retrieve(). Composable with the optional ragleap-graph package for knowledge-graph-augmented retrieval. BYOK, no vendor lock-in, no hardcoded model defaults."
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"
 authors = [
     { name = "Antony", email = "antony@ragleap.com" }
 ]
-keywords = ["rag", "retrieval-augmented-generation", "llm", "vector-search", "pgvector", "hybrid-search"]
+keywords = ["rag", "retrieval-augmented-generation", "llm", "vector-search", "pgvector", "hybrid-search", "embeddings", "faiss", "pinecone", "weaviate", "qdrant", "milvus", "gemini", "anthropic", "openai", "reranking", "structured-output", "query-rewriting", "cost-tracking", "self-hosted", "byok"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -45,7 +45,7 @@ from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.11.2"
+__version__ = "0.12.1"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult", "TranscriptionConfig", "VectorBackend", "PgVectorBackend"]
 
 
@@ -478,6 +478,52 @@ class RagLeap:
             self._memory.add_message(session_id, "assistant", result["answer"])
 
         return result
+
+    def retrieve(
+        self,
+        query: str,
+        top_k: int = 5,
+        hybrid: bool = True,
+        rerank: bool = False,
+        metadata_filter: Optional[Dict] = None,
+    ) -> List[Dict]:
+        """
+        Retrieve chunks for a query without generating an answer - the
+        same embed -> search -> (optional rerank) pipeline ask() uses,
+        stopping before generation. Useful for callers (e.g.
+        ragleap-graph's GraphRetriever) that want raw retrieved chunks
+        to combine with other retrieval signals themselves, without
+        paying for or waiting on an LLM generation call they don't need.
+
+        Does not support query_rewrite= or session_id= - those involve
+        LLM calls and conversation-history orchestration that ask()
+        owns. Pass an already-rewritten query string directly if needed.
+        """
+        query_embedding = self._embed_query_cached(query)
+        if query_embedding is None:
+            return []
+
+        pool_size = top_k * 4 if rerank else top_k
+        if hybrid:
+            chunks = self._vector_backend.search_hybrid(
+                query, query_embedding, top_k=pool_size, metadata_filter=metadata_filter
+            )
+        else:
+            chunks = self._vector_backend.search_dense(
+                query_embedding, top_k=pool_size, metadata_filter=metadata_filter
+            )
+
+        if rerank and chunks:
+            if self._reranker is None:
+                self._reranker = RerankerService()
+            chunks = self._reranker.rerank(query, chunks, top_k=top_k)
+
+        fire_event(
+            {"query": query, "hybrid": hybrid, "rerank": rerank, "top_k": top_k,
+             "chunks_retrieved": len(chunks), "streaming": False, "query_rewrite": None},
+            self._on_query, "on_query",
+        )
+        return chunks
 
     def ask_stream(
         self,

--- a/packages/ragleap-rag/tests/test_retrieval.py
+++ b/packages/ragleap-rag/tests/test_retrieval.py
@@ -1,3 +1,5 @@
+import pytest
+
 """Tests for the active VectorBackend's retrieval methods - dense (fake
 embeddings, plumbing only), sparse (real Postgres full-text search,
 genuinely meaningful), and hybrid RRF fusion. Accesses rag's internal
@@ -67,3 +69,78 @@ def test_backend_reports_sparse_support(rag):
     this isn't a formality, ask()/ask_stream() could check it before
     assuming hybrid mode does anything beyond dense search."""
     assert rag._vector_backend.supports_sparse() is True
+
+
+def test_retrieve_returns_chunks_without_generating_answer(rag, monkeypatch):
+    """retrieve() must never call generation - verify by making the
+    generator explode if invoked, so a silent regression back to
+    calling generate_answer() fails loudly instead of just costing
+    extra tokens unnoticed."""
+    from ragleap.generation import GenerationService
+
+    def _explode(self, *args, **kwargs):
+        raise AssertionError("retrieve() must not call generate_answer()")
+
+    monkeypatch.setattr(GenerationService, "generate_answer", _explode)
+
+    rag.ingest_text(filename="a.txt", text="This document specifically discusses giraffes.")
+    chunks = rag.retrieve("giraffes", top_k=1)
+
+    assert len(chunks) == 1
+    assert chunks[0]["document_name"] == "a.txt"
+    assert "text" in chunks[0]
+    assert "answer" not in chunks[0]
+
+
+def test_retrieve_respects_top_k(rag):
+    rag.ingest_text(filename="a.txt", text="Alpha content one.")
+    rag.ingest_text(filename="b.txt", text="Alpha content two.")
+    rag.ingest_text(filename="c.txt", text="Alpha content three.")
+
+    chunks = rag.retrieve("Alpha content", top_k=2)
+    assert len(chunks) <= 2
+
+
+def test_retrieve_respects_metadata_filter(rag):
+    rag.ingest_text(filename="a.txt", text="Content about pricing plans.", metadata={"tenant": "acme"})
+    rag.ingest_text(filename="b.txt", text="Content about pricing plans.", metadata={"tenant": "globex"})
+
+    chunks = rag.retrieve("pricing plans", top_k=5, metadata_filter={"tenant": "acme"})
+    assert len(chunks) == 1
+    assert chunks[0]["document_name"] == "a.txt"
+
+
+def test_retrieve_dense_only_when_hybrid_false(rag):
+    rag.ingest_text(filename="a.txt", text="Some content about widgets.")
+    chunks = rag.retrieve("widgets", top_k=5, hybrid=False)
+    # Dense-only path shouldn't tag results as hybrid_rrf.
+    assert all(c.get("retrieval_method") != "hybrid_rrf" for c in chunks)
+
+
+def test_retrieve_no_documents_returns_empty(rag):
+    """Note: NOT testing "no semantic match" with an ingested document -
+    the rag fixture uses fake deterministic pseudo-embeddings with no
+    real semantic signal (see conftest.py), so with only one document
+    in the corpus, dense search always returns it as nearest-neighbor
+    regardless of query content. That is expected fake-embedder
+    behavior, not a retrieve() bug - caught by an earlier, wrongly-
+    written version of this test. Testing the unambiguous case instead:
+    zero ingested documents must return zero chunks."""
+    chunks = rag.retrieve("anything", top_k=5)
+    assert chunks == []
+
+
+def test_retrieve_with_rerank_does_not_crash(rag):
+    """rerank=True lazily constructs a RerankerService - just verify
+    the plumbing doesn't break, not reranking quality (out of scope
+    here, already covered in test_reranking.py). Skips cleanly if the
+    optional 'rerank' extra isn't installed, matching the pattern
+    already established in test_reranking.py - CI doesn't install this
+    extra by default, and that is correct: it is optional, not required."""
+    pytest.importorskip("onnxruntime")
+    pytest.importorskip("tokenizers")
+    pytest.importorskip("huggingface_hub")
+
+    rag.ingest_text(filename="a.txt", text="Some content for reranking test.")
+    chunks = rag.retrieve("content", top_k=3, rerank=True)
+    assert isinstance(chunks, list)


### PR DESCRIPTION
…a fix

- Add RagLeap.retrieve(query, top_k=5, hybrid=True, rerank=False, metadata_filter=None): retrieval-only entry point using the same embed->search->rerank pipeline as ask(), stopping before generation. First consumer: ragleap-graph's GraphRetriever (v0.3.0).
- 6 new tests, including a regression-guard verifying retrieve() never triggers generation (generator explodes if called).
- Fix PyPI description/keywords: previous draft incorrectly claimed 'knowledge-graph integration via ragleap-graph' - backwards, since ragleap-rag has zero dependency on or awareness of ragleap-graph.
- README: document retrieve(), correct Status section (ragleap-graph is published, not 'in progress').

Published to PyPI as v0.12.0 and v0.12.1 (metadata-only patch).

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
