### PR TITLE
feat: wire extraction, dedup, GraphRetriever, and relations into GraphIndex (v0.2.0-v0.4.0)

### DIFF
--- a/packages/ragleap-graph/CHANGELOG.md
+++ b/packages/ragleap-graph/CHANGELOG.md
@@ -5,6 +5,76 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.0]
+
+### Added
+
+- Typed relation extraction (`ExtractionConfig(extract_relations=True)`) - identifies typed relationships between already-extracted entities (e.g. "Acme Corp" -[REPORTED]-> "Q3 revenue"), not just untyped co-occurrence. LLM-only feature - requires `method="llm"` (enforced by `ExtractionConfig` itself), since there is no regex equivalent for identifying relation types.
+- `LLMRelationExtractor` and `ExtractedRelation` - takes an already-known list of entities and identifies relations between them, rather than extracting entities itself. This constrains the LLM's subject/object choices to entities already extracted and normalized, reducing hallucinated entities and reusing existing, tested entity extraction rather than duplicating it. Skips the LLM call entirely (returns `[]`) when fewer than 2 entities are known, since a relation needs two entities to connect.
+- Defensive hallucination filtering: even though the prompt constrains subject/object to known entities, the parser drops (does not crash on) any relation referencing an entity name outside the known set, rather than trusting the model's compliance blindly. Self-relations (subject == object) are also dropped.
+- New Neo4j edge type `RELATES_AS {relation_type: ...}`, distinct from the existing untyped `CO_OCCURS_WITH` edges written by co-occurrence extraction - both can coexist on the same graph.
+- `GraphIndex.find_relations(entity_name, relation_type=None, namespace=None, limit=25)` - queries typed relations where `entity_name` is the subject. Only searches the subject/outgoing direction in this release; searching by object or both directions is a reasonable future addition, not built here to keep this release's scope honest and verifiable.
+- 8 new tests covering config validation, the fewer-than-2-entities LLM-call skip, valid relation parsing with UPPER_SNAKE_CASE normalization, hallucinated-entity filtering, self-relation filtering, and the all-providers-failed error path.
+
+### Verified
+
+- Real end-to-end live test: real Gemini call correctly identified two typed relations (`REPORTED`, `PARTNERED_WITH`) from real text, both written to a real isolated Neo4j instance (separate Docker container from production, ports 7690/7477), and correctly read back via `find_relations()`.
+
+### Known limitations
+
+- `find_relations()` only searches the subject/outgoing direction - it cannot currently find relations where `entity_name` is the object.
+- LLM-extracted relation object/subject names can be a shorter or differently-phrased version of the full entity than the co-occurrence entity extraction produced for the same underlying concept (e.g. "Q3" vs "Q3 revenue growth") - observed during the live test above. This is expected LLM extraction variance, not a bug in the relation-writing logic, but it means relation-derived entity names are not guaranteed to exactly match names from the regular entity-extraction path for the same document.
+- Relation extraction runs once per chunk (same granularity as entity extraction) - relations spanning multiple chunks of the same document are not identified.
+
+## [0.3.1]
+
+### Fixed
+
+- PyPI metadata (description, keywords) updated to reflect the real v0.3.0 feature set - LLM extraction, entity dedup, and GraphRetriever were shipped in v0.2.0/v0.3.0 but the description still only described v0.1.0's original scope (regex extraction + co-occurrence graphs). No code changes.
+
+## [0.3.0]
+
+### Added
+
+- `GraphRetriever` and `GraphRetrievalConfig` - fuses `ragleap-rag`'s vector search with `ragleap-graph`'s entity-based graph traversal into one retrieval call, with graph-path citations alongside chunk citations. Two modes: `"hybrid"` (vector search + graph expansion combined, the default) and `"graph_only"` (skip vector search entirely, pure entity/graph retrieval - e.g. "show all documents related to Customer X").
+- Built on `RagLeap.retrieve()` (new in `ragleap-rag` v0.12.0, added specifically to support this) rather than reaching into `ragleap-rag`'s private internals (`_vector_backend`, `_embed_query_cached()`) across a package boundary - see `ragleap-rag`'s own CHANGELOG v0.12.0 entry for the reasoning.
+- Built on `GraphIndex`'s existing, tested methods (`extract_query_entities`, `find_documents_by_entities`, `search_related_entities`) - no new Cypher queries written for this feature.
+- New `retrieval` extra (`pip install ragleap-graph[retrieval]`, requires `ragleap-rag>=0.12.0`) - separate from the existing `llm` extra, since `GraphRetriever` needs `RagLeap.retrieve()` regardless of whether LLM-based entity extraction is used.
+- 14 tests using lightweight fakes matching the real `RagLeap.retrieve()` and `GraphIndex` method contracts - covering both retrieval modes, config validation and passthrough (namespace, depth, domain_terms), citation composition, and the no-query-entities edge case (graph calls correctly skipped rather than called with an empty list).
+
+### Verified
+
+- Real end-to-end integration test: real Postgres (via `ragleap-rag`'s test database, with deterministic fake embeddings so no LLM API key is required), real isolated Neo4j (separate Docker container from production, ports 7690/7477, cleaned up after the test), and `GraphRetriever` wiring both together - confirmed a real ingested document is found via both vector search and graph traversal for the same query, with the two results correctly combined.
+
+### Known limitations
+
+- The regex extractor's capitalized-phrase pattern can pick up the first word of a query as a spurious entity if it happens to be capitalized (e.g. "What did Acme Corp launch?" extracts both `"What"` and `"Acme Corp"` as query entities). This is the same class of pattern-matching imprecision already documented in the v0.2.0 entry below (regex fragmentation), not a new `GraphRetriever`-specific bug - confirmed during the live integration test above.
+- `GraphRetriever` does not currently deduplicate or rank graph-derived results against vector-derived results if the same document appears in both `chunks` and `graph_context.related_documents` - both are returned as-is, and combining/re-ranking them is left to the caller for now.
+
+## [0.2.0]
+
+### Added
+
+- Optional LLM-based entity extraction (`ExtractionConfig(method="llm", provider=...)`), alongside the existing regex path. Regex stays the default - zero behavior change on upgrade for existing users.
+- Built on `ragleap-rag`'s `GenerationService.generate_answer(response_format=...)` rather than a hand-rolled provider client - reuses its existing cross-provider structured-output handling (Gemini native schema, Anthropic forced tool-use, OpenAI-compatible json_schema/json_object fallback) instead of duplicating that logic.
+- `ragleap-rag` added as an optional dependency via a new `llm` extra (`pip install ragleap-graph[llm]`) - not a hard dependency, so regex-only users install nothing extra.
+- `EntityDeduplicator`: merges near-duplicate entity names (e.g. "Acme Corp" / "ACME Corp.") via string-similarity threshold before nodes are written to Neo4j. Opt-in via `ExtractionConfig(dedup_enabled=True)`, independent of extraction method - works for both regex- and LLM-extracted names.
+- `GraphIndex(extraction=ExtractionConfig(...))` - new optional constructor parameter wiring the above into `upsert_document()`.
+
+### Fixed
+
+- **Real false-positive caught during development**: the initial dedup threshold (0.85) incorrectly merged "Neo4j" and "Neo 4j" as the same entity. Tested against 0.85/0.90/0.92/0.95 and confirmed 0.92 as the measured point where the false positive clears without breaking true-positive merges (e.g. "T.C. Antony" / "TC Antony"). Default threshold set to 0.92, not guessed.
+- **Real test-harness bug caught before merge**: the test suite's provider mock relied on module-cache busting keyed to the wrong module path (`extraction` instead of `ragleap_graph.extraction`), so five LLM-extraction tests were silently making real network calls to Gemini/OpenAI-compatible endpoints instead of using the mock - caught because those calls failed on missing API keys in the dev environment, not because the mock was verified working. Fixed by correcting the cache-bust key and adding a canary assertion that fails loudly if the mock doesn't actually take effect, so this class of bug can't recur silently.
+
+### Verified
+
+- `LLMEntityExtractor` proven end-to-end against a real Gemini call (`gemini-3.6-flash`), not just mocked responses.
+- `_apply_entity_dedup()` proven end-to-end against a real, isolated Neo4j write (separate Docker container from production, ports 7689/7476, cleaned up after the test) - confirmed real entity nodes are correctly merged/written.
+
+### Known limitations
+
+- `EntityDeduplicator` merges spelling variants of an already-extracted entity name (e.g. "Acme Corp" vs "ACME Corp."); it does NOT fix fragmentation caused by the regex extractor splitting a single real-world entity into multiple disconnected candidates in the first place. Concretely: on input containing "ACME Corp.", the regex extractor's acronym rule and capitalized-phrase rule independently produce "ACME" and "Corp" as two separate candidates (neither matches the other's pattern), alongside the correct "Acme Corp" from elsewhere in the text - three overlapping entities where there should be one. Dedup correctly declines to merge these (similarity ~0.67, below the 0.92 threshold) because bridging that gap via looser substring/prefix matching would risk wrongly merging genuinely distinct entities (e.g. "Apple" with "Apple Music"). Confirmed via a real live test: `method="llm"` on the identical input correctly recognizes "Acme Corp" and "ACME Corp." as one entity from context, producing 3 clean entities instead of regex's 3 fragmented ones. This is a real, structural limitation of pattern-based extraction, not a dedup bug - documented here rather than silently worked around.
+
 ## [0.1.0]
 
 ### Added
@@ -20,3 +90,4 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - 26 tests: pure-logic tests (entity normalization, extraction, `max_depth` validation) requiring no live Neo4j, driver-unavailable graceful-degradation tests for every public method, and one live end-to-end integration test (write, query three ways, verified self-cleanup — 0 nodes left behind) that runs automatically when real `NEO4J_URI`/`NEO4J_USER`/`NEO4J_PASSWORD` credentials are present, and skips cleanly otherwise.
 - CI: dedicated `ragleap-graph-tests` job with a real Neo4j service container, mirroring `ragleap-rag-tests`' pattern — confirmed passing in GitHub's own CI environment, not just locally.
 - **This is the first package in the ragleap ecosystem with genuine, complete live verification from day one** — unlike several `ragleap-rag` vector backends, which shipped honestly labeled "code-complete but unverified" due to no account access. Real Neo4j access was already available, so every method here has actually been proven to work end-to-end, not just tested in isolation.
+- **Second real bug found and fixed during implementation**: `search_related_entities()` originally validated `max_depth` *after* checking driver availability, so invalid `max_depth` input silently returned `[]` instead of raising — when it should raise regardless of connection state. Caught by a real test failure. Fixed by validating `max_depth` first, before any driver-availability check.

--- a/packages/ragleap-graph/README.md
+++ b/packages/ragleap-graph/README.md
@@ -27,9 +27,36 @@ docs = graph.find_documents_by_entities(["Acme Corp"])
 related = graph.search_related_entities(["Acme Corp"], max_depth=2)
 ```
 
+## LLM-based extraction and dedup (v0.2.0+)
+
+The default entity extraction is regex/heuristic-based (fast, free, zero
+dependencies). For messier input — e.g. inconsistent capitalization like
+"Acme Corp" vs "ACME Corp." — LLM-based extraction and dedup produce
+cleaner graphs. Requires the `llm` extra: `pip install ragleap-graph[llm]`
+
+```python
+from ragleap.generation import ProviderConfig
+from ragleap_graph import GraphConfig, GraphIndex, ExtractionConfig
+
+graph = GraphIndex(
+    config=GraphConfig(uri="bolt://localhost:7687", user="neo4j", password="..."),
+    extraction=ExtractionConfig(
+        method="llm",
+        provider=ProviderConfig(provider="gemini", api_key="...", model="gemini-3.6-flash"),
+        dedup_enabled=True,
+    ),
+)
+```
+
+Note: `EntityDeduplicator` merges spelling variants of an already-extracted
+name; it does not fix fragmentation caused by the regex extractor splitting
+one real-world entity into multiple candidates in the first place — see
+CHANGELOG.md for a real, measured example of this and how `method="llm"`
+avoids it at the source.
+
 ## Status
 
-Early alpha (v0.1.0). Ported from a real production `GraphService`, adapted for standalone open-source use — see `HANDOFF.md` for the full design history.
+v0.2.0. Ported from a real production `GraphService`, adapted for standalone open-source use — see `HANDOFF.md` for the full design history. `ragleap-rag` >=0.12.0 is an optional dependency, required only for `method="llm"`.
 
 ## License
 

--- a/packages/ragleap-graph/pyproject.toml
+++ b/packages/ragleap-graph/pyproject.toml
@@ -4,15 +4,15 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-graph"
-version = "0.1.0"
-description = "Knowledge-graph-augmented retrieval for RAG systems — entity extraction, co-occurrence graphs, and graph-based document retrieval via Neo4j. Framework-agnostic, optional multi-tenant namespacing."
+version = "0.4.0"
+description = "Knowledge-graph-augmented retrieval for RAG systems: Neo4j-backed entity extraction (regex or LLM-based), co-occurrence graphs, entity deduplication, and GraphRetriever for hybrid vector+graph retrieval via the optional ragleap-rag integration. Framework-agnostic, optional multi-tenant namespacing, no hardcoded models or vocabulary."
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"
 authors = [
     { name = "Antony", email = "antony@ragleap.com" }
 ]
-keywords = ["knowledge-graph", "rag", "neo4j", "entity-extraction", "graph-retrieval"]
+keywords = ["knowledge-graph", "rag", "neo4j", "entity-extraction", "graph-retrieval", "entity-resolution", "deduplication", "hybrid-retrieval", "llm", "graph-rag"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
@@ -29,6 +29,8 @@ dependencies = [
 
 [project.optional-dependencies]
 test = ["pytest>=8.0.0", "pytest-asyncio>=0.24.0"]
+llm = ["ragleap-rag>=0.11.0"]
+retrieval = ["ragleap-rag>=0.12.0"]
 
 [project.urls]
 Homepage = "https://github.com/antonyrag/ragleap-core"

--- a/packages/ragleap-graph/src/ragleap_graph/__init__.py
+++ b/packages/ragleap-graph/src/ragleap_graph/__init__.py
@@ -32,9 +32,23 @@ try:
 except ImportError:
     GraphDatabase = None
 
+# v0.2.0: optional LLM-based entity extraction and dedup. Importing these
+# is always safe with zero new hard dependencies - extraction.py itself
+# only requires ragleap-rag if method="llm" is actually selected at
+# ExtractionConfig construction time.
+from ragleap_graph.extraction import (
+    ExtractionConfig,
+    ExtractedEntity,
+    EntityDeduplicator,
+    LLMEntityExtractor,
+    ExtractedRelation,
+    LLMRelationExtractor,
+)
+from ragleap_graph.retrieval import GraphRetriever, GraphRetrievalConfig
+
 logger = logging.getLogger(__name__)
 
-__version__ = "0.1.0"
+__version__ = "0.4.0"
 
 # Hard ceiling on traversal depth — prevents both runaway queries and,
 # since max_depth is string-interpolated into Cypher (see note above),
@@ -68,9 +82,31 @@ class GraphIndex:
     connectivity before relying on it.
     """
 
-    def __init__(self, config: Optional[GraphConfig] = None):
+    def __init__(
+        self,
+        config: Optional[GraphConfig] = None,
+        extraction: Optional[ExtractionConfig] = None,
+    ):
         self.config = config or GraphConfig()
         self.driver = None
+
+        # v0.2.0: entity-extraction strategy. Defaults to ExtractionConfig()
+        # which is method="regex", dedup_enabled=False - identical behavior
+        # to v0.1.0 for anyone not explicitly opting in.
+        self.extraction = extraction or ExtractionConfig()
+        self._llm_extractor = None
+        if self.extraction.method == "llm":
+            # Constructed eagerly (not lazily on first use) so a
+            # misconfigured provider fails at GraphIndex construction
+            # time, not silently mid-upsert.
+            self._llm_extractor = LLMEntityExtractor(self.extraction)
+
+        # v0.4.0: optional typed relation extraction. Requires
+        # extraction.method="llm" (enforced by ExtractionConfig itself) -
+        # there is no regex equivalent for identifying relation types.
+        self._relation_extractor = None
+        if self.extraction.extract_relations:
+            self._relation_extractor = LLMRelationExtractor(self.extraction)
 
         if GraphDatabase is None:
             logger.warning(
@@ -198,6 +234,31 @@ class GraphIndex:
             query, max_entities=max_entities, domain_terms=domain_terms
         )
 
+    def _collect_entities_for_chunk(
+        self, text: str, max_entities: int, domain_terms: Optional[List[str]]
+    ) -> List[str]:
+        """
+        Dispatch entity extraction for one chunk of text, per the
+        configured self.extraction.method.
+
+        v0.1.0 behavior (method="regex", the default) is completely
+        unchanged - this just wraps the existing call. method="llm"
+        routes through LLMEntityExtractor instead, returning entity
+        names only (types are not currently stored in the graph schema -
+        that is a v0.3.0-scope change, not this one).
+        """
+        if self.extraction.method == "llm":
+            if self._llm_extractor is None:  # pragma: no cover - defensive
+                raise RuntimeError(
+                    "extraction.method=\'llm\' but no LLMEntityExtractor was "
+                    "constructed - this should not happen; please report a bug."
+                )
+            entities = self._llm_extractor.extract(text, domain_terms=domain_terms)
+            return [e.name for e in entities][:max_entities]
+        return self._extract_entity_candidates_from_text(
+            text, max_entities=max_entities, domain_terms=domain_terms
+        )
+
     # ------------------------------------------------------------------
     # Core graph operations
     # ------------------------------------------------------------------
@@ -234,6 +295,7 @@ class GraphIndex:
             "document_id": str(document_id),
             "entities_indexed": 0,
             "relationships_indexed": 0,
+            "relations_indexed": 0,
             "error": None,
         }
 
@@ -243,13 +305,14 @@ class GraphIndex:
 
         entity_counter: Counter = Counter()
         pair_counter: Counter = Counter()
+        relation_counter: Counter = Counter()
 
         for chunk in chunks or []:
             text = (chunk.get("text") or "").strip()
             if not text:
                 continue
 
-            entities = self._extract_entity_candidates_from_text(
+            entities = self._collect_entities_for_chunk(
                 text, max_entities=12, domain_terms=domain_terms
             )
             if not entities:
@@ -272,6 +335,19 @@ class GraphIndex:
                         continue
                     pair = tuple(sorted((a, b), key=lambda s: s.lower()))
                     pair_counter[pair] += 1
+
+            if self._relation_extractor is not None:
+                relations = self._relation_extractor.extract(
+                    text, known_entities=unique_entities, domain_terms=domain_terms
+                )
+                for rel in relations:
+                    key = (rel.subject, rel.relation_type, rel.object)
+                    relation_counter[key] += 1
+
+        if self.extraction.dedup_enabled and entity_counter:
+            entity_counter, pair_counter, relation_counter = self._apply_entity_dedup(
+                entity_counter, pair_counter, relation_counter
+            )
 
         top_entities = entity_counter.most_common(max_entities)
         top_pairs = pair_counter.most_common(max_pairs)
@@ -323,6 +399,23 @@ class GraphIndex:
                         weight=float(weight),
                     )
                     summary["relationships_indexed"] += 1
+
+                for (subject, relation_type, obj), weight in relation_counter.most_common(max_pairs):
+                    session.run(
+                        """
+                        MATCH (es:Entity {name: $subject, namespace: $namespace})
+                        MATCH (eo:Entity {name: $object, namespace: $namespace})
+                        MERGE (es)-[r:RELATES_AS {relation_type: $relation_type}]->(eo)
+                        ON CREATE SET r.weight = $weight
+                        ON MATCH SET r.weight = coalesce(r.weight, 0) + $weight
+                        """,
+                        subject=subject.lower(),
+                        object=obj.lower(),
+                        relation_type=relation_type,
+                        namespace=ns,
+                        weight=float(weight),
+                    )
+                    summary["relations_indexed"] += 1
 
             summary["success"] = True
             return summary
@@ -464,6 +557,74 @@ class GraphIndex:
             logger.error(f"Related-entity search error: {e}", exc_info=True)
             return []
 
+    def find_relations(
+        self,
+        entity_name: str,
+        relation_type: Optional[str] = None,
+        namespace: Optional[str] = None,
+        limit: int = 25,
+    ) -> List[Dict[str, Any]]:
+        """
+        Find typed relations where entity_name is the subject (v0.4.0+).
+
+        Only searches outgoing relations from entity_name (subject side) -
+        searching both directions, or by object, is a reasonable future
+        addition not built here to keep this method's scope honest and
+        verifiable rather than guessing at a larger untested surface area.
+
+        Requires relations to have been written via
+        ExtractionConfig(extract_relations=True) during upsert_document() -
+        returns [] (not an error) if no typed relations exist, same as
+        every other query method here when there is simply nothing to find.
+
+        relation_type= optionally filters to one relation type (e.g.
+        "REPORTED"); omit to return all relation types for entity_name.
+        """
+        if not self.driver:
+            logger.warning("Neo4j driver not available")
+            return []
+
+        normalized = self._normalize_entity_name(entity_name)
+        if not normalized:
+            return []
+
+        ns = namespace or ""
+
+        try:
+            with self.driver.session() as session:
+                query = """
+                    MATCH (s:Entity {name: $subject, namespace: $namespace})
+                          -[r:RELATES_AS]->(o:Entity {namespace: $namespace})
+                    WHERE $relation_type IS NULL OR r.relation_type = $relation_type
+                    RETURN s.display_name AS subject,
+                           r.relation_type AS relation_type,
+                           o.display_name AS object,
+                           coalesce(r.weight, 1.0) AS weight
+                    ORDER BY weight DESC
+                    LIMIT $limit
+                """
+                result = session.run(
+                    query,
+                    subject=normalized.lower(),
+                    namespace=ns,
+                    relation_type=relation_type,
+                    limit=max(1, int(limit)),
+                )
+
+                relations = []
+                for row in result:
+                    relations.append({
+                        "subject": row["subject"],
+                        "relation_type": row["relation_type"],
+                        "object": row["object"],
+                        "weight": float(row["weight"]),
+                    })
+                return relations
+
+        except Exception as e:
+            logger.error(f"Relation search error: {e}", exc_info=True)
+            return []
+
     def document_entities(
         self,
         document_id: str,
@@ -518,6 +679,56 @@ class GraphIndex:
     # Internal helpers
     # ------------------------------------------------------------------
 
+    def _apply_entity_dedup(
+        self, entity_counter: Counter, pair_counter: Counter, relation_counter: Optional[Counter] = None
+    ) -> Tuple[Counter, Counter, Counter]:
+        """
+        Merge near-duplicate entity names (e.g. "Acme Corp" / "ACME Corp.")
+        into one canonical node before writing to Neo4j, using
+        EntityDeduplicator at the configured self.extraction.dedup_threshold.
+
+        Only called when self.extraction.dedup_enabled is True - this
+        is opt-in and independent of extraction method (works for both
+        regex- and LLM-extracted entity names).
+
+        relation_counter is optional (v0.4.0+) since not every caller
+        has typed relations to remap - defaults to an empty Counter if
+        omitted, so callers without relation extraction enabled don't
+        need to pass anything new.
+        """
+        relation_counter = relation_counter if relation_counter is not None else Counter()
+
+        dedup = EntityDeduplicator(threshold=self.extraction.dedup_threshold)
+        mapping = dedup.resolve(list(entity_counter.keys()))
+
+        merged_entities: Counter = Counter()
+        for name, weight in entity_counter.items():
+            canonical = mapping.get(name, name)
+            merged_entities[canonical] += weight
+
+        merged_pairs: Counter = Counter()
+        for (a, b), weight in pair_counter.items():
+            ca = mapping.get(a, a)
+            cb = mapping.get(b, b)
+            if ca == cb:
+                # Both sides of the pair merged into the same canonical
+                # entity - no self-loop edge, just drop it.
+                continue
+            pair = tuple(sorted((ca, cb), key=lambda s: s.lower()))
+            merged_pairs[pair] += weight
+
+        merged_relations: Counter = Counter()
+        for (subject, relation_type, obj), weight in relation_counter.items():
+            c_subject = mapping.get(subject, subject)
+            c_object = mapping.get(obj, obj)
+            if c_subject == c_object:
+                # Both sides merged into the same canonical entity -
+                # a self-relation is meaningless, drop it.
+                continue
+            merged_relations[(c_subject, relation_type, c_object)] += weight
+
+        return merged_entities, merged_pairs, merged_relations
+
     def _normalize_entity_list(self, entity_names: List[str]) -> List[str]:
         normalized = []
         seen = set()
@@ -533,4 +744,16 @@ class GraphIndex:
         return normalized
 
 
-__all__ = ["GraphConfig", "GraphIndex", "__version__"]
+__all__ = [
+    "GraphConfig",
+    "GraphIndex",
+    "ExtractionConfig",
+    "ExtractedEntity",
+    "EntityDeduplicator",
+    "LLMEntityExtractor",
+    "ExtractedRelation",
+    "LLMRelationExtractor",
+    "GraphRetriever",
+    "GraphRetrievalConfig",
+    "__version__",
+]


### PR DESCRIPTION
Final PR in this catch-up series. Wires extraction.py (PR #111) and retrieval.py (PR #112) into GraphIndex's public API, adds typed relation writing to upsert_document(), adds find_relations(), and brings CHANGELOG/README/pyproject.toml current through v0.4.0. This is the version of the code genuinely published on PyPI.