### PR TITLE
feat(graph): flag vector/graph result overlap in GraphRetriever (0.6.1)

### DIFF
--- a/packages/ragleap-graph/CHANGELOG.md
+++ b/packages/ragleap-graph/CHANGELOG.md
@@ -5,6 +5,12 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.6.1]
+### Added
+- `GraphRetriever.retrieve()`'s `graph_context.related_documents` entries now include an `already_in_vector_results` boolean flag. Closes a known limitation: a document could genuinely surface through both vector search (as a chunk) and graph traversal (as a related document), with no way for the caller to know about the overlap. Deliberately flags rather than removes overlapping entries - removing them would silently discard real graph-relationship context (matched entities, graph score) that's still useful even for a document also present in the chunk list.
+### Verified
+- Regression test added first using the existing `FakeRag`/`FakeGraph` test doubles (no live services needed - `GraphRetriever` has no I/O of its own), confirmed failing (`KeyError: 'already_in_vector_results'`), then confirmed passing after the fix. Full suite re-run: 81 passed, 1 skipped (unrelated), zero regressions.
+
 ## [0.6.0]
 ### Fixed
 - `CO_OCCURS_WITH` and `RELATES_AS` had the same weight-doubling idempotency bug fixed for `CONTAINS` in v0.5.4, but couldn't use the same fix directly: these edges deliberately aggregate weight across multiple different documents that share entities, and there was no per-document contribution tracking to subtract just one document's share on re-upsert without corrupting other documents' contributions.

--- a/packages/ragleap-graph/pyproject.toml
+++ b/packages/ragleap-graph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-graph"
-version = "0.6.0"
+version = "0.6.1"
 description = "Knowledge-graph-augmented retrieval for RAG systems: Neo4j-backed entity extraction (regex or LLM-based), co-occurrence graphs, entity deduplication, and GraphRetriever for hybrid vector+graph retrieval via the optional ragleap-rag integration. Framework-agnostic, optional multi-tenant namespacing, no hardcoded models or vocabulary."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-graph/src/ragleap_graph/__init__.py
+++ b/packages/ragleap-graph/src/ragleap_graph/__init__.py
@@ -48,7 +48,7 @@ from ragleap_graph.retrieval import GraphRetriever, GraphRetrievalConfig
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 # Hard ceiling on traversal depth — prevents both runaway queries and,
 # since max_depth is string-interpolated into Cypher (see note above),

--- a/packages/ragleap-graph/src/ragleap_graph/retrieval.py
+++ b/packages/ragleap-graph/src/ragleap_graph/retrieval.py
@@ -129,6 +129,18 @@ class GraphRetriever:
             chunks = self._rag.retrieve(query, top_k=top_k, metadata_filter=metadata_filter)
             retrieval_method = "hybrid_vector_graph"
 
+        # Flag, don't remove: a document can genuinely surface through
+        # both vector search (as a chunk) and graph traversal (as a
+        # related document) - that overlap is real signal, not noise.
+        # Removing the graph-side entry would silently discard its
+        # matched-entity/graph-score context. Flagging lets the caller
+        # decide whether to filter, de-emphasize, or just note it.
+        chunk_document_ids = {
+            c.get("document_id") for c in chunks if c.get("document_id") is not None
+        }
+        for doc in graph_context["related_documents"]:
+            doc["already_in_vector_results"] = doc.get("document_id") in chunk_document_ids
+
         citations = self._build_citations(chunks, graph_context)
 
         return {

--- a/packages/ragleap-graph/tests/test_retrieval.py
+++ b/packages/ragleap-graph/tests/test_retrieval.py
@@ -203,6 +203,37 @@ def test_namespace_passed_through_to_graph_methods():
     assert graph.search_related_calls[0]["namespace"] == "acme-tenant"
 
 
+def test_related_documents_flagged_when_overlapping_vector_chunks():
+    """
+    Regression test for a known limitation: GraphRetriever returned
+    chunks (vector results) and related_documents (graph results) as
+    fully separate lists, with no way for the caller to know a document
+    surfaced through BOTH paths - real, meaningful overlap information
+    that was silently discarded rather than exposed. Fixed by adding
+    an already_in_vector_results flag to each related_documents entry,
+    rather than removing overlapping entries outright - the caller
+    still gets full graph-relationship context (matched entities, graph
+    score) even for documents also present in the chunk list, just now
+    knows about the overlap.
+    """
+    rag = FakeRag(chunks=[
+        {"chunk_id": "c1", "text": "Acme Corp news.", "document_id": "d1",
+         "document_name": "a.pdf", "chunk_index": 0},
+    ])
+    graph = FakeGraph(related_documents=[
+        {"document_id": "d1", "document_name": "a.pdf", "matched_entities": 1,
+         "graph_score": 1.0, "matched_entity_names": ["Acme Corp"]},
+        {"document_id": "d9", "document_name": "b.pdf", "matched_entities": 1,
+         "graph_score": 1.0, "matched_entity_names": ["Globex Corp"]},
+    ])
+    retriever = GraphRetriever(graph=graph, rag=rag, config=GraphRetrievalConfig())
+    result = retriever.retrieve("test query")
+    related = result["graph_context"]["related_documents"]
+    by_id = {d["document_id"]: d for d in related}
+    assert by_id["d1"]["already_in_vector_results"] is True
+    assert by_id["d9"]["already_in_vector_results"] is False
+
+
 def test_domain_terms_passed_through_to_extract_query_entities():
     rag = FakeRag()
     graph = FakeGraph()


### PR DESCRIPTION
Closes a known limitation: `GraphRetriever.retrieve()` returned `chunks` and `graph_context.related_documents` as fully separate lists, with no way for the caller to know a document surfaced through both retrieval paths.

**The fix**: added `already_in_vector_results` to each `related_documents` entry, rather than removing overlapping entries outright. Removing them would silently discard real graph-relationship context (matched entities, graph score) still useful even for a document also present in the chunk list. Caller decides what to do with the flag.

**Verification**: test-first using the existing `FakeRag`/`FakeGraph` doubles, confirmed failing (`KeyError`) before the fix, passing after. Full suite: 81 passed, 1 skipped (unrelated), zero regressions.

Published to PyPI as 0.6.1 before this PR.