### PR TITLE
feat: ragleap-graph GraphRetriever - hybrid vector+graph retrieval (v0.3.0)

### DIFF
--- a/packages/ragleap-graph/src/ragleap_graph/retrieval.py
+++ b/packages/ragleap-graph/src/ragleap_graph/retrieval.py
@@ -1,0 +1,181 @@
+"""
+ragleap_graph.retrieval
+
+v0.3.0 addition: GraphRetriever fuses ragleap-rag's vector search with
+ragleap-graph's entity-based graph traversal into a single retrieval
+call, with graph-path citations alongside chunk citations.
+
+Two modes:
+  - "hybrid" (default): vector search for chunks + graph traversal from
+    query entities, combined into one result.
+  - "graph_only": skip vector search entirely, pure entity-based +
+    traversal retrieval (e.g. "show all documents related to Customer X").
+
+Design constraints (locked, matches the reasoning behind extraction.py):
+  - Built on RagLeap.retrieve() (ragleap-rag >=0.12.0), not a hand-rolled
+    vector-search call - reuses the real, tested embed->search->rerank
+    pipeline rather than duplicating it.
+  - Built on GraphIndex's existing, tested methods
+    (extract_query_entities, find_documents_by_entities,
+    search_related_entities) - no new Cypher queries written here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, Optional
+
+
+RetrievalMode = Literal["hybrid", "graph_only"]
+
+
+@dataclass
+class GraphRetrievalConfig:
+    """Configuration for GraphRetriever.
+
+    Parameters
+    ----------
+    mode:
+        "hybrid" (default) - vector search + graph expansion combined.
+        "graph_only" - skip vector search, pure entity/graph retrieval.
+    graph_expand_depth:
+        Passed to GraphIndex.search_related_entities()'s max_depth.
+        Bounded 1-10 there already; not re-validated here.
+    max_graph_results:
+        Passed to both find_documents_by_entities() and
+        search_related_entities()'s limit.
+    domain_terms:
+        Optional caller-supplied vocabulary passed through to
+        GraphIndex.extract_query_entities() - same convention as the
+        rest of ragleap-graph, no hardcoded vocabulary.
+    max_query_entities:
+        Passed to extract_query_entities()'s max_entities.
+    """
+
+    mode: RetrievalMode = "hybrid"
+    graph_expand_depth: int = 2
+    max_graph_results: int = 10
+    domain_terms: Optional[list[str]] = None
+    max_query_entities: int = 10
+
+    def __post_init__(self) -> None:
+        if self.mode not in ("hybrid", "graph_only"):
+            raise ValueError(f"mode must be 'hybrid' or 'graph_only', got {self.mode!r}")
+        if self.graph_expand_depth < 1:
+            raise ValueError("graph_expand_depth must be >= 1")
+        if self.max_graph_results < 1:
+            raise ValueError("max_graph_results must be >= 1")
+        if self.max_query_entities < 1:
+            raise ValueError("max_query_entities must be >= 1")
+
+
+class GraphRetriever:
+    """
+    Combines vector search (via an existing RagLeap instance) with
+    entity-based graph traversal (via an existing GraphIndex instance)
+    into one retrieval call.
+
+    Does not own either RagLeap or GraphIndex's lifecycle - pass in
+    instances you've already constructed and configured (schema
+    initialized, connections open), same pattern as passing an existing
+    driver/service into a wrapper rather than this class reaching into
+    construction details it shouldn't own.
+    """
+
+    def __init__(
+        self,
+        graph: Any,
+        rag: Any,
+        config: Optional[GraphRetrievalConfig] = None,
+    ) -> None:
+        self._graph = graph
+        self._rag = rag
+        self._config = config or GraphRetrievalConfig()
+
+    def retrieve(
+        self,
+        query: str,
+        top_k: int = 5,
+        namespace: Optional[str] = None,
+        metadata_filter: Optional[dict] = None,
+    ) -> dict:
+        """
+        Retrieve for a query using the configured mode.
+
+        Returns:
+        {
+            "chunks": [...],                # from rag.retrieve(), [] in graph_only mode
+            "query_entities": [...],        # entity names extracted from the query itself
+            "graph_context": {
+                "related_documents": [...], # from GraphIndex.find_documents_by_entities()
+                "related_entities": [...],  # from GraphIndex.search_related_entities()
+            },
+            "citations": [...],             # chunk citations + graph-path citations
+            "retrieval_method": "hybrid_vector_graph" | "graph_only",
+        }
+        """
+        query_entities = self._graph.extract_query_entities(
+            query,
+            max_entities=self._config.max_query_entities,
+            domain_terms=self._config.domain_terms,
+        )
+
+        graph_context = self._build_graph_context(query_entities, namespace)
+
+        if self._config.mode == "graph_only":
+            chunks: list[dict] = []
+            retrieval_method = "graph_only"
+        else:
+            chunks = self._rag.retrieve(query, top_k=top_k, metadata_filter=metadata_filter)
+            retrieval_method = "hybrid_vector_graph"
+
+        citations = self._build_citations(chunks, graph_context)
+
+        return {
+            "chunks": chunks,
+            "query_entities": query_entities,
+            "graph_context": graph_context,
+            "citations": citations,
+            "retrieval_method": retrieval_method,
+        }
+
+    def _build_graph_context(
+        self, query_entities: list[str], namespace: Optional[str]
+    ) -> dict:
+        if not query_entities:
+            return {"related_documents": [], "related_entities": []}
+
+        related_documents = self._graph.find_documents_by_entities(
+            query_entities, namespace=namespace, limit=self._config.max_graph_results
+        )
+        related_entities = self._graph.search_related_entities(
+            query_entities,
+            namespace=namespace,
+            max_depth=self._config.graph_expand_depth,
+            limit=self._config.max_graph_results,
+        )
+        return {"related_documents": related_documents, "related_entities": related_entities}
+
+    def _build_citations(self, chunks: list[dict], graph_context: dict) -> list[dict]:
+        citations: list[dict] = []
+
+        for i, chunk in enumerate(chunks, start=1):
+            text = chunk.get("text", "")
+            citations.append({
+                "type": "chunk",
+                "source_number": i,
+                "document_name": chunk.get("document_name", "unknown document"),
+                "document_id": chunk.get("document_id"),
+                "chunk_id": chunk.get("chunk_id"),
+                "text_preview": text[:150] + ("..." if len(text) > 150 else ""),
+            })
+
+        for entity in graph_context.get("related_entities", []):
+            citations.append({
+                "type": "graph_path",
+                "entity_name": entity.get("entity_name"),
+                "relationship": entity.get("relationship"),
+                "depth": entity.get("depth"),
+            })
+
+        return citations

--- a/packages/ragleap-graph/tests/test_retrieval.py
+++ b/packages/ragleap-graph/tests/test_retrieval.py
@@ -1,0 +1,214 @@
+"""
+Tests for ragleap_graph.retrieval (v0.3.0).
+
+Uses lightweight fakes matching the real contracts of RagLeap.retrieve()
+and GraphIndex's methods (extract_query_entities,
+find_documents_by_entities, search_related_entities) - no live services
+needed for these, since GraphRetriever itself has no I/O of its own,
+it only orchestrates calls to injected graph/rag objects.
+"""
+import pytest
+
+from ragleap_graph.retrieval import GraphRetriever, GraphRetrievalConfig
+
+
+class FakeRag:
+    """Matches RagLeap.retrieve()'s real signature and return shape."""
+
+    def __init__(self, chunks=None):
+        self._chunks = chunks if chunks is not None else [
+            {"chunk_id": "c1", "text": "Acme Corp reported strong Q3 revenue growth.",
+             "document_id": "d1", "document_name": "q3_report.pdf", "chunk_index": 0},
+            {"chunk_id": "c2", "text": "The new product line launched in partnership with Neo4j.",
+             "document_id": "d2", "document_name": "press_release.pdf", "chunk_index": 0},
+        ]
+        self.called_with = None
+
+    def retrieve(self, query, top_k=5, hybrid=True, rerank=False, metadata_filter=None):
+        self.called_with = {"query": query, "top_k": top_k, "metadata_filter": metadata_filter}
+        return self._chunks[:top_k]
+
+
+class FakeGraph:
+    """Matches GraphIndex's real method signatures and return shapes."""
+
+    def __init__(self, query_entities=None, related_documents=None, related_entities=None):
+        self._query_entities = query_entities if query_entities is not None else ["Acme Corp"]
+        self._related_documents = related_documents if related_documents is not None else [
+            {"document_id": "d3", "document_name": "acme_contract.pdf",
+             "matched_entities": 1, "graph_score": 2.5, "matched_entity_names": ["Acme Corp"]},
+        ]
+        self._related_entities = related_entities if related_entities is not None else [
+            {"entity_id": "neo4j", "entity_name": "Neo4j", "relationship": "CO_OCCURS_WITH", "depth": 1},
+        ]
+        self.extract_calls = []
+        self.find_docs_calls = []
+        self.search_related_calls = []
+
+    def extract_query_entities(self, query, max_entities=10, domain_terms=None):
+        self.extract_calls.append({"query": query, "max_entities": max_entities, "domain_terms": domain_terms})
+        return self._query_entities
+
+    def find_documents_by_entities(self, entity_names, namespace=None, limit=25):
+        self.find_docs_calls.append({"entity_names": entity_names, "namespace": namespace, "limit": limit})
+        return self._related_documents
+
+    def search_related_entities(self, entity_names, namespace=None, max_depth=2, limit=10):
+        self.search_related_calls.append({"entity_names": entity_names, "namespace": namespace, "max_depth": max_depth, "limit": limit})
+        return self._related_entities
+
+
+# ---------------------------------------------------------------------------
+# GraphRetrievalConfig - pure logic
+# ---------------------------------------------------------------------------
+
+def test_config_defaults_to_hybrid():
+    config = GraphRetrievalConfig()
+    assert config.mode == "hybrid"
+    assert config.graph_expand_depth == 2
+    assert config.max_graph_results == 10
+
+
+def test_config_rejects_bad_mode():
+    with pytest.raises(ValueError, match="mode must be"):
+        GraphRetrievalConfig(mode="bogus")
+
+
+def test_config_rejects_bad_depth():
+    with pytest.raises(ValueError, match="graph_expand_depth"):
+        GraphRetrievalConfig(graph_expand_depth=0)
+
+
+def test_config_rejects_bad_max_graph_results():
+    with pytest.raises(ValueError, match="max_graph_results"):
+        GraphRetrievalConfig(max_graph_results=0)
+
+
+def test_config_rejects_bad_max_query_entities():
+    with pytest.raises(ValueError, match="max_query_entities"):
+        GraphRetrievalConfig(max_query_entities=0)
+
+
+# ---------------------------------------------------------------------------
+# GraphRetriever - hybrid mode
+# ---------------------------------------------------------------------------
+
+def test_hybrid_mode_combines_chunks_and_graph_context():
+    rag = FakeRag()
+    graph = FakeGraph()
+    retriever = GraphRetriever(graph=graph, rag=rag, config=GraphRetrievalConfig(mode="hybrid"))
+
+    result = retriever.retrieve("What products has Acme Corp launched?", top_k=2)
+
+    assert len(result["chunks"]) == 2
+    assert result["query_entities"] == ["Acme Corp"]
+    assert len(result["graph_context"]["related_documents"]) == 1
+    assert len(result["graph_context"]["related_entities"]) == 1
+    assert result["retrieval_method"] == "hybrid_vector_graph"
+
+
+def test_hybrid_mode_calls_rag_retrieve_with_correct_args():
+    rag = FakeRag()
+    graph = FakeGraph()
+    retriever = GraphRetriever(graph=graph, rag=rag)
+
+    retriever.retrieve("some query", top_k=3, metadata_filter={"tenant": "acme"})
+
+    assert rag.called_with["query"] == "some query"
+    assert rag.called_with["top_k"] == 3
+    assert rag.called_with["metadata_filter"] == {"tenant": "acme"}
+
+
+def test_hybrid_mode_citations_include_both_chunk_and_graph_path_types():
+    rag = FakeRag()
+    graph = FakeGraph()
+    retriever = GraphRetriever(graph=graph, rag=rag)
+
+    result = retriever.retrieve("query")
+
+    citation_types = [c["type"] for c in result["citations"]]
+    assert citation_types.count("chunk") == 2
+    assert citation_types.count("graph_path") == 1
+
+
+def test_no_query_entities_skips_graph_calls_but_still_returns_chunks():
+    """When the query has no extractable entities, graph lookups are
+    pointless and should be skipped entirely - not called with an
+    empty list."""
+    rag = FakeRag()
+    graph = FakeGraph(query_entities=[])
+    retriever = GraphRetriever(graph=graph, rag=rag, config=GraphRetrievalConfig(mode="hybrid"))
+
+    result = retriever.retrieve("vague query with no named entities")
+
+    assert result["query_entities"] == []
+    assert result["graph_context"] == {"related_documents": [], "related_entities": []}
+    assert len(graph.find_docs_calls) == 0
+    assert len(graph.search_related_calls) == 0
+    assert len(result["chunks"]) == 2  # hybrid mode still returns vector chunks
+
+
+# ---------------------------------------------------------------------------
+# GraphRetriever - graph_only mode
+# ---------------------------------------------------------------------------
+
+def test_graph_only_mode_never_calls_rag_retrieve():
+    rag = FakeRag()
+    graph = FakeGraph()
+    retriever = GraphRetriever(graph=graph, rag=rag, config=GraphRetrievalConfig(mode="graph_only"))
+
+    result = retriever.retrieve("Show all documents about Acme Corp")
+
+    assert result["chunks"] == []
+    assert rag.called_with is None
+    assert result["retrieval_method"] == "graph_only"
+
+
+def test_graph_only_mode_still_populates_graph_context():
+    rag = FakeRag()
+    graph = FakeGraph()
+    retriever = GraphRetriever(graph=graph, rag=rag, config=GraphRetrievalConfig(mode="graph_only"))
+
+    result = retriever.retrieve("Acme Corp related tickets")
+
+    assert len(result["graph_context"]["related_documents"]) == 1
+    assert len(result["graph_context"]["related_entities"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# GraphRetriever - config passthrough
+# ---------------------------------------------------------------------------
+
+def test_graph_expand_depth_and_max_results_passed_through():
+    rag = FakeRag()
+    graph = FakeGraph()
+    config = GraphRetrievalConfig(graph_expand_depth=5, max_graph_results=3)
+    retriever = GraphRetriever(graph=graph, rag=rag, config=config)
+
+    retriever.retrieve("query about Acme Corp")
+
+    assert graph.search_related_calls[0]["max_depth"] == 5
+    assert graph.search_related_calls[0]["limit"] == 3
+    assert graph.find_docs_calls[0]["limit"] == 3
+
+
+def test_namespace_passed_through_to_graph_methods():
+    rag = FakeRag()
+    graph = FakeGraph()
+    retriever = GraphRetriever(graph=graph, rag=rag)
+
+    retriever.retrieve("query about Acme Corp", namespace="acme-tenant")
+
+    assert graph.find_docs_calls[0]["namespace"] == "acme-tenant"
+    assert graph.search_related_calls[0]["namespace"] == "acme-tenant"
+
+
+def test_domain_terms_passed_through_to_extract_query_entities():
+    rag = FakeRag()
+    graph = FakeGraph()
+    config = GraphRetrievalConfig(domain_terms=["ALARA", "dose limits"])
+    retriever = GraphRetriever(graph=graph, rag=rag, config=config)
+
+    retriever.retrieve("query")
+
+    assert graph.extract_calls[0]["domain_terms"] == ["ALARA", "dose limits"]


### PR DESCRIPTION
Adds GraphRetriever and GraphRetrievalConfig - hybrid vector+graph retrieval published to PyPI as part of v0.3.0. Wiring into __init__.py's public exports is in a follow-up PR.