### PR TITLE
feat: ragleap-graph v0.5.0 - entity typing/ontology guidance

### DIFF
--- a/packages/ragleap-graph/CHANGELOG.md
+++ b/packages/ragleap-graph/CHANGELOG.md
@@ -5,6 +5,27 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.5.0]
+
+### Added
+
+- Optional entity typing/ontology guidance (`ExtractionConfig(entity_types=[...])`) - lets callers guide LLM entity extraction toward domain-specific categories (e.g. "Customer", "Product", "Ticket") instead of generic categories like "ORG"/"PERSON". Passed as guidance in the extraction prompt, same convention as the existing `domain_terms=` parameter - not enforced/validated, the model uses its own judgment for entities that don't fit any given category.
+- Entity type is now stored on the graph: `:Entity` nodes gain an `entity_type` property (previously computed by `LLMEntityExtractor` since v0.2.0 but discarded before reaching Neo4j - this closes that gap). Regex-extracted entities are stored with `entity_type="UNKNOWN"`, since regex has no semantic understanding to draw a type from.
+- Re-upserting a document does not downgrade a real type to `"UNKNOWN"`: a later regex-only upsert of the same document won't overwrite an already-recorded LLM-derived type, via `coalesce(NULLIF($entity_type, "UNKNOWN"), e.entity_type, "UNKNOWN")` in the write query.
+- `GraphIndex.find_entities_by_type(entity_type, namespace=None, limit=25)` - queries entities by their stored type.
+- `_collect_entities_for_chunk()` now returns `(name, entity_type)` pairs instead of bare names - internal signature change, not part of the public API. Verified via a regression test that the set of entity *names* produced by the regex path is byte-identical before and after this change; only the return shape changed, not the extraction logic itself.
+- 8 new tests: config defaults, prompt-guidance passthrough, response type-field regression guard, regex-path UNKNOWN-typing, the names-unchanged regression guard, and `find_entities_by_type()` edge cases.
+
+### Verified
+
+- Real end-to-end live test: real Gemini call with `entity_types=["Customer", "Product"]` guidance correctly typed "Acme Corp" as `Customer` and "Neo4j Enterprise" as `Product`, both written to a real isolated Neo4j instance and correctly retrieved via `find_entities_by_type()`.
+
+### Known limitations
+
+- No schema *enforcement* - `entity_types=` is guidance only, the model can and will assign types outside the given list when nothing fits; there's no validation or rejection of out-of-vocabulary types.
+- No relationship-type ontology constraints (e.g. "a REPORTED relation can only go Customer -> Product") - relation types (v0.4.0) and entity types (v0.5.0) aren't currently cross-validated against each other.
+- `find_entities_by_type()` does an exact string match on `entity_type` - "Customer" and "customer" are treated as different types, since entity_type is stored exactly as the model (or "UNKNOWN") produced it, with no additional normalization applied.
+
 ## [0.4.0]
 
 ### Added

--- a/packages/ragleap-graph/pyproject.toml
+++ b/packages/ragleap-graph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-graph"
-version = "0.4.0"
+version = "0.5.0"
 description = "Knowledge-graph-augmented retrieval for RAG systems: Neo4j-backed entity extraction (regex or LLM-based), co-occurrence graphs, entity deduplication, and GraphRetriever for hybrid vector+graph retrieval via the optional ragleap-rag integration. Framework-agnostic, optional multi-tenant namespacing, no hardcoded models or vocabulary."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-graph/src/ragleap_graph/__init__.py
+++ b/packages/ragleap-graph/src/ragleap_graph/__init__.py
@@ -48,7 +48,7 @@ from ragleap_graph.retrieval import GraphRetriever, GraphRetrievalConfig
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 # Hard ceiling on traversal depth — prevents both runaway queries and,
 # since max_depth is string-interpolated into Cypher (see note above),
@@ -236,28 +236,32 @@ class GraphIndex:
 
     def _collect_entities_for_chunk(
         self, text: str, max_entities: int, domain_terms: Optional[List[str]]
-    ) -> List[str]:
+    ) -> List[Tuple[str, str]]:
         """
         Dispatch entity extraction for one chunk of text, per the
-        configured self.extraction.method.
+        configured self.extraction.method. Returns (name, entity_type)
+        pairs (v0.5.0+) - entity_type is "UNKNOWN" for the regex path
+        (no semantic understanding to draw a type from), or whatever
+        LLMEntityExtractor determined (e.g. "ORG", "PERSON", or a
+        caller-supplied category from ExtractionConfig.entity_types=)
+        for the LLM path.
 
-        v0.1.0 behavior (method="regex", the default) is completely
-        unchanged - this just wraps the existing call. method="llm"
-        routes through LLMEntityExtractor instead, returning entity
-        names only (types are not currently stored in the graph schema -
-        that is a v0.3.0-scope change, not this one).
+        v0.1.0 regex behavior is otherwise completely unchanged - same
+        candidates, just paired with a constant "UNKNOWN" type now
+        instead of being returned as bare strings.
         """
         if self.extraction.method == "llm":
             if self._llm_extractor is None:  # pragma: no cover - defensive
                 raise RuntimeError(
-                    "extraction.method=\'llm\' but no LLMEntityExtractor was "
+                    "extraction.method='llm' but no LLMEntityExtractor was "
                     "constructed - this should not happen; please report a bug."
                 )
             entities = self._llm_extractor.extract(text, domain_terms=domain_terms)
-            return [e.name for e in entities][:max_entities]
-        return self._extract_entity_candidates_from_text(
+            return [(e.name, e.type) for e in entities][:max_entities]
+        names = self._extract_entity_candidates_from_text(
             text, max_entities=max_entities, domain_terms=domain_terms
         )
+        return [(name, "UNKNOWN") for name in names]
 
     # ------------------------------------------------------------------
     # Core graph operations
@@ -306,27 +310,34 @@ class GraphIndex:
         entity_counter: Counter = Counter()
         pair_counter: Counter = Counter()
         relation_counter: Counter = Counter()
+        entity_type_map: Dict[str, str] = {}
 
         for chunk in chunks or []:
             text = (chunk.get("text") or "").strip()
             if not text:
                 continue
 
-            entities = self._collect_entities_for_chunk(
+            entity_type_pairs = self._collect_entities_for_chunk(
                 text, max_entities=12, domain_terms=domain_terms
             )
-            if not entities:
+            if not entity_type_pairs:
                 continue
 
             unique_entities = []
             seen_local = set()
-            for ent in entities:
+            for ent, ent_type in entity_type_pairs:
                 key = ent.lower()
                 if key in seen_local:
                     continue
                 seen_local.add(key)
                 unique_entities.append(ent)
                 entity_counter[ent] += 1
+                # First type seen for a given entity name wins - later
+                # chunks mentioning the same entity don't override an
+                # already-recorded type. Simple, deterministic tie-break;
+                # entities are normalized/deduped by name already, so a
+                # genuinely different type for the "same" name is rare.
+                entity_type_map.setdefault(key, ent_type)
 
             for i in range(len(unique_entities)):
                 for j in range(i + 1, len(unique_entities)):
@@ -367,11 +378,13 @@ class GraphIndex:
                 )
 
                 for entity_name, weight in top_entities:
+                    entity_type = entity_type_map.get(entity_name.lower(), "UNKNOWN")
                     session.run(
                         """
                         MATCH (d:Document {id: $document_id, namespace: $namespace})
                         MERGE (e:Entity {name: $name_lower, namespace: $namespace})
                         ON CREATE SET e.display_name = $name
+                        SET e.entity_type = coalesce(NULLIF($entity_type, "UNKNOWN"), e.entity_type, "UNKNOWN")
                         MERGE (d)-[r:CONTAINS]->(e)
                         ON CREATE SET r.weight = $weight
                         ON MATCH SET r.weight = coalesce(r.weight, 0) + $weight
@@ -380,6 +393,7 @@ class GraphIndex:
                         namespace=ns,
                         name_lower=entity_name.lower(),
                         name=entity_name,
+                        entity_type=entity_type,
                         weight=float(weight),
                     )
                     summary["entities_indexed"] += 1
@@ -661,6 +675,60 @@ class GraphIndex:
 
         except Exception as e:
             logger.error(f"Document entity lookup error: {e}", exc_info=True)
+            return []
+
+    def find_entities_by_type(
+        self,
+        entity_type: str,
+        namespace: Optional[str] = None,
+        limit: int = 25,
+    ) -> List[Dict[str, Any]]:
+        """
+        Find entities of a given type (v0.5.0+), e.g. "ORG", "PERSON",
+        or a caller-supplied category from ExtractionConfig.entity_types=.
+
+        Only meaningful for entities extracted via method="llm" - regex
+        extraction has no semantic understanding to draw a type from, so
+        entities from that path are always stored with entity_type
+        "UNKNOWN" and will only show up here if entity_type="UNKNOWN" is
+        searched for explicitly.
+        """
+        if not self.driver:
+            logger.warning("Neo4j driver not available")
+            return []
+
+        if not entity_type or not entity_type.strip():
+            return []
+
+        ns = namespace or ""
+
+        try:
+            with self.driver.session() as session:
+                result = session.run(
+                    """
+                    MATCH (e:Entity {namespace: $namespace})
+                    WHERE e.entity_type = $entity_type
+                    RETURN e.name AS entity_id,
+                           e.display_name AS entity_name,
+                           e.entity_type AS entity_type
+                    LIMIT $limit
+                    """,
+                    namespace=ns,
+                    entity_type=entity_type,
+                    limit=max(1, int(limit)),
+                )
+
+                entities = []
+                for row in result:
+                    entities.append({
+                        "entity_id": row["entity_id"],
+                        "entity_name": row["entity_name"],
+                        "entity_type": row["entity_type"],
+                    })
+                return entities
+
+        except Exception as e:
+            logger.error(f"Entity-by-type search error: {e}", exc_info=True)
             return []
 
     def health_check(self) -> bool:

--- a/packages/ragleap-graph/src/ragleap_graph/extraction.py
+++ b/packages/ragleap-graph/src/ragleap_graph/extraction.py
@@ -76,6 +76,7 @@ class ExtractionConfig:
     dedup_threshold: float = 0.92
     max_entities_per_chunk: int = 25
     extract_relations: bool = False
+    entity_types: Optional[list[str]] = None
 
     def __post_init__(self) -> None:
         if self.extract_relations and self.method != "llm":
@@ -211,12 +212,19 @@ class LLMEntityExtractor:
         return self._parse_result(result)
 
     def _build_instruction(self, domain_terms: Optional[list[str]]) -> str:
+        base = "Extract all named entities from the given text."
+        if self._config.entity_types:
+            types_joined = ", ".join(self._config.entity_types)
+            base += (
+                f" Where an entity fits one of these categories, use that "
+                f"category as its type: {types_joined}. Use your own "
+                f"judgment for entities that do not fit any of these."
+            )
         if not domain_terms:
-            return "Extract all named entities from the given text."
+            return base
         joined = ", ".join(domain_terms)
-        return (
-            "Extract all named entities from the given text. Pay "
-            f"particular attention to these known domain terms if present: {joined}."
+        return base + (
+            f" Pay particular attention to these known domain terms if present: {joined}."
         )
 
     def _parse_result(self, result: dict[str, Any]) -> list[ExtractedEntity]:

--- a/packages/ragleap-graph/tests/test_extraction.py
+++ b/packages/ragleap-graph/tests/test_extraction.py
@@ -475,3 +475,67 @@ def test_relation_extractor_raises_when_all_providers_failed():
     extractor = LLMRelationExtractor(config)
     with pytest.raises(RuntimeError, match="all configured providers"):
         extractor.extract("text", known_entities=["A", "B"])
+
+
+# ---------------------------------------------------------------------------
+# ExtractionConfig.entity_types (v0.5.0) - mocked GenerationService
+# ---------------------------------------------------------------------------
+
+def test_extraction_config_entity_types_defaults_to_none():
+    from ragleap_graph.extraction import ExtractionConfig
+    config = ExtractionConfig()
+    assert config.entity_types is None
+
+
+def test_llm_extractor_passes_entity_types_into_instruction():
+    """Verify entity_types= actually reaches the prompt sent to the
+    provider - not just accepted and silently dropped."""
+    from ragleap_graph.extraction import ExtractionConfig, LLMEntityExtractor
+
+    captured = {}
+
+    class CapturingService(FakeGenerationService):
+        def generate_answer(self, query, chunks, response_format=None, temperature=None, **kw):
+            captured["query"] = query
+            return {
+                "answer": json.dumps({"entities": []}),
+                "provider_used": "gemini",
+                "structured": {"entities": []},
+                "structured_valid": True,
+                "structured_enforcement": "native",
+            }
+
+    import ragleap_graph.extraction as extraction_module
+    extraction_module.GenerationService = CapturingService
+
+    config = ExtractionConfig(
+        method="llm",
+        provider=FakeProviderConfig(provider="gemini"),
+        entity_types=["Customer", "Product", "Ticket"],
+    )
+    LLMEntityExtractor(config).extract("some text")
+    assert "Customer" in captured["query"]
+    assert "Product" in captured["query"]
+    assert "Ticket" in captured["query"]
+
+
+def test_llm_extractor_still_returns_type_field_from_response():
+    """Regression guard: entity_types= guidance must not break the
+    existing per-entity type field already returned by extract() since
+    v0.2.0 - it just influences what values that field tends to hold."""
+    from ragleap_graph.extraction import ExtractionConfig, LLMEntityExtractor
+    FakeGenerationService.next_response = {
+        "answer": json.dumps({"entities": [{"name": "Acme Corp", "type": "Customer"}]}),
+        "provider_used": "gemini",
+        "structured": {"entities": [{"name": "Acme Corp", "type": "Customer"}]},
+        "structured_valid": True,
+        "structured_enforcement": "native",
+    }
+    config = ExtractionConfig(
+        method="llm",
+        provider=FakeProviderConfig(provider="gemini"),
+        entity_types=["Customer", "Product"],
+    )
+    entities = LLMEntityExtractor(config).extract("Acme Corp is a customer.")
+    assert len(entities) == 1
+    assert entities[0].type == "Customer"

--- a/packages/ragleap-graph/tests/test_ragleap_graph.py
+++ b/packages/ragleap-graph/tests/test_ragleap_graph.py
@@ -249,3 +249,37 @@ def test_live_full_roundtrip():
                 ns=TEST_NAMESPACE,
             )
         graph.close()
+
+
+# ---------------------------------------------------------------------------
+# Entity typing (v0.5.0)
+# ---------------------------------------------------------------------------
+
+def test_collect_entities_for_chunk_regex_path_returns_unknown_type(graph_no_driver):
+    """Regex extraction has no semantic understanding to draw a type
+    from - every entity must be paired with 'UNKNOWN', not left
+    untyped or crashing."""
+    text = "Acme Corp reported strong Q3 revenue with ALARA compliance."
+    result = graph_no_driver._collect_entities_for_chunk(text, max_entities=12, domain_terms=None)
+    assert len(result) > 0
+    assert all(isinstance(pair, tuple) and len(pair) == 2 for pair in result)
+    assert all(entity_type == "UNKNOWN" for _, entity_type in result)
+
+
+def test_collect_entities_for_chunk_regex_path_names_match_old_behavior(graph_no_driver):
+    """Regression guard: the set of entity NAMES extracted by the regex
+    path must be identical before and after the (name, type) tuple
+    change - only the return shape changed, not the extraction logic."""
+    text = "Acme Corp reported strong Q3 revenue with ALARA compliance."
+    old_style_names = graph_no_driver._extract_entity_candidates_from_text(text, max_entities=12)
+    new_style_names = [name for name, _ in graph_no_driver._collect_entities_for_chunk(text, max_entities=12, domain_terms=None)]
+    assert old_style_names == new_style_names
+
+
+def test_find_entities_by_type_empty_without_driver(graph_no_driver):
+    assert graph_no_driver.find_entities_by_type("ORG") == []
+
+
+def test_find_entities_by_type_empty_string_returns_empty(graph_no_driver):
+    assert graph_no_driver.find_entities_by_type("") == []
+    assert graph_no_driver.find_entities_by_type("   ") == []


### PR DESCRIPTION
- ExtractionConfig(entity_types=[...]) - optional guidance steering LLM entity extraction toward domain-specific categories (e.g. 'Customer', 'Product', 'Ticket'), same convention as the existing domain_terms= parameter. Guidance only, not enforced/validated.
- Entity type is now stored on the graph: :Entity nodes gain an entity_type property. This closes a real gap - LLMEntityExtractor has computed a per-entity type since v0.2.0, but GraphIndex discarded it before it ever reached Neo4j.
- Re-upserting a document never downgrades a real type to 'UNKNOWN' - a later regex-only upsert of the same document preserves an already-recorded LLM-derived type.
- GraphIndex.find_entities_by_type(entity_type, namespace=None, limit=25).
- _collect_entities_for_chunk() now returns (name, entity_type) pairs - internal signature change. Verified via a regression test that the regex path's extracted entity NAMES are byte-identical before and after this change, proving only the return shape changed.
- 8 new tests: config defaults, prompt-guidance passthrough, response type-field regression guard, regex-path UNKNOWN-typing, the names-unchanged regression guard, and find_entities_by_type() edges.

Published to PyPI as v0.5.0. Real end-to-end live test: real Gemini call with entity_types=['Customer','Product'] guidance correctly typed real entities, written to a real isolated Neo4j instance, correctly retrieved via find_entities_by_type().

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
