### PR TITLE
feat: ragleap-graph extraction, dedup, and typed relations (v0.2.0/v0.4.0)

### DIFF
--- a/packages/ragleap-graph/src/ragleap_graph/extraction.py
+++ b/packages/ragleap-graph/src/ragleap_graph/extraction.py
@@ -1,0 +1,462 @@
+"""
+ragleap_graph.extraction
+
+v0.2.0 addition: optional LLM-based entity extraction and entity
+deduplication, layered on top of the v0.1.0 regex extraction path.
+
+Design constraints (locked, see CHANGELOG for rationale):
+  - Default extraction method stays "regex" — zero behavior change on
+    upgrade for existing users.
+  - LLM extraction reuses ragleap-rag's ProviderConfig rather than
+    inventing a second provider abstraction.
+  - Dedup is a separate opt-in flag from extraction method, since regex
+    extraction can also benefit from it.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+from typing import Any, Literal, Optional
+
+try:
+    # Reuse ragleap-rag's existing provider abstraction rather than
+    # building a second one. ragleap-graph declares ragleap-rag as an
+    # optional dependency for this feature only — regex-only users don't
+    # need it installed.
+    #
+    # Confirmed against the real source (ragleap/generation.py):
+    # GenerationService.generate_answer(..., response_format=<json schema>)
+    # already enforces structured JSON output across Gemini (native
+    # response_schema), Anthropic (forced single tool-use call), and
+    # OpenAI-compatible providers (json_schema, honestly falling back to
+    # json_object if a provider doesn't support strict mode) — with the
+    # actual enforcement method reported back in the result. That's
+    # exactly what entity extraction needs, so LLMEntityExtractor is
+    # built on top of it rather than inventing a second, parallel
+    # structured-output mechanism.
+    from ragleap.generation import ProviderConfig, GenerationService
+except ImportError:  # pragma: no cover - exercised when ragleap-rag absent
+    ProviderConfig = None  # type: ignore[assignment,misc]
+    GenerationService = None  # type: ignore[assignment,misc]
+
+
+ExtractionMethod = Literal["regex", "llm"]
+
+
+@dataclass
+class ExtractionConfig:
+    """Configuration for entity extraction and deduplication.
+
+    Parameters
+    ----------
+    method:
+        "regex" (default, v0.1.0 behavior, no LLM calls) or "llm"
+        (function-calling extraction via a ragleap-rag ProviderConfig).
+    provider:
+        Required when method="llm". A ragleap.ProviderConfig instance.
+        Ignored when method="regex".
+    dedup_enabled:
+        If True, run entity names through EntityDeduplicator before
+        nodes are written to Neo4j. Independent of `method` — regex
+        extraction benefits from this too (e.g. "Acme Corp" vs
+        "ACME Corp.").
+    dedup_threshold:
+        Similarity cutoff (0.0-1.0) above which two entity names are
+        merged into one canonical node. Only used when dedup_enabled.
+    max_entities_per_chunk:
+        Passed through to whichever extractor is active.
+    """
+
+    method: ExtractionMethod = "regex"
+    provider: Optional["ProviderConfig"] = None
+    dedup_enabled: bool = False
+    dedup_threshold: float = 0.92
+    max_entities_per_chunk: int = 25
+    extract_relations: bool = False
+
+    def __post_init__(self) -> None:
+        if self.extract_relations and self.method != "llm":
+            raise ValueError(
+                "extract_relations=True requires method='llm' - relation "
+                "extraction has no regex equivalent, unlike entity extraction."
+            )
+        if self.method == "llm" and self.provider is None:
+            raise ValueError(
+                "ExtractionConfig(method='llm') requires provider=... "
+                "(a ragleap.ProviderConfig instance)."
+            )
+        if self.method == "llm" and ProviderConfig is None:
+            raise ImportError(
+                "method='llm' requires the 'ragleap-rag' package. "
+                "Install it with: pip install ragleap-rag"
+            )
+        if not 0.0 < self.dedup_threshold <= 1.0:
+            raise ValueError("dedup_threshold must be in (0.0, 1.0]")
+        if self.max_entities_per_chunk < 1:
+            raise ValueError("max_entities_per_chunk must be >= 1")
+
+
+# Passed as response_format= to GenerationService.generate_answer(). This
+# is a plain JSON Schema object, NOT an Anthropic-style tool definition —
+# generate_answer() itself handles wrapping it correctly per-provider
+# (native schema / forced tool-use / json_schema), so extraction.py stays
+# provider-agnostic and doesn't duplicate that per-provider logic.
+_ENTITY_JSON_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "entities": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The entity's name exactly as it appears in the text.",
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": (
+                            "Entity category, e.g. PERSON, ORG, PRODUCT, "
+                            "DATE, LOCATION, or a domain-specific type."
+                        ),
+                    },
+                },
+                "required": ["name", "type"],
+            },
+        }
+    },
+    "required": ["entities"],
+}
+
+_EXTRACTION_SYSTEM_PROMPT = (
+    "You extract named entities from text. Only extract entities "
+    "explicitly present in the given text — never invent or infer "
+    "entities that aren't stated. Respond using the required structure "
+    "only; do not include any commentary outside it."
+)
+
+
+@dataclass
+class ExtractedEntity:
+    """A single extracted entity, typed (unlike v0.1.0's plain strings)."""
+
+    name: str
+    type: str = "UNKNOWN"
+
+
+class LLMEntityExtractor:
+    """LLM-based entity extraction via ragleap-rag's GenerationService.
+
+    Built on GenerationService.generate_answer(response_format=...)
+    rather than a hand-rolled provider client — that method already
+    handles the real per-provider structured-output differences
+    (Gemini native schema, Anthropic forced tool-use, OpenAI-compatible
+    json_schema/json_object fallback), tested and shipped in
+    ragleap-rag. No new per-provider logic is introduced here.
+
+    Kept intentionally separate from the regex path in
+    ragleap_graph.__init__ rather than merged into it, so the default
+    (regex) code path has zero new dependencies or failure modes.
+    """
+
+    def __init__(self, config: ExtractionConfig) -> None:
+        if config.method != "llm":
+            raise ValueError("LLMEntityExtractor requires ExtractionConfig(method='llm')")
+        if GenerationService is None:
+            raise ImportError(
+                "LLMEntityExtractor requires the 'ragleap-rag' package. "
+                "Install it with: pip install ragleap-rag"
+            )
+        self._config = config
+        # temperature=0.0: extraction wants deterministic, literal recall
+        # of what's in the text, not creative variation.
+        self._service = GenerationService(
+            primary=config.provider,
+            default_temperature=0.0,
+            system_prompt=_EXTRACTION_SYSTEM_PROMPT,
+        )
+
+    def extract(self, text: str, domain_terms: Optional[list[str]] = None) -> list[ExtractedEntity]:
+        """Extract entities from `text` using the configured LLM provider.
+
+        `domain_terms` is passed through as extra guidance in the prompt,
+        mirroring the v0.1.0 `domain_terms=` convention on the regex path
+        — no hardcoded vocabulary, caller supplies their own.
+        """
+        if not text or not text.strip():
+            return []
+
+        instruction = self._build_instruction(domain_terms)
+        # generate_answer() is shaped around (query, chunks) for RAG, but
+        # its context-building/response_format machinery works fine for
+        # a single-chunk extraction call: the "query" is our fixed
+        # extraction instruction, and the "chunk" is the text to extract
+        # from. This reuses generate_answer()'s tested trimming, citation,
+        # and structured-output logic rather than re-implementing it.
+        result = self._service.generate_answer(
+            query=instruction,
+            chunks=[{"text": text, "document_name": "extraction_input", "chunk_index": 0}],
+            response_format=_ENTITY_JSON_SCHEMA,
+            temperature=0.0,
+        )
+
+        if result.get("provider_used") is None:
+            raise RuntimeError(
+                f"LLM entity extraction failed on all configured providers: {result.get('answer')}"
+            )
+
+        return self._parse_result(result)
+
+    def _build_instruction(self, domain_terms: Optional[list[str]]) -> str:
+        if not domain_terms:
+            return "Extract all named entities from the given text."
+        joined = ", ".join(domain_terms)
+        return (
+            "Extract all named entities from the given text. Pay "
+            f"particular attention to these known domain terms if present: {joined}."
+        )
+
+    def _parse_result(self, result: dict[str, Any]) -> list[ExtractedEntity]:
+        entities_raw: Optional[list[dict[str, Any]]] = None
+
+        if result.get("structured_valid") and isinstance(result.get("structured"), dict):
+            entities_raw = result["structured"].get("entities")
+
+        if entities_raw is None:
+            # structured_valid can be False even when enforcement was
+            # "native", if the provider technically returned valid JSON
+            # that didn't match the schema shape exactly. Fall back to
+            # parsing the raw answer text directly before giving up.
+            try:
+                fallback = json.loads(result.get("answer", ""))
+                entities_raw = fallback.get("entities") if isinstance(fallback, dict) else None
+            except (json.JSONDecodeError, AttributeError):
+                entities_raw = None
+
+        if entities_raw is None:
+            raise ValueError(
+                f"Malformed extraction response from provider "
+                f"'{result.get('provider_used')}' "
+                f"(enforcement={result.get('structured_enforcement')}): "
+                f"{result.get('answer')!r}"
+            )
+
+        entities: list[ExtractedEntity] = []
+        seen: set[str] = set()
+        for item in entities_raw[: self._config.max_entities_per_chunk]:
+            name = str(item.get("name", "")).strip()
+            if not name or name.lower() in seen:
+                continue
+            seen.add(name.lower())
+            entities.append(ExtractedEntity(name=name, type=str(item.get("type", "UNKNOWN"))))
+        return entities
+
+
+class EntityDeduplicator:
+    """Merge near-duplicate entity names into one canonical form.
+
+    Independent of extraction method — works on any list of entity name
+    strings, whether produced by the regex path or the LLM path.
+    """
+
+    def __init__(self, threshold: float = 0.92) -> None:
+        if not 0.0 < threshold <= 1.0:
+            raise ValueError("threshold must be in (0.0, 1.0]")
+        self._threshold = threshold
+
+    def resolve(self, names: list[str]) -> dict[str, str]:
+        """Return a mapping of {original_name: canonical_name}.
+
+        Canonical form is chosen as the longest variant seen (heuristic:
+        "T.C. Antony" over "TC Antony" tends to preserve more information).
+        Pure string-similarity based; no embeddings required, so this
+        works with zero extra dependencies even when method="regex".
+        """
+        if not names:
+            return {}
+
+        normalized = [(n, self._normalize(n)) for n in names]
+        clusters: list[list[str]] = []
+
+        for name, norm in normalized:
+            placed = False
+            for cluster in clusters:
+                cluster_norm = self._normalize(cluster[0])
+                if self._similarity(norm, cluster_norm) >= self._threshold:
+                    cluster.append(name)
+                    placed = True
+                    break
+            if not placed:
+                clusters.append([name])
+
+        mapping: dict[str, str] = {}
+        for cluster in clusters:
+            canonical = max(cluster, key=len)
+            for name in cluster:
+                mapping[name] = canonical
+        return mapping
+
+    @staticmethod
+    def _normalize(name: str) -> str:
+        collapsed = re.sub(r"[.\-_,]", "", name.lower())
+        collapsed = re.sub(r"\s+", " ", collapsed).strip()
+        return collapsed
+
+    @staticmethod
+    def _similarity(a: str, b: str) -> float:
+        return SequenceMatcher(None, a, b).ratio()
+
+
+_RELATION_JSON_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "relations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "subject": {
+                        "type": "string",
+                        "description": "Name of the subject entity. Must exactly match one of the provided known entity names.",
+                    },
+                    "relation_type": {
+                        "type": "string",
+                        "description": "Relationship type in UPPER_SNAKE_CASE, e.g. REPORTED, LAUNCHED, PARTNERED_WITH, ACQUIRED.",
+                    },
+                    "object": {
+                        "type": "string",
+                        "description": "Name of the object entity. Must exactly match one of the provided known entity names.",
+                    },
+                },
+                "required": ["subject", "relation_type", "object"],
+            },
+        }
+    },
+    "required": ["relations"],
+}
+
+_RELATION_SYSTEM_PROMPT = (
+    "You identify relationships between named entities in text. Only "
+    "identify relationships explicitly stated or clearly implied by the "
+    "text - never invent relationships not supported by it. Both the "
+    "subject and object of every relation must be exactly one of the "
+    "provided known entity names - do not introduce new entity names."
+)
+
+
+@dataclass
+class ExtractedRelation:
+    """A single typed relation between two known entities."""
+
+    subject: str
+    relation_type: str
+    object: str
+
+
+class LLMRelationExtractor:
+    """
+    Identifies typed relations between an already-known set of entities
+    in a piece of text.
+
+    Deliberately takes known_entities= as an explicit parameter rather
+    than extracting entities itself - constrains the LLM's subject/object
+    choices to entities already extracted and normalized (by either the
+    regex or LLM entity-extraction path), which both reduces hallucinated
+    entities and reuses the existing, tested entity extraction rather
+    than duplicating it.
+    """
+
+    def __init__(self, config: ExtractionConfig) -> None:
+        if config.method != "llm":
+            raise ValueError("LLMRelationExtractor requires ExtractionConfig(method='llm')")
+        if GenerationService is None:
+            raise ImportError(
+                "LLMRelationExtractor requires the 'ragleap-rag' package. "
+                "Install it with: pip install ragleap-rag"
+            )
+        self._config = config
+        self._service = GenerationService(
+            primary=config.provider,
+            default_temperature=0.0,
+            system_prompt=_RELATION_SYSTEM_PROMPT,
+        )
+
+    def extract(
+        self,
+        text: str,
+        known_entities: list[str],
+        domain_terms: Optional[list[str]] = None,
+    ) -> list[ExtractedRelation]:
+        """
+        Identify relations between known_entities as they appear in text.
+        Returns [] without any LLM call if fewer than 2 entities are
+        known - a relation needs at least two entities to connect, so
+        there is nothing to ask for and no reason to spend a call.
+        """
+        if not text or not text.strip() or len(known_entities) < 2:
+            return []
+
+        instruction = self._build_instruction(known_entities, domain_terms)
+        result = self._service.generate_answer(
+            query=instruction,
+            chunks=[{"text": text, "document_name": "relation_extraction_input", "chunk_index": 0}],
+            response_format=_RELATION_JSON_SCHEMA,
+            temperature=0.0,
+        )
+
+        if result.get("provider_used") is None:
+            raise RuntimeError(
+                f"LLM relation extraction failed on all configured providers: {result.get('answer')}"
+            )
+
+        return self._parse_result(result, known_entities)
+
+    def _build_instruction(self, known_entities: list[str], domain_terms: Optional[list[str]]) -> str:
+        entity_list = ", ".join(known_entities)
+        base = f"Identify relationships between these known entities: {entity_list}."
+        if domain_terms:
+            joined = ", ".join(domain_terms)
+            base += f" Pay particular attention to these known domain terms if present: {joined}."
+        return base
+
+    def _parse_result(self, result: dict[str, Any], known_entities: list[str]) -> list[ExtractedRelation]:
+        relations_raw: Optional[list[dict[str, Any]]] = None
+
+        if result.get("structured_valid") and isinstance(result.get("structured"), dict):
+            relations_raw = result["structured"].get("relations")
+
+        if relations_raw is None:
+            try:
+                fallback = json.loads(result.get("answer", ""))
+                relations_raw = fallback.get("relations") if isinstance(fallback, dict) else None
+            except (json.JSONDecodeError, AttributeError):
+                relations_raw = None
+
+        if relations_raw is None:
+            raise ValueError(
+                f"Malformed relation extraction response from provider "
+                f"'{result.get('provider_used')}': {result.get('answer')!r}"
+            )
+
+        # Defensive validation: even though the prompt constrains subject/
+        # object to known_entities, the LLM can still hallucinate a name
+        # not in that list - drop (do not crash on) any relation where
+        # either side is not a known entity, rather than trusting the
+        # model's compliance blindly.
+        known_lower = {e.lower() for e in known_entities}
+        relations: list[ExtractedRelation] = []
+        for item in relations_raw:
+            subject = str(item.get("subject", "")).strip()
+            relation_type = str(item.get("relation_type", "")).strip().upper()
+            obj = str(item.get("object", "")).strip()
+            if not subject or not relation_type or not obj:
+                continue
+            if subject.lower() not in known_lower or obj.lower() not in known_lower:
+                continue
+            if subject.lower() == obj.lower():
+                continue
+            relations.append(ExtractedRelation(subject=subject, relation_type=relation_type, object=obj))
+        return relations

--- a/packages/ragleap-graph/tests/test_extraction.py
+++ b/packages/ragleap-graph/tests/test_extraction.py
@@ -1,0 +1,477 @@
+"""
+Tests for ragleap_graph.extraction (v0.2.0).
+
+Mirrors v0.1.0's test style: pure-logic tests need no live services,
+mocked-provider tests verify request/response handling without burning
+real API calls, and one live test (skipped without credentials) proves
+the real end-to-end path actually works.
+"""
+import json
+import os
+import sys
+import types
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Mock ragleap.generation before importing extraction, so tests run without
+# ragleap-rag installed (mirrors how method="regex" has zero dependency on
+# it). The mock's generate_answer() return shape matches the REAL
+# GenerationService.generate_answer() dict shape confirmed against
+# ragleap-rag/src/ragleap/generation.py.
+# ---------------------------------------------------------------------------
+
+class FakeProviderConfig:
+    def __init__(self, provider, api_key=None, model=None, base_url=None):
+        self.provider = provider
+        self.api_key = api_key
+        self.model = model
+        self.base_url = base_url
+
+
+class FakeGenerationService:
+    """Set FakeGenerationService.next_response before calling extract()
+    to control what generate_answer() returns for that test."""
+
+    next_response = None
+
+    def __init__(self, primary, default_temperature=0.3, system_prompt=None):
+        self.primary = primary
+        self.default_temperature = default_temperature
+        self.system_prompt = system_prompt
+
+    def generate_answer(self, query, chunks, response_format=None, temperature=None, **kw):
+        return FakeGenerationService.next_response
+
+
+@pytest.fixture(autouse=True)
+def mock_ragleap_generation(monkeypatch):
+    ragleap_pkg = types.ModuleType("ragleap")
+    ragleap_gen = types.ModuleType("ragleap.generation")
+    ragleap_gen.ProviderConfig = FakeProviderConfig
+    ragleap_gen.GenerationService = FakeGenerationService
+    monkeypatch.setitem(sys.modules, "ragleap", ragleap_pkg)
+    monkeypatch.setitem(sys.modules, "ragleap.generation", ragleap_gen)
+    # Bust ragleap_graph.extraction's cache so it re-imports and rebinds
+    # ProviderConfig/GenerationService against the fakes above. This
+    # submodule may already be cached with REAL bindings from an earlier,
+    # unmocked import via ragleap_graph/__init__.py during test collection
+    # (since ragleap-rag is genuinely installed in this environment) - a
+    # real bug caught in this exact spot, see CHANGELOG.
+    monkeypatch.delitem(sys.modules, "ragleap_graph.extraction", raising=False)
+
+    # Canary: confirm the mock actually took effect. If it did not, tests
+    # would silently make real network calls instead of using the fakes -
+    # fail loudly here instead of letting that happen quietly.
+    import ragleap_graph.extraction as _ext_check
+    assert _ext_check.GenerationService is FakeGenerationService, (
+        "Mock did not take effect - ragleap_graph.extraction is still bound "
+        "to the real GenerationService. Tests would make real network calls."
+    )
+    yield
+
+
+# ---------------------------------------------------------------------------
+# ExtractionConfig — pure logic, no live services needed
+# ---------------------------------------------------------------------------
+
+def test_extraction_config_defaults_to_regex():
+    from ragleap_graph.extraction import ExtractionConfig
+    config = ExtractionConfig()
+    assert config.method == "regex"
+    assert config.dedup_enabled is False
+    assert config.provider is None
+
+
+def test_extraction_config_llm_requires_provider():
+    from ragleap_graph.extraction import ExtractionConfig
+    with pytest.raises(ValueError, match="requires provider"):
+        ExtractionConfig(method="llm")
+
+
+def test_extraction_config_llm_with_provider_succeeds():
+    from ragleap_graph.extraction import ExtractionConfig
+    config = ExtractionConfig(method="llm", provider=FakeProviderConfig(provider="gemini"))
+    assert config.method == "llm"
+
+
+def test_extraction_config_rejects_bad_dedup_threshold():
+    from ragleap_graph.extraction import ExtractionConfig
+    with pytest.raises(ValueError, match="dedup_threshold"):
+        ExtractionConfig(dedup_threshold=1.5)
+    with pytest.raises(ValueError, match="dedup_threshold"):
+        ExtractionConfig(dedup_threshold=0.0)
+
+
+def test_extraction_config_rejects_bad_max_entities():
+    from ragleap_graph.extraction import ExtractionConfig
+    with pytest.raises(ValueError, match="max_entities_per_chunk"):
+        ExtractionConfig(max_entities_per_chunk=0)
+
+
+# ---------------------------------------------------------------------------
+# EntityDeduplicator — pure logic, no live services needed
+# ---------------------------------------------------------------------------
+
+def test_dedup_merges_punctuation_variants():
+    from ragleap_graph.extraction import EntityDeduplicator
+    dedup = EntityDeduplicator()
+    mapping = dedup.resolve(["TC Antony", "T.C. Antony"])
+    assert mapping["TC Antony"] == mapping["T.C. Antony"]
+
+
+def test_dedup_merges_case_and_trailing_punctuation():
+    from ragleap_graph.extraction import EntityDeduplicator
+    dedup = EntityDeduplicator()
+    mapping = dedup.resolve(["Acme Corp", "ACME Corp."])
+    assert mapping["Acme Corp"] == mapping["ACME Corp."]
+
+
+def test_dedup_default_threshold_does_not_merge_distinct_short_names():
+    """Regression test for a real false-positive caught during development:
+    default threshold must NOT merge 'Neo4j' and 'Neo 4j' — they are
+    different entities, and naive normalization made them look identical
+    at a lower threshold (0.85)."""
+    from ragleap_graph.extraction import EntityDeduplicator
+    dedup = EntityDeduplicator()
+    mapping = dedup.resolve(["Neo4j", "Neo 4j"])
+    assert mapping["Neo4j"] != mapping["Neo 4j"]
+
+
+def test_dedup_canonical_form_prefers_longer_variant():
+    from ragleap_graph.extraction import EntityDeduplicator
+    dedup = EntityDeduplicator()
+    mapping = dedup.resolve(["TC Antony", "T.C. Antony"])
+    assert mapping["TC Antony"] == "T.C. Antony"
+
+
+def test_dedup_empty_input_returns_empty_mapping():
+    from ragleap_graph.extraction import EntityDeduplicator
+    dedup = EntityDeduplicator()
+    assert dedup.resolve([]) == {}
+
+
+def test_dedup_rejects_invalid_threshold():
+    from ragleap_graph.extraction import EntityDeduplicator
+    with pytest.raises(ValueError):
+        EntityDeduplicator(threshold=0.0)
+    with pytest.raises(ValueError):
+        EntityDeduplicator(threshold=1.5)
+
+
+# ---------------------------------------------------------------------------
+# LLMEntityExtractor — mocked GenerationService, no real API calls
+# ---------------------------------------------------------------------------
+
+def test_llm_extractor_requires_llm_method():
+    from ragleap_graph.extraction import ExtractionConfig, LLMEntityExtractor
+    config = ExtractionConfig()  # defaults to method="regex"
+    with pytest.raises(ValueError, match="requires ExtractionConfig"):
+        LLMEntityExtractor(config)
+
+
+def test_llm_extractor_empty_text_returns_empty_without_calling_provider():
+    from ragleap_graph.extraction import ExtractionConfig, LLMEntityExtractor
+    config = ExtractionConfig(method="llm", provider=FakeProviderConfig(provider="gemini"))
+    extractor = LLMEntityExtractor(config)
+    assert extractor.extract("") == []
+    assert extractor.extract("   ") == []
+
+
+def test_llm_extractor_parses_native_structured_response():
+    from ragleap_graph.extraction import ExtractionConfig, LLMEntityExtractor
+    FakeGenerationService.next_response = {
+        "answer": json.dumps({"entities": [{"name": "Acme Corp", "type": "ORG"}]}),
+        "provider_used": "gemini",
+        "structured": {"entities": [{"name": "Acme Corp", "type": "ORG"}]},
+        "structured_valid": True,
+        "structured_enforcement": "native",
+    }
+    config = ExtractionConfig(method="llm", provider=FakeProviderConfig(provider="gemini"))
+    entities = LLMEntityExtractor(config).extract("Acme Corp reported strong Q3 revenue.")
+    assert len(entities) == 1
+    assert entities[0].name == "Acme Corp"
+    assert entities[0].type == "ORG"
+
+
+def test_llm_extractor_falls_back_to_parsing_raw_answer():
+    """structured_valid can be False even when the provider actually
+    returned usable JSON — verify the raw-answer fallback path works."""
+    from ragleap_graph.extraction import ExtractionConfig, LLMEntityExtractor
+    FakeGenerationService.next_response = {
+        "answer": json.dumps({"entities": [{"name": "Neo4j", "type": "PRODUCT"}]}),
+        "provider_used": "together",
+        "structured": None,
+        "structured_valid": False,
+        "structured_enforcement": "json_object_fallback",
+    }
+    config = ExtractionConfig(method="llm", provider=FakeProviderConfig(provider="together"))
+    entities = LLMEntityExtractor(config).extract("Neo4j is a graph database.")
+    assert len(entities) == 1
+    assert entities[0].name == "Neo4j"
+
+
+def test_llm_extractor_raises_when_all_providers_failed():
+    from ragleap_graph.extraction import ExtractionConfig, LLMEntityExtractor
+    FakeGenerationService.next_response = {
+        "answer": "Sorry, all configured providers failed. Last error: auth failed",
+        "provider_used": None,
+        "structured": None,
+        "structured_valid": False,
+        "structured_enforcement": None,
+    }
+    config = ExtractionConfig(method="llm", provider=FakeProviderConfig(provider="gemini"))
+    with pytest.raises(RuntimeError, match="all configured providers"):
+        LLMEntityExtractor(config).extract("some text")
+
+
+def test_llm_extractor_raises_on_malformed_response():
+    from ragleap_graph.extraction import ExtractionConfig, LLMEntityExtractor
+    FakeGenerationService.next_response = {
+        "answer": "not valid json at all",
+        "provider_used": "gemini",
+        "structured": None,
+        "structured_valid": False,
+        "structured_enforcement": None,
+    }
+    config = ExtractionConfig(method="llm", provider=FakeProviderConfig(provider="gemini"))
+    with pytest.raises(ValueError, match="Malformed extraction response"):
+        LLMEntityExtractor(config).extract("some text")
+
+
+def test_llm_extractor_deduplicates_repeated_entities_case_insensitively():
+    from ragleap_graph.extraction import ExtractionConfig, LLMEntityExtractor
+    FakeGenerationService.next_response = {
+        "answer": json.dumps({"entities": [
+            {"name": "Acme Corp", "type": "ORG"},
+            {"name": "acme corp", "type": "ORG"},
+        ]}),
+        "provider_used": "gemini",
+        "structured": {"entities": [
+            {"name": "Acme Corp", "type": "ORG"},
+            {"name": "acme corp", "type": "ORG"},
+        ]},
+        "structured_valid": True,
+        "structured_enforcement": "native",
+    }
+    config = ExtractionConfig(method="llm", provider=FakeProviderConfig(provider="gemini"))
+    entities = LLMEntityExtractor(config).extract("Acme Corp mentioned twice.")
+    assert len(entities) == 1
+
+
+def test_llm_extractor_respects_max_entities_per_chunk():
+    from ragleap_graph.extraction import ExtractionConfig, LLMEntityExtractor
+    many_entities = [{"name": f"Entity{i}", "type": "MISC"} for i in range(10)]
+    FakeGenerationService.next_response = {
+        "answer": json.dumps({"entities": many_entities}),
+        "provider_used": "gemini",
+        "structured": {"entities": many_entities},
+        "structured_valid": True,
+        "structured_enforcement": "native",
+    }
+    config = ExtractionConfig(
+        method="llm", provider=FakeProviderConfig(provider="gemini"), max_entities_per_chunk=3
+    )
+    entities = LLMEntityExtractor(config).extract("text with many entities")
+    assert len(entities) == 3
+
+
+def test_llm_extractor_passes_domain_terms_into_instruction():
+    """Verify domain_terms= actually reaches the prompt sent to the
+    provider — not just accepted and silently dropped."""
+    from ragleap_graph.extraction import ExtractionConfig, LLMEntityExtractor
+
+    captured = {}
+
+    class CapturingService(FakeGenerationService):
+        def generate_answer(self, query, chunks, response_format=None, temperature=None, **kw):
+            captured["query"] = query
+            return {
+                "answer": json.dumps({"entities": []}),
+                "provider_used": "gemini",
+                "structured": {"entities": []},
+                "structured_valid": True,
+                "structured_enforcement": "native",
+            }
+
+    import ragleap_graph.extraction as extraction_module
+    extraction_module.GenerationService = CapturingService
+
+    config = ExtractionConfig(method="llm", provider=FakeProviderConfig(provider="gemini"))
+    LLMEntityExtractor(config).extract("some text", domain_terms=["ALARA", "dose limits"])
+    assert "ALARA" in captured["query"]
+    assert "dose limits" in captured["query"]
+
+
+# ---------------------------------------------------------------------------
+# Live integration test — real LLM call, real structured extraction.
+# Skips cleanly without credentials, same pattern as v0.1.0's
+# test_live_full_roundtrip for Neo4j.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    not os.environ.get("GEMINI_API_KEY"),
+    reason="No GEMINI_API_KEY in environment — skipping real live LLM call.",
+)
+def test_live_llm_extraction_roundtrip(monkeypatch):
+    """Real end-to-end test: actual Gemini call, actual structured
+    extraction, actual parsing — no mocks. Mirrors v0.1.0's
+    test_live_full_roundtrip pattern for Neo4j: runs automatically when
+    real credentials are present, skips cleanly otherwise.
+
+    Explicitly un-mocks ragleap_graph.extraction for this one test, since
+    the autouse fixture above replaces ragleap.generation with fakes for
+    every other test in this module.
+    """
+    monkeypatch.delitem(sys.modules, "ragleap", raising=False)
+    monkeypatch.delitem(sys.modules, "ragleap.generation", raising=False)
+    monkeypatch.delitem(sys.modules, "ragleap_graph.extraction", raising=False)
+
+    from ragleap.generation import ProviderConfig
+    from ragleap_graph.extraction import ExtractionConfig, LLMEntityExtractor
+
+    real_config = ExtractionConfig(
+        method="llm",
+        provider=ProviderConfig(
+            provider="gemini",
+            api_key=os.environ["GEMINI_API_KEY"],
+            model=os.environ.get("GEMINI_CHAT_MODEL", "gemini-3.6-flash"),
+        ),
+    )
+    extractor = LLMEntityExtractor(real_config)
+    entities = extractor.extract(
+        "Acme Corporation reported strong Q3 revenue growth, driven by "
+        "their new product line launched in partnership with Neo4j Inc."
+    )
+
+    assert len(entities) > 0, "Live extraction returned zero entities"
+    names_lower = [e.name.lower() for e in entities]
+    assert any("acme" in n for n in names_lower), (
+        f"Expected an Acme-related entity in live extraction, got: {names_lower}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# LLMRelationExtractor (v0.4.0) - mocked GenerationService, no real API calls
+# ---------------------------------------------------------------------------
+
+def test_extraction_config_extract_relations_requires_llm_method():
+    from ragleap_graph.extraction import ExtractionConfig
+    with pytest.raises(ValueError, match="extract_relations=True requires method='llm'"):
+        ExtractionConfig(extract_relations=True)  # defaults to method="regex"
+
+
+def test_extraction_config_extract_relations_with_llm_method_succeeds():
+    from ragleap_graph.extraction import ExtractionConfig
+    config = ExtractionConfig(method="llm", provider=FakeProviderConfig(provider="gemini"), extract_relations=True)
+    assert config.extract_relations is True
+
+
+def test_relation_extractor_requires_llm_method():
+    from ragleap_graph.extraction import ExtractionConfig, LLMRelationExtractor
+    config = ExtractionConfig()  # method="regex"
+    with pytest.raises(ValueError, match="requires ExtractionConfig"):
+        LLMRelationExtractor(config)
+
+
+def test_relation_extractor_skips_llm_call_with_fewer_than_two_entities():
+    """A relation needs 2 entities to connect - verify no LLM call
+    happens when there's only 0 or 1 known entities, by making the
+    generator explode if invoked."""
+    from ragleap_graph.extraction import ExtractionConfig, LLMRelationExtractor
+
+    def _explode(self, *a, **kw):
+        raise AssertionError("should not call generate_answer with <2 known entities")
+    FakeGenerationService.generate_answer = _explode
+
+    config = ExtractionConfig(method="llm", provider=FakeProviderConfig(provider="gemini"))
+    extractor = LLMRelationExtractor(config)
+
+    assert extractor.extract("some text", known_entities=[]) == []
+    assert extractor.extract("some text", known_entities=["Acme Corp"]) == []
+
+    # restore normal behavior for subsequent tests
+    FakeGenerationService.generate_answer = lambda self, query, chunks, response_format=None, temperature=None, **kw: FakeGenerationService.next_response
+
+
+def test_relation_extractor_parses_valid_relations():
+    from ragleap_graph.extraction import ExtractionConfig, LLMRelationExtractor
+    FakeGenerationService.next_response = {
+        "answer": json.dumps({"relations": [
+            {"subject": "Acme Corp", "relation_type": "reported", "object": "Q3 revenue growth"},
+        ]}),
+        "provider_used": "gemini",
+        "structured": {"relations": [
+            {"subject": "Acme Corp", "relation_type": "reported", "object": "Q3 revenue growth"},
+        ]},
+        "structured_valid": True,
+        "structured_enforcement": "native",
+    }
+    config = ExtractionConfig(method="llm", provider=FakeProviderConfig(provider="gemini"))
+    extractor = LLMRelationExtractor(config)
+    relations = extractor.extract(
+        "Acme Corp reported strong Q3 revenue growth.",
+        known_entities=["Acme Corp", "Q3 revenue growth"],
+    )
+    assert len(relations) == 1
+    assert relations[0].subject == "Acme Corp"
+    assert relations[0].relation_type == "REPORTED"  # uppercased
+    assert relations[0].object == "Q3 revenue growth"
+
+
+def test_relation_extractor_drops_hallucinated_entities():
+    """Even though the prompt constrains subject/object to known
+    entities, verify the defensive filter actually drops a relation
+    referencing an entity name that isn't in known_entities."""
+    from ragleap_graph.extraction import ExtractionConfig, LLMRelationExtractor
+    FakeGenerationService.next_response = {
+        "answer": json.dumps({"relations": [
+            {"subject": "Acme Corp", "relation_type": "REPORTED", "object": "Q3 revenue growth"},
+            {"subject": "Globex Inc", "relation_type": "ACQUIRED", "object": "Neo4j"},
+        ]}),
+        "provider_used": "gemini",
+        "structured": {"relations": [
+            {"subject": "Acme Corp", "relation_type": "REPORTED", "object": "Q3 revenue growth"},
+            {"subject": "Globex Inc", "relation_type": "ACQUIRED", "object": "Neo4j"},
+        ]},
+        "structured_valid": True,
+        "structured_enforcement": "native",
+    }
+    config = ExtractionConfig(method="llm", provider=FakeProviderConfig(provider="gemini"))
+    extractor = LLMRelationExtractor(config)
+    relations = extractor.extract(
+        "text", known_entities=["Acme Corp", "Q3 revenue growth"],  # "Globex Inc" and "Neo4j" NOT known
+    )
+    assert len(relations) == 1
+    assert relations[0].subject == "Acme Corp"
+
+
+def test_relation_extractor_drops_self_relations():
+    from ragleap_graph.extraction import ExtractionConfig, LLMRelationExtractor
+    FakeGenerationService.next_response = {
+        "answer": json.dumps({"relations": [{"subject": "Acme Corp", "relation_type": "IS", "object": "Acme Corp"}]}),
+        "provider_used": "gemini",
+        "structured": {"relations": [{"subject": "Acme Corp", "relation_type": "IS", "object": "Acme Corp"}]},
+        "structured_valid": True,
+        "structured_enforcement": "native",
+    }
+    config = ExtractionConfig(method="llm", provider=FakeProviderConfig(provider="gemini"))
+    extractor = LLMRelationExtractor(config)
+    relations = extractor.extract("text", known_entities=["Acme Corp", "Other Entity"])
+    assert relations == []
+
+
+def test_relation_extractor_raises_when_all_providers_failed():
+    from ragleap_graph.extraction import ExtractionConfig, LLMRelationExtractor
+    FakeGenerationService.next_response = {
+        "answer": "Sorry, all configured providers failed. Last error: auth failed",
+        "provider_used": None,
+        "structured": None,
+        "structured_valid": False,
+        "structured_enforcement": None,
+    }
+    config = ExtractionConfig(method="llm", provider=FakeProviderConfig(provider="gemini"))
+    extractor = LLMRelationExtractor(config)
+    with pytest.raises(RuntimeError, match="all configured providers"):
+        extractor.extract("text", known_entities=["A", "B"])


### PR DESCRIPTION
Adds ExtractionConfig, LLMEntityExtractor, EntityDeduplicator, LLMRelationExtractor, and ExtractedRelation - the LLM-based extraction, deduplication, and typed relation extraction features published to PyPI as part of v0.2.0 and v0.4.0. See CHANGELOG.md (in a follow-up PR wiring these into GraphIndex) for full details.