### PR TITLE
fix(graph): CONTAINS edges actually idempotent on re-upsert (0.5.4)

### DIFF
--- a/packages/ragleap-graph/CHANGELOG.md
+++ b/packages/ragleap-graph/CHANGELOG.md
@@ -5,6 +5,14 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.5.4]
+### Fixed
+- `upsert_document()`'s docstring claimed writes were "idempotent - safe to re-run," which was false for two real reasons: (1) re-upserting identical content doubled `CONTAINS` edge weight every single call (`ON MATCH SET weight = weight + new` instead of replacing it); (2) re-upserting a document whose content changed to no longer mention an entity left the old `CONTAINS` edge in place forever, with no cleanup path. Fixed by deleting a document's existing `CONTAINS` edges before rewriting them on each upsert - safe because `CONTAINS` is a clean 1:1 document-to-entity link.
+### Known limitation (not fixed here, scoped out deliberately)
+- `CO_OCCURS_WITH` and `RELATES_AS` still have the same weight-doubling issue, but the fix above does not apply to them: those edges deliberately aggregate weight across *multiple different documents* that share entities - that's the actual point of co-occurrence weighting. There is currently no per-document contribution tracking, so there's no way to subtract just one document's share on re-upsert without corrupting other documents' contributions. Fixing this properly needs a real schema addition (per-document contribution tracking), not a quick patch - tracked as upcoming work, not glossed over.
+### Verified
+- Both bugs reproduced live before any code changed. Regression test added, initially failed on an unrelated Cypher parameter-escaping mistake in the test itself (not the fix) - caught and corrected before treating the test as valid. Full suite re-run: 78 passed, 1 skipped (Gemini-key skip, unrelated) - zero regressions.
+
 ## [0.5.3]
 ### Fixed
 - `find_relations()` only ever searched outgoing relations (entity_name as subject) - searching from the object side silently returned `[]` even when the entity was clearly involved in a real relation. Added `direction=` parameter: `"outgoing"` (default, unchanged), `"incoming"` (new), `"both"` (new, deduplicated via `startNode()`/`endNode()` rather than a UNION, so subject/object stay correctly labeled regardless of which direction matched). Closes a known limitation open since v0.4.0.

--- a/packages/ragleap-graph/pyproject.toml
+++ b/packages/ragleap-graph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-graph"
-version = "0.5.3"
+version = "0.5.4"
 description = "Knowledge-graph-augmented retrieval for RAG systems: Neo4j-backed entity extraction (regex or LLM-based), co-occurrence graphs, entity deduplication, and GraphRetriever for hybrid vector+graph retrieval via the optional ragleap-rag integration. Framework-agnostic, optional multi-tenant namespacing, no hardcoded models or vocabulary."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-graph/src/ragleap_graph/__init__.py
+++ b/packages/ragleap-graph/src/ragleap_graph/__init__.py
@@ -48,7 +48,7 @@ from ragleap_graph.retrieval import GraphRetriever, GraphRetrievalConfig
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.5.3"
+__version__ = "0.5.4"
 
 # Hard ceiling on traversal depth — prevents both runaway queries and,
 # since max_depth is string-interpolated into Cypher (see note above),
@@ -396,6 +396,34 @@ class GraphIndex:
                     namespace=ns,
                     title=title or "",
                 )
+                # v0.5.4: delete this document's existing CONTAINS edges
+                # before rewriting them. Two real bugs this fixes:
+                # (1) re-upserting identical content used to double the
+                # weight every time (ON MATCH SET weight = weight + new,
+                # contradicting the "idempotent, safe to re-run" claim);
+                # (2) re-upserting changed content left stale CONTAINS
+                # edges to entities no longer mentioned - they never got
+                # cleaned up. Delete-then-rewrite fixes both: CONTAINS is
+                # a clean 1:1 document->entity link, so wiping and
+                # rebuilding per document is safe.
+                #
+                # NOT applied to CO_OCCURS_WITH/RELATES_AS - those
+                # aggregate weight across MULTIPLE different documents by
+                # design (that's the point of co-occurrence weighting),
+                # and there is currently no per-document contribution
+                # tracking that would let us subtract just this
+                # document's share without affecting others. Fixing that
+                # properly needs a real schema addition, not a quick
+                # patch here - tracked as a known limitation.
+                session.run(
+                    """
+                    MATCH (d:Document {id: $document_id, namespace: $namespace})
+                          -[r:CONTAINS]->()
+                    DELETE r
+                    """,
+                    document_id=str(document_id),
+                    namespace=ns,
+                )
 
                 for entity_name, weight in top_entities:
                     entity_type = entity_type_map.get(entity_name.lower(), "UNKNOWN")
@@ -406,8 +434,7 @@ class GraphIndex:
                         ON CREATE SET e.display_name = $name
                         SET e.entity_type = coalesce(NULLIF($entity_type, "UNKNOWN"), e.entity_type, "UNKNOWN")
                         MERGE (d)-[r:CONTAINS]->(e)
-                        ON CREATE SET r.weight = $weight
-                        ON MATCH SET r.weight = coalesce(r.weight, 0) + $weight
+                        SET r.weight = $weight
                         """,
                         document_id=str(document_id),
                         namespace=ns,

--- a/packages/ragleap-graph/tests/test_ragleap_graph.py
+++ b/packages/ragleap-graph/tests/test_ragleap_graph.py
@@ -267,6 +267,67 @@ def test_live_full_roundtrip():
 
 
 @pytest.mark.skipif(not HAS_LIVE_NEO4J, reason="No live Neo4j credentials in environment")
+def test_upsert_document_contains_is_actually_idempotent():
+    """
+    Regression test for two real bugs found in upsert_document() (v0.5.4):
+    1. Weight-doubling: re-upserting identical content doubled CONTAINS
+       weight every time, contradicting the docstring's "idempotent -
+       safe to re-run" claim.
+    2. Stale entities: re-upserting a document whose content changed to
+       no longer mention an entity left the old CONTAINS edge in place
+       forever - never cleaned up.
+    Scoped to CONTAINS only - CO_OCCURS_WITH/RELATES_AS still aggregate
+    weight across multiple documents by design and are not covered by
+    this fix (see the code comment at the fix site).
+    """
+    config = GraphConfig(uri=NEO4J_URI, user=NEO4J_USER, password=NEO4J_PASSWORD)
+    graph = GraphIndex(config=config)
+    try:
+        graph.upsert_document(
+            "idempotent-doc-1", "Test", [{"text": "Acme Corp is great."}],
+            namespace=TEST_NAMESPACE,
+        )
+        graph.upsert_document(
+            "idempotent-doc-1", "Test", [{"text": "Acme Corp is great."}],
+            namespace=TEST_NAMESPACE,
+        )
+        with graph.driver.session() as session:
+            row = session.run(
+                "MATCH (:Document {id: $id, namespace: $ns})"
+                "-[c:CONTAINS]->(:Entity {name: $name}) RETURN c.weight AS w",
+                id="idempotent-doc-1", ns=TEST_NAMESPACE, name="acme corp",
+            ).single()
+            assert row["w"] == 1.0
+
+        graph.upsert_document(
+            "idempotent-doc-2", "Test2",
+            [{"text": "Globex Corp announced results."}],
+            namespace=TEST_NAMESPACE,
+        )
+        graph.upsert_document(
+            "idempotent-doc-2", "Test2",
+            [{"text": "No companies mentioned here now."}],
+            namespace=TEST_NAMESPACE,
+        )
+        with graph.driver.session() as session:
+            names = {
+                row["name"] for row in session.run(
+                    "MATCH (:Document {id: $id, namespace: $ns})"
+                    "-[:CONTAINS]->(e:Entity) RETURN e.display_name AS name",
+                    id="idempotent-doc-2", ns=TEST_NAMESPACE,
+                )
+            }
+            assert "Globex Corp" not in names
+    finally:
+        with graph.driver.session() as session:
+            session.run(
+                "MATCH (n) WHERE n.namespace = $ns DETACH DELETE n",
+                ns=TEST_NAMESPACE,
+            )
+        graph.close()
+
+
+@pytest.mark.skipif(not HAS_LIVE_NEO4J, reason="No live Neo4j credentials in environment")
 def test_find_relations_direction_parameter():
     """
     Regression test for find_relations(direction=) (v0.5.3). Known


### PR DESCRIPTION
upsert_document()'s docstring claimed writes were idempotent and safe to re-run. False for two real reasons:

1. **Weight-doubling**: re-upserting identical content doubled `CONTAINS` weight every call.
2. **Stale entities**: re-upserting changed content left old `CONTAINS` edges to no-longer-mentioned entities in place forever.

**Fix**: delete a document's existing `CONTAINS` edges before rewriting them per upsert. Safe — `CONTAINS` is a clean 1:1 document-to-entity link.

**Deliberately scoped out**: `CO_OCCURS_WITH`/`RELATES_AS` have the same weight-doubling bug but aren't touched here — those edges aggregate weight across *multiple different documents* by design, and fixing them properly needs per-document contribution tracking (a real schema addition), not a quick patch. Tracked as upcoming 0.6.0 work.

**Verification**: both bugs reproduced live first. Full suite re-run: 78 passed, 1 skipped (unrelated), zero regressions.

Published to PyPI as 0.5.4 before this PR.