### PR TITLE
fix: PyPI Documentation URLs -> packages.ragleap.com (0.12.2, 0.5.1)

### DIFF
--- a/packages/ragleap-graph/pyproject.toml
+++ b/packages/ragleap-graph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-graph"
-version = "0.5.0"
+version = "0.5.1"
 description = "Knowledge-graph-augmented retrieval for RAG systems: Neo4j-backed entity extraction (regex or LLM-based), co-occurrence graphs, entity deduplication, and GraphRetriever for hybrid vector+graph retrieval via the optional ragleap-rag integration. Framework-agnostic, optional multi-tenant namespacing, no hardcoded models or vocabulary."
 readme = "README.md"
 license = "MIT"
@@ -35,6 +35,7 @@ retrieval = ["ragleap-rag>=0.12.0"]
 [project.urls]
 Homepage = "https://github.com/antonyrag/ragleap-core"
 Repository = "https://github.com/antonyrag/ragleap-core"
+Documentation = "https://packages.ragleap.com/docs/ragleap-graph.html"
 Issues = "https://github.com/antonyrag/ragleap-core/issues"
 
 [tool.hatch.build.targets.wheel]

--- a/packages/ragleap-graph/src/ragleap_graph/__init__.py
+++ b/packages/ragleap-graph/src/ragleap_graph/__init__.py
@@ -48,7 +48,7 @@ from ragleap_graph.retrieval import GraphRetriever, GraphRetrievalConfig
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 # Hard ceiling on traversal depth — prevents both runaway queries and,
 # since max_depth is string-interpolated into Cypher (see note above),

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.12.1"
+version = "0.12.2"
 description = "Self-hosted RAG engine: hybrid dense+sparse retrieval, 28-format ingestion (docs, URLs, images, audio, video), 6 vector backends, 8 embedding providers, 12+ generation providers with automatic fallback, query rewriting (HyDE/contextual/multi-query), structured JSON output, real per-call cost tracking, and standalone retrieval via retrieve(). Composable with the optional ragleap-graph package for knowledge-graph-augmented retrieval. BYOK, no vendor lock-in, no hardcoded model defaults."
 readme = "README.md"
 license = "MIT"
@@ -63,7 +63,7 @@ all = ["google-genai>=0.3.0", "anthropic>=0.34.0", "openai>=1.40.0", "onnxruntim
 [project.urls]
 Homepage = "https://github.com/antonyrag/ragleap-core"
 Repository = "https://github.com/antonyrag/ragleap-core"
-Documentation = "https://docs.ragleap.com"
+Documentation = "https://packages.ragleap.com/docs/ragleap-rag.html"
 Issues = "https://github.com/antonyrag/ragleap-core/issues"
 
 [tool.hatch.build.targets.wheel]

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -45,7 +45,7 @@ from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.12.1"
+__version__ = "0.12.2"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult", "TranscriptionConfig", "VectorBackend", "PgVectorBackend"]
 
 


### PR DESCRIPTION
Metadata-only patch releases for both packages.

**ragleap-rag 0.12.2**
- Documentation URL was pointing to docs.ragleap.com (commercial platform docs — has zero content about this package, confirmed via direct fetch in a prior session)
- Now points to https://packages.ragleap.com/docs/ragleap-rag.html

**ragleap-graph 0.5.1**
- Had no Documentation URL in pyproject.toml at all
- Added, pointing to https://packages.ragleap.com/docs/ragleap-graph.html

Both already built, twine-checked, and published to PyPI before this PR — confirmed live via the version-specific JSON endpoint for each. No code changes, version bump only.