### PR TITLE
fix(graph): drop sentence-initial stopwords from entity extraction (0.5.2)

### DIFF
--- a/packages/ragleap-graph/CHANGELOG.md
+++ b/packages/ragleap-graph/CHANGELOG.md
@@ -5,6 +5,17 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.5.2]
+### Fixed
+- Regex entity extraction (`_extract_entity_candidates_from_text()`, backing `extract_query_entities()`) no longer extracts common sentence-initial words ("What", "Who", "The", auxiliary verbs, etc.) as spurious single-word entity candidates. English capitalizes the first word of any sentence regardless of whether it's a proper noun, so a query like "What did Acme Corp launch?" previously produced `["What", "Acme Corp"]` instead of just `["Acme Corp"]`. Fix is narrowly scoped: only exact single-word matches against a fixed stopword list (`_SENTENCE_INITIAL_STOPWORDS`) are dropped, so a genuine multi-word entity that happens to start with one of these words is unaffected. Documented as a known limitation since v0.1.0; closed here.
+### Verified
+- Regression test added first, confirmed failing against the pre-fix code (`assert "What" not in result` failed against real output `['What', 'Acme Corp']`), then confirmed passing after the fix. Full suite re-run afterward: 75 passed, 2 skipped (skips are the standard live-credential guards, unrelated to this change) - zero regressions.
+
+## [0.5.1]
+### Fixed
+- PyPI `Documentation` URL was missing entirely from `[project.urls]` - this package had no Documentation link on its PyPI page at all. Added, pointing to this package's reference page on packages.ragleap.com (a documentation site for this package ecosystem, separate from docs.ragleap.com which covers only the commercial RagLeap platform and has zero content about this package).
+- Metadata-only patch, no code changes.
+
 ## [0.5.0]
 
 ### Added

--- a/packages/ragleap-graph/pyproject.toml
+++ b/packages/ragleap-graph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-graph"
-version = "0.5.1"
+version = "0.5.2"
 description = "Knowledge-graph-augmented retrieval for RAG systems: Neo4j-backed entity extraction (regex or LLM-based), co-occurrence graphs, entity deduplication, and GraphRetriever for hybrid vector+graph retrieval via the optional ragleap-rag integration. Framework-agnostic, optional multi-tenant namespacing, no hardcoded models or vocabulary."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-graph/src/ragleap_graph/__init__.py
+++ b/packages/ragleap-graph/src/ragleap_graph/__init__.py
@@ -48,12 +48,27 @@ from ragleap_graph.retrieval import GraphRetriever, GraphRetrievalConfig
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 # Hard ceiling on traversal depth — prevents both runaway queries and,
 # since max_depth is string-interpolated into Cypher (see note above),
 # guards against malformed/malicious input reaching the query text.
 MAX_ALLOWED_DEPTH = 10
+
+# v0.5.2: single-word candidates dropped from regex entity extraction.
+# English capitalizes the first word of any sentence regardless of
+# whether it's a proper noun, so naive capitalized-word matching
+# extracts spurious entities like "What" from "What did Acme Corp
+# launch?" alongside the genuine "Acme Corp". Narrow by design: only
+# filters exact single-word matches equal to one of these, so a real
+# multi-word entity that happens to start with one of these words is
+# unaffected.
+_SENTENCE_INITIAL_STOPWORDS = frozenset({
+    "What", "Who", "When", "Where", "Why", "How", "Which",
+    "The", "This", "That", "These", "Those",
+    "Is", "Are", "Was", "Were", "Do", "Does", "Did",
+    "Can", "Could", "Would", "Should", "Will", "May", "Might",
+})
 
 
 @dataclass
@@ -201,8 +216,13 @@ class GraphIndex:
         # 1) Acronyms and all-caps entities.
         candidates.extend(re.findall(r"\b[A-Z]{2,}(?:-[A-Z0-9]+)?\b", text))
         # 2) Capitalized word sequences (person/org/concept-like phrases).
+        raw_phrase_candidates = re.findall(
+            r"\b(?:[A-Z][a-z]{2,})(?:\s+[A-Z][a-z]{2,}){0,2}\b", text
+        )
+        # 2b) Drop exact single-word sentence-initial stopwords (see
+        # _SENTENCE_INITIAL_STOPWORDS docstring above _extract_entity_candidates_from_text).
         candidates.extend(
-            re.findall(r"\b(?:[A-Z][a-z]{2,})(?:\s+[A-Z][a-z]{2,}){0,2}\b", text)
+            c for c in raw_phrase_candidates if c not in _SENTENCE_INITIAL_STOPWORDS
         )
         # 3) Optional caller-supplied domain terms that may appear lowercase.
         if domain_terms:

--- a/packages/ragleap-graph/tests/test_ragleap_graph.py
+++ b/packages/ragleap-graph/tests/test_ragleap_graph.py
@@ -137,6 +137,21 @@ def test_extract_query_entities_delegates_correctly(graph_no_driver):
     assert "Acme Corp" in result
 
 
+def test_extract_query_entities_excludes_sentence_initial_stopwords(graph_no_driver):
+    """Regression test: capitalized question words ("What", "Who", "The", ...)
+    should not be extracted as entities just because English capitalizes the
+    first word of a sentence. Documented as a known limitation prior to this
+    fix - see CHANGELOG.
+    """
+    result = graph_no_driver.extract_query_entities("What did Acme Corp launch?")
+    assert "Acme Corp" in result
+    assert "What" not in result
+
+    result2 = graph_no_driver.extract_query_entities("Who founded Acme Corp?")
+    assert "Acme Corp" in result2
+    assert "Who" not in result2
+
+
 # ---------------------------------------------------------------------------
 # max_depth validation (the security fix — real Cypher-injection guard)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes a known limitation open since v0.1.0.

**The bug**
Regex entity extraction picked up capitalized sentence-initial words ("What", "Who", "The", auxiliary verbs) as spurious entities, since English capitalizes a sentence's first word regardless of whether it's a proper noun. `extract_query_entities("What did Acme Corp launch?")` returned `['What', 'Acme Corp']` instead of `['Acme Corp']`.

**The fix**
Narrow stopword filter (`_SENTENCE_INITIAL_STOPWORDS`) applied only to exact single-word candidates — multi-word entities unaffected.

**Verification**
- Reproduced live before touching any code
- Regression test added first, confirmed it fails against the real bug
- Fix applied, same test confirmed passing
- Full suite re-run: 75 passed, 2 skipped (unrelated live-credential skips), zero regressions

**Also included:** backfilled CHANGELOG entry for 0.5.1 (previously published to PyPI but never logged).

Published to PyPI as 0.5.2 before this PR.