### PR TITLE
fix(graph): add direction= to find_relations(), closes reverse-lookup limitation (0.5.3)

### DIFF
--- a/packages/ragleap-graph/CHANGELOG.md
+++ b/packages/ragleap-graph/CHANGELOG.md
@@ -5,6 +5,12 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.5.3]
+### Fixed
+- `find_relations()` only ever searched outgoing relations (entity_name as subject) - searching from the object side silently returned `[]` even when the entity was clearly involved in a real relation. Added `direction=` parameter: `"outgoing"` (default, unchanged), `"incoming"` (new), `"both"` (new, deduplicated via `startNode()`/`endNode()` rather than a UNION, so subject/object stay correctly labeled regardless of which direction matched). Closes a known limitation open since v0.4.0.
+### Verified
+- Zero prior test coverage existed for `find_relations()` at all, including the existing outgoing-only behavior - backfilled that alongside the new direction tests. Regression test writes `RELATES_AS` edges directly via Cypher (deterministic, no live LLM call needed since this method doesn't touch extraction), confirmed failing first (`TypeError: unexpected keyword argument 'direction'`), then confirmed passing after the fix, including an explicit assertion that the old default behavior still returns `[]` when searching from the object side without `direction="incoming"` - proving the fix is additive, not a silent behavior change. Full suite re-run: 77 passed, 1 skipped (Gemini-key skip, unrelated) - zero regressions.
+
 ## [0.5.2]
 ### Fixed
 - Regex entity extraction (`_extract_entity_candidates_from_text()`, backing `extract_query_entities()`) no longer extracts common sentence-initial words ("What", "Who", "The", auxiliary verbs, etc.) as spurious single-word entity candidates. English capitalizes the first word of any sentence regardless of whether it's a proper noun, so a query like "What did Acme Corp launch?" previously produced `["What", "Acme Corp"]` instead of just `["Acme Corp"]`. Fix is narrowly scoped: only exact single-word matches against a fixed stopword list (`_SENTENCE_INITIAL_STOPWORDS`) are dropped, so a genuine multi-word entity that happens to start with one of these words is unaffected. Documented as a known limitation since v0.1.0; closed here.

--- a/packages/ragleap-graph/pyproject.toml
+++ b/packages/ragleap-graph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-graph"
-version = "0.5.2"
+version = "0.5.3"
 description = "Knowledge-graph-augmented retrieval for RAG systems: Neo4j-backed entity extraction (regex or LLM-based), co-occurrence graphs, entity deduplication, and GraphRetriever for hybrid vector+graph retrieval via the optional ragleap-rag integration. Framework-agnostic, optional multi-tenant namespacing, no hardcoded models or vocabulary."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-graph/src/ragleap_graph/__init__.py
+++ b/packages/ragleap-graph/src/ragleap_graph/__init__.py
@@ -48,7 +48,7 @@ from ragleap_graph.retrieval import GraphRetriever, GraphRetrievalConfig
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"
 
 # Hard ceiling on traversal depth — prevents both runaway queries and,
 # since max_depth is string-interpolated into Cypher (see note above),
@@ -597,46 +597,78 @@ class GraphIndex:
         relation_type: Optional[str] = None,
         namespace: Optional[str] = None,
         limit: int = 25,
+        direction: str = "outgoing",
     ) -> List[Dict[str, Any]]:
         """
-        Find typed relations where entity_name is the subject (v0.4.0+).
-
-        Only searches outgoing relations from entity_name (subject side) -
-        searching both directions, or by object, is a reasonable future
-        addition not built here to keep this method's scope honest and
-        verifiable rather than guessing at a larger untested surface area.
-
+        Find typed relations involving entity_name (v0.4.0+;
+        direction= added v0.5.3, closing a known limitation).
+        direction="outgoing" (default, unchanged since v0.4.0):
+        entity_name is the subject, e.g.
+        (entity_name)-[:PARTNERED_WITH]->(other).
+        direction="incoming": entity_name is the object, e.g.
+        (other)-[:PARTNERED_WITH]->(entity_name). Previously, searching
+        from the object side silently returned [] even when the entity
+        was clearly involved in a real relation - this was the actual
+        bug, not just a missing feature.
+        direction="both": relations in either direction, deduplicated.
         Requires relations to have been written via
         ExtractionConfig(extract_relations=True) during upsert_document() -
         returns [] (not an error) if no typed relations exist, same as
         every other query method here when there is simply nothing to find.
-
         relation_type= optionally filters to one relation type (e.g.
         "REPORTED"); omit to return all relation types for entity_name.
         """
+        if direction not in ("outgoing", "incoming", "both"):
+            raise ValueError(
+                f'direction must be "outgoing", "incoming", or "both", got {direction!r}'
+            )
         if not self.driver:
             logger.warning("Neo4j driver not available")
             return []
-
         normalized = self._normalize_entity_name(entity_name)
         if not normalized:
             return []
-
         ns = namespace or ""
-
         try:
             with self.driver.session() as session:
-                query = """
-                    MATCH (s:Entity {name: $subject, namespace: $namespace})
-                          -[r:RELATES_AS]->(o:Entity {namespace: $namespace})
-                    WHERE $relation_type IS NULL OR r.relation_type = $relation_type
-                    RETURN s.display_name AS subject,
-                           r.relation_type AS relation_type,
-                           o.display_name AS object,
-                           coalesce(r.weight, 1.0) AS weight
-                    ORDER BY weight DESC
-                    LIMIT $limit
-                """
+                if direction == "outgoing":
+                    query = """
+                        MATCH (s:Entity {name: $subject, namespace: $namespace})
+                              -[r:RELATES_AS]->(o:Entity {namespace: $namespace})
+                        WHERE $relation_type IS NULL OR r.relation_type = $relation_type
+                        RETURN s.display_name AS subject,
+                               r.relation_type AS relation_type,
+                               o.display_name AS object,
+                               coalesce(r.weight, 1.0) AS weight
+                        ORDER BY weight DESC
+                        LIMIT $limit
+                    """
+                elif direction == "incoming":
+                    query = """
+                        MATCH (o:Entity {name: $subject, namespace: $namespace})
+                              <-[r:RELATES_AS]-(s:Entity {namespace: $namespace})
+                        WHERE $relation_type IS NULL OR r.relation_type = $relation_type
+                        RETURN s.display_name AS subject,
+                               r.relation_type AS relation_type,
+                               o.display_name AS object,
+                               coalesce(r.weight, 1.0) AS weight
+                        ORDER BY weight DESC
+                        LIMIT $limit
+                    """
+                else:
+                    query = """
+                        MATCH (a:Entity {namespace: $namespace})
+                              -[r:RELATES_AS]-(b:Entity {namespace: $namespace})
+                        WHERE (a.name = $subject OR b.name = $subject)
+                          AND ($relation_type IS NULL OR r.relation_type = $relation_type)
+                        WITH DISTINCT startNode(r) AS s, endNode(r) AS o, r
+                        RETURN s.display_name AS subject,
+                               r.relation_type AS relation_type,
+                               o.display_name AS object,
+                               coalesce(r.weight, 1.0) AS weight
+                        ORDER BY weight DESC
+                        LIMIT $limit
+                    """
                 result = session.run(
                     query,
                     subject=normalized.lower(),
@@ -644,7 +676,6 @@ class GraphIndex:
                     relation_type=relation_type,
                     limit=max(1, int(limit)),
                 )
-
                 relations = []
                 for row in result:
                     relations.append({
@@ -654,7 +685,6 @@ class GraphIndex:
                         "weight": float(row["weight"]),
                     })
                 return relations
-
         except Exception as e:
             logger.error(f"Relation search error: {e}", exc_info=True)
             return []

--- a/packages/ragleap-graph/tests/test_ragleap_graph.py
+++ b/packages/ragleap-graph/tests/test_ragleap_graph.py
@@ -266,6 +266,81 @@ def test_live_full_roundtrip():
         graph.close()
 
 
+@pytest.mark.skipif(not HAS_LIVE_NEO4J, reason="No live Neo4j credentials in environment")
+def test_find_relations_direction_parameter():
+    """
+    Regression test for find_relations(direction=) (v0.5.3). Known
+    limitation prior to this fix: find_relations() only ever searched
+    outgoing relations - "Globex Industries" would find nothing even
+    though it's clearly the object of a real relation.
+
+    Writes RELATES_AS edges directly via Cypher (bypassing LLM
+    extraction, which find_relations() doesn't touch anyway) so this
+    test is deterministic and only needs NEO4J_URI, not GEMINI_API_KEY.
+
+    Graph: (Acme Corp)-[:PARTNERED_WITH]->(Globex Industries)
+    """
+    config = GraphConfig(uri=NEO4J_URI, user=NEO4J_USER, password=NEO4J_PASSWORD)
+    graph = GraphIndex(config=config)
+    try:
+        with graph.driver.session() as session:
+            session.run(
+                """
+                MERGE (a:Entity {name: $subj, namespace: $ns})
+                ON CREATE SET a.display_name = $subj_display, a.entity_type = "UNKNOWN"
+                MERGE (b:Entity {name: $obj, namespace: $ns})
+                ON CREATE SET b.display_name = $obj_display, b.entity_type = "UNKNOWN"
+                MERGE (a)-[r:RELATES_AS {relation_type: $rel}]->(b)
+                SET r.weight = 1.0
+                """,
+                subj="acme corp", subj_display="Acme Corp",
+                obj="globex industries", obj_display="Globex Industries",
+                rel="PARTNERED_WITH",
+                ns=TEST_NAMESPACE,
+            )
+
+        # Existing behavior (default direction="outgoing") - unchanged, must still work
+        outgoing = graph.find_relations("Acme Corp", namespace=TEST_NAMESPACE)
+        assert len(outgoing) == 1
+        assert outgoing[0]["subject"] == "Acme Corp"
+        assert outgoing[0]["object"] == "Globex Industries"
+
+        # The actual bug: searching from the object side with default
+        # direction finds nothing, even though Globex Industries is
+        # clearly involved in a real relation.
+        outgoing_from_object = graph.find_relations("Globex Industries", namespace=TEST_NAMESPACE)
+        assert outgoing_from_object == []
+
+        # New: direction="incoming" - the fix
+        incoming = graph.find_relations(
+            "Globex Industries", namespace=TEST_NAMESPACE, direction="incoming"
+        )
+        assert len(incoming) == 1
+        assert incoming[0]["subject"] == "Acme Corp"
+        assert incoming[0]["object"] == "Globex Industries"
+
+        # New: direction="both" finds the relation from either side
+        both_from_subject = graph.find_relations(
+            "Acme Corp", namespace=TEST_NAMESPACE, direction="both"
+        )
+        assert len(both_from_subject) == 1
+        both_from_object = graph.find_relations(
+            "Globex Industries", namespace=TEST_NAMESPACE, direction="both"
+        )
+        assert len(both_from_object) == 1
+
+        # Invalid direction value should raise, not silently misbehave
+        with pytest.raises(ValueError):
+            graph.find_relations("Acme Corp", namespace=TEST_NAMESPACE, direction="sideways")
+    finally:
+        with graph.driver.session() as session:
+            session.run(
+                "MATCH (n) WHERE n.namespace = $ns DETACH DELETE n",
+                ns=TEST_NAMESPACE,
+            )
+        graph.close()
+
+
 # ---------------------------------------------------------------------------
 # Entity typing (v0.5.0)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes a known limitation open since v0.4.0.

**The bug**
`find_relations()` only ever searched outgoing relations. Searching from the object side silently returned `[]` even when the entity was clearly involved in a real relation.

**The fix**
New `direction=` parameter: `"outgoing"` (default, unchanged), `"incoming"` (new), `"both"` (new). The `"both"` case uses `startNode()`/`endNode()` rather than a Cypher `UNION`, so subject/object stay correctly labeled regardless of which direction matched.

**Verification**
- Zero prior test coverage existed for this method at all - backfilled alongside the new tests
- Regression test writes `RELATES_AS` edges directly via Cypher (deterministic, no live LLM call needed)
- Confirmed failing first (`TypeError`), confirmed passing after the fix
- Explicitly asserts old default behavior is unchanged - proves this is additive
- Full suite re-run: 77 passed, 1 skipped (unrelated), zero regressions

Published to PyPI as 0.5.3 before this PR.