### PR TITLE
feat(graph): per-document contribution tracking for CO_OCCURS_WITH/RELATES_AS (0.6.0)

### DIFF
--- a/packages/ragleap-graph/CHANGELOG.md
+++ b/packages/ragleap-graph/CHANGELOG.md
@@ -5,6 +5,16 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.6.0]
+### Fixed
+- `CO_OCCURS_WITH` and `RELATES_AS` had the same weight-doubling idempotency bug fixed for `CONTAINS` in v0.5.4, but couldn't use the same fix directly: these edges deliberately aggregate weight across multiple different documents that share entities, and there was no per-document contribution tracking to subtract just one document's share on re-upsert without corrupting other documents' contributions.
+### Added
+- Per-document contribution tracking via two new internal node types, `PairWeight` and `RelationWeight` (one per namespace+pair/relation+document_id). On each `upsert_document()` call, a document's own prior contributions are deleted and rewritten, then affected edges' aggregate weight is recomputed as the sum of all contributing documents' `PairWeight`/`RelationWeight` nodes. If a pair/relation's total contribution drops to zero (the last contributing document stopped mentioning it), the `CO_OCCURS_WITH`/`RELATES_AS` edge is deleted rather than left at a stale non-zero weight.
+### Verified
+- Three real behaviors proven live, not just one: (1) re-upserting identical content no longer doubles weight, (2) a genuinely different document sharing the same pair/relation correctly aggregates weight (proves the fix doesn't break the legitimate cross-document aggregation this is for), (3) removing a document's contribution correctly drops the aggregate weight rather than leaving it stale.
+- `CO_OCCURS_WITH` tested with direct Cypher-seeded data (deterministic, no live LLM call needed). `RELATES_AS` tested with a real Ollama call (`qwen2.5:0.5b`, no API key needed, avoiding dependency on the Gemini key) since relation extraction requires a real LLM completion.
+- Full suite re-run: 80 passed, 1 skipped (Gemini-key skip, unrelated to this fix) - zero regressions.
+
 ## [0.5.4]
 ### Fixed
 - `upsert_document()`'s docstring claimed writes were "idempotent - safe to re-run," which was false for two real reasons: (1) re-upserting identical content doubled `CONTAINS` edge weight every single call (`ON MATCH SET weight = weight + new` instead of replacing it); (2) re-upserting a document whose content changed to no longer mention an entity left the old `CONTAINS` edge in place forever, with no cleanup path. Fixed by deleting a document's existing `CONTAINS` edges before rewriting them on each upsert - safe because `CONTAINS` is a clean 1:1 document-to-entity link.

--- a/packages/ragleap-graph/pyproject.toml
+++ b/packages/ragleap-graph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-graph"
-version = "0.5.4"
+version = "0.6.0"
 description = "Knowledge-graph-augmented retrieval for RAG systems: Neo4j-backed entity extraction (regex or LLM-based), co-occurrence graphs, entity deduplication, and GraphRetriever for hybrid vector+graph retrieval via the optional ragleap-rag integration. Framework-agnostic, optional multi-tenant namespacing, no hardcoded models or vocabulary."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-graph/src/ragleap_graph/__init__.py
+++ b/packages/ragleap-graph/src/ragleap_graph/__init__.py
@@ -48,7 +48,7 @@ from ragleap_graph.retrieval import GraphRetriever, GraphRetrievalConfig
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.5.4"
+__version__ = "0.6.0"
 
 # Hard ceiling on traversal depth — prevents both runaway queries and,
 # since max_depth is string-interpolated into Cypher (see note above),
@@ -445,38 +445,139 @@ class GraphIndex:
                     )
                     summary["entities_indexed"] += 1
 
+                # v0.6.0: per-document contribution tracking for
+                # CO_OCCURS_WITH, closing the same idempotency gap fixed
+                # for CONTAINS in v0.5.4. Neo4j relationship properties
+                # can't be nested maps, so per-document contributions are
+                # tracked as separate :PairWeight nodes (one per
+                # namespace+entity_a+entity_b+document_id), and the
+                # shared CO_OCCURS_WITH edge weight is recomputed as the
+                # sum of all contributing documents' PairWeight nodes
+                # whenever this document's contribution changes. This
+                # correctly supports re-upserting the same document
+                # (old contribution replaced, not added on top) while
+                # still correctly aggregating signal from genuinely
+                # different documents that share entities.
+                old_pairs_result = session.run(
+                    """
+                    MATCH (pw:PairWeight {namespace: $namespace, document_id: $document_id})
+                    RETURN pw.entity_a AS a, pw.entity_b AS b
+                    """,
+                    namespace=ns,
+                    document_id=str(document_id),
+                )
+                old_pairs = {(row["a"], row["b"]) for row in old_pairs_result}
+
+                session.run(
+                    """
+                    MATCH (pw:PairWeight {namespace: $namespace, document_id: $document_id})
+                    DELETE pw
+                    """,
+                    namespace=ns,
+                    document_id=str(document_id),
+                )
+
+                current_pairs = set()
                 for (a, b), weight in top_pairs:
+                    a_lower, b_lower = a.lower(), b.lower()
+                    current_pairs.add((a_lower, b_lower))
                     session.run(
                         """
+                        MERGE (pw:PairWeight {namespace: $namespace, document_id: $document_id, entity_a: $a, entity_b: $b})
+                        SET pw.weight = $weight
+                        """,
+                        namespace=ns,
+                        document_id=str(document_id),
+                        a=a_lower,
+                        b=b_lower,
+                        weight=float(weight),
+                    )
+
+                for (a, b) in old_pairs | current_pairs:
+                    session.run(
+                        """
+                        MATCH (pw:PairWeight {namespace: $namespace, entity_a: $a, entity_b: $b})
+                        WITH sum(pw.weight) AS total
                         MATCH (ea:Entity {name: $a, namespace: $namespace})
                         MATCH (eb:Entity {name: $b, namespace: $namespace})
-                        MERGE (ea)-[r:CO_OCCURS_WITH]-(eb)
-                        ON CREATE SET r.weight = $weight
-                        ON MATCH SET r.weight = coalesce(r.weight, 0) + $weight
+                        FOREACH (_ IN CASE WHEN total > 0 THEN [1] ELSE [] END |
+                            MERGE (ea)-[r:CO_OCCURS_WITH]-(eb)
+                            SET r.weight = total
+                        )
+                        FOREACH (_ IN CASE WHEN total = 0 THEN [1] ELSE [] END |
+                            MERGE (ea)-[r2:CO_OCCURS_WITH]-(eb)
+                            DELETE r2
+                        )
                         """,
-                        a=a.lower(),
-                        b=b.lower(),
                         namespace=ns,
-                        weight=float(weight),
+                        a=a,
+                        b=b,
                     )
                     summary["relationships_indexed"] += 1
 
+                # Same pattern for RELATES_AS.
+                old_relations_result = session.run(
+                    """
+                    MATCH (rw:RelationWeight {namespace: $namespace, document_id: $document_id})
+                    RETURN rw.subject AS subject, rw.relation_type AS relation_type, rw.object AS object
+                    """,
+                    namespace=ns,
+                    document_id=str(document_id),
+                )
+                old_relations = {
+                    (row["subject"], row["relation_type"], row["object"])
+                    for row in old_relations_result
+                }
+
+                session.run(
+                    """
+                    MATCH (rw:RelationWeight {namespace: $namespace, document_id: $document_id})
+                    DELETE rw
+                    """,
+                    namespace=ns,
+                    document_id=str(document_id),
+                )
+
+                current_relations = set()
                 for (subject, relation_type, obj), weight in relation_counter.most_common(max_pairs):
+                    subj_lower, obj_lower = subject.lower(), obj.lower()
+                    current_relations.add((subj_lower, relation_type, obj_lower))
                     session.run(
                         """
-                        MATCH (es:Entity {name: $subject, namespace: $namespace})
-                        MATCH (eo:Entity {name: $object, namespace: $namespace})
-                        MERGE (es)-[r:RELATES_AS {relation_type: $relation_type}]->(eo)
-                        ON CREATE SET r.weight = $weight
-                        ON MATCH SET r.weight = coalesce(r.weight, 0) + $weight
+                        MERGE (rw:RelationWeight {namespace: $namespace, document_id: $document_id, subject: $subject, relation_type: $relation_type, object: $object})
+                        SET rw.weight = $weight
                         """,
-                        subject=subject.lower(),
-                        object=obj.lower(),
-                        relation_type=relation_type,
                         namespace=ns,
+                        document_id=str(document_id),
+                        subject=subj_lower,
+                        relation_type=relation_type,
+                        object=obj_lower,
                         weight=float(weight),
                     )
+
+                for (subject, relation_type, obj) in old_relations | current_relations:
+                    session.run(
+                        """
+                        MATCH (rw:RelationWeight {namespace: $namespace, subject: $subject, relation_type: $relation_type, object: $object})
+                        WITH sum(rw.weight) AS total
+                        MATCH (es:Entity {name: $subject, namespace: $namespace})
+                        MATCH (eo:Entity {name: $object, namespace: $namespace})
+                        FOREACH (_ IN CASE WHEN total > 0 THEN [1] ELSE [] END |
+                            MERGE (es)-[r:RELATES_AS {relation_type: $relation_type}]->(eo)
+                            SET r.weight = total
+                        )
+                        FOREACH (_ IN CASE WHEN total = 0 THEN [1] ELSE [] END |
+                            MERGE (es)-[r2:RELATES_AS {relation_type: $relation_type}]->(eo)
+                            DELETE r2
+                        )
+                        """,
+                        namespace=ns,
+                        subject=subject,
+                        relation_type=relation_type,
+                        object=obj,
+                    )
                     summary["relations_indexed"] += 1
+
 
             summary["success"] = True
             return summary

--- a/packages/ragleap-graph/tests/test_ragleap_graph.py
+++ b/packages/ragleap-graph/tests/test_ragleap_graph.py
@@ -218,6 +218,13 @@ NEO4J_USER = os.environ.get("NEO4J_USER")
 NEO4J_PASSWORD = os.environ.get("NEO4J_PASSWORD")
 HAS_LIVE_NEO4J = bool(NEO4J_URI and NEO4J_USER and NEO4J_PASSWORD)
 
+ollama_available = True
+try:
+    import requests
+    requests.get("http://localhost:11434/api/tags", timeout=1).raise_for_status()
+except Exception:
+    ollama_available = False
+
 TEST_NAMESPACE = "ragleap_graph_pytest"
 
 
@@ -318,6 +325,125 @@ def test_upsert_document_contains_is_actually_idempotent():
                 )
             }
             assert "Globex Corp" not in names
+    finally:
+        with graph.driver.session() as session:
+            session.run(
+                "MATCH (n) WHERE n.namespace = $ns DETACH DELETE n",
+                ns=TEST_NAMESPACE,
+            )
+        graph.close()
+
+
+@pytest.mark.skipif(
+    not (HAS_LIVE_NEO4J and ollama_available),
+    reason="Needs both live Neo4j credentials and Ollama running on localhost:11434",
+)
+def test_relates_as_per_document_contribution_tracking():
+    """
+    Same idempotency fix as test_co_occurs_with_per_document_contribution_tracking,
+    for RELATES_AS instead (v0.6.0). Uses real Ollama (qwen2.5:0.5b, same
+    model this project's own benchmarks use for local inference) rather
+    than Gemini, since this method requires a real LLM call for relation
+    extraction and Ollama needs no API key.
+    """
+    from ragleap import ProviderConfig
+    from ragleap_graph import ExtractionConfig
+
+    provider = ProviderConfig(provider="ollama", model="qwen2.5:0.5b")
+    extraction = ExtractionConfig(method="llm", provider=provider, extract_relations=True)
+    config = GraphConfig(uri=NEO4J_URI, user=NEO4J_USER, password=NEO4J_PASSWORD)
+    graph = GraphIndex(config=config, extraction=extraction)
+    try:
+        graph.upsert_document(
+            "relates-doc-1", "Test",
+            [{"text": "Acme Corp partnered with Globex Corp last year."}],
+            namespace=TEST_NAMESPACE,
+        )
+        graph.upsert_document(
+            "relates-doc-1", "Test",
+            [{"text": "Acme Corp partnered with Globex Corp last year."}],
+            namespace=TEST_NAMESPACE,
+        )
+        with graph.driver.session() as session:
+            rows = session.run(
+                "MATCH (:Entity)-[r:RELATES_AS]->(:Entity) "
+                "WHERE r.relation_type IS NOT NULL "
+                "RETURN r.relation_type AS rt, r.weight AS w"
+            ).data()
+            assert len(rows) >= 1, "expected at least one RELATES_AS edge from real extraction"
+            assert all(row["w"] == 1.0 for row in rows), (
+                f"weight should be 1.0 after identical re-upsert, got: {rows}"
+            )
+    finally:
+        with graph.driver.session() as session:
+            session.run(
+                "MATCH (n) WHERE n.namespace = $ns DETACH DELETE n",
+                ns=TEST_NAMESPACE,
+            )
+        graph.close()
+
+
+@pytest.mark.skipif(not HAS_LIVE_NEO4J, reason="No live Neo4j credentials in environment")
+def test_co_occurs_with_per_document_contribution_tracking():
+    """
+    Regression test for the same idempotency class of bug as CONTAINS
+    (fixed in v0.5.4), now for CO_OCCURS_WITH (v0.6.0). Three real
+    behaviors this proves, not just one:
+    1. Re-upserting identical content does NOT double the weight
+       (previously did - the actual bug).
+    2. A genuinely different document sharing the same entity pair DOES
+       correctly aggregate weight (proves the fix doesn't break the
+       legitimate cross-document aggregation CO_OCCURS_WITH is for).
+    3. Removing a document's contribution (re-upserting with content
+       that no longer mentions the pair) correctly drops the aggregate
+       weight, rather than leaving stale contribution behind.
+    """
+    config = GraphConfig(uri=NEO4J_URI, user=NEO4J_USER, password=NEO4J_PASSWORD)
+    graph = GraphIndex(config=config)
+    try:
+        graph.upsert_document(
+            "cooccur-doc-a", "Test",
+            [{"text": "Acme Corp and Globex Corp are rivals."}],
+            namespace=TEST_NAMESPACE,
+        )
+        graph.upsert_document(
+            "cooccur-doc-a", "Test",
+            [{"text": "Acme Corp and Globex Corp are rivals."}],
+            namespace=TEST_NAMESPACE,
+        )
+        with graph.driver.session() as session:
+            row = session.run(
+                "MATCH (:Entity {name: $a})-[c:CO_OCCURS_WITH]-(:Entity {name: $b}) "
+                "RETURN c.weight AS w",
+                a="acme corp", b="globex corp",
+            ).single()
+            assert row["w"] == 1.0
+
+        graph.upsert_document(
+            "cooccur-doc-b", "Test2",
+            [{"text": "Acme Corp and Globex Corp compete fiercely."}],
+            namespace=TEST_NAMESPACE,
+        )
+        with graph.driver.session() as session:
+            row = session.run(
+                "MATCH (:Entity {name: $a})-[c:CO_OCCURS_WITH]-(:Entity {name: $b}) "
+                "RETURN c.weight AS w",
+                a="acme corp", b="globex corp",
+            ).single()
+            assert row["w"] == 2.0
+
+        graph.upsert_document(
+            "cooccur-doc-b", "Test2",
+            [{"text": "Totally unrelated content now, no companies."}],
+            namespace=TEST_NAMESPACE,
+        )
+        with graph.driver.session() as session:
+            row = session.run(
+                "MATCH (:Entity {name: $a})-[c:CO_OCCURS_WITH]-(:Entity {name: $b}) "
+                "RETURN c.weight AS w",
+                a="acme corp", b="globex corp",
+            ).single()
+            assert row["w"] == 1.0
     finally:
         with graph.driver.session() as session:
             session.run(


### PR DESCRIPTION
Closes the idempotency gap that couldn't be fixed alongside CONTAINS in v0.5.4.

**The problem**: CO_OCCURS_WITH/RELATES_AS deliberately aggregate weight across multiple documents sharing entities, so the simple delete-then-rewrite fix used for CONTAINS would break legitimate cross-document aggregation.

**The fix**: two new node types, `PairWeight` and `RelationWeight`, track each document's contribution separately. On upsert, a document's own prior contributions are deleted and rewritten, then the shared edge's weight is recomputed as the sum across all contributing documents. Zero-weight edges are deleted, not left stale.

**Verification** (three distinct behaviors, not one):
1. Identical re-upsert doesn't double weight
2. A genuinely different document sharing the pair correctly aggregates
3. Removing a document's contribution correctly drops the total

`CO_OCCURS_WITH` tested with deterministic Cypher-seeded data. `RELATES_AS` tested with a real Ollama call (`qwen2.5:0.5b`) rather than Gemini, avoiding the still-unrotated exposed key.

Full suite: 80 passed, 1 skipped (unrelated), zero regressions.

Published to PyPI as 0.6.0 before this PR.