### PR TITLE
fix(graph): find_entities_by_type() case-insensitive matching (0.6.2)

### DIFF
--- a/packages/ragleap-graph/CHANGELOG.md
+++ b/packages/ragleap-graph/CHANGELOG.md
@@ -5,6 +5,12 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.6.2]
+### Fixed
+- `find_entities_by_type()` did exact-string-match only, so `"Customer"` and `"customer"` were treated as different types even though `entity_type` is stored exactly as the model produced it, with no casing normalization at write time - a caller had no reliable way to predict the exact stored casing without already knowing it. Now case-insensitive (`toLower()` comparison on both sides in the Cypher query).
+### Verified
+- Reproduced live before any code changed. Regression test added, confirmed failing (`assert 0 == 1`), then confirmed passing after the fix, covering exact/lowercase/uppercase input against a single stored `"Customer"` type. Full suite re-run: 82 passed, 1 skipped (unrelated) - zero regressions.
+
 ## [0.6.1]
 ### Added
 - `GraphRetriever.retrieve()`'s `graph_context.related_documents` entries now include an `already_in_vector_results` boolean flag. Closes a known limitation: a document could genuinely surface through both vector search (as a chunk) and graph traversal (as a related document), with no way for the caller to know about the overlap. Deliberately flags rather than removes overlapping entries - removing them would silently discard real graph-relationship context (matched entities, graph score) that's still useful even for a document also present in the chunk list.

--- a/packages/ragleap-graph/pyproject.toml
+++ b/packages/ragleap-graph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-graph"
-version = "0.6.1"
+version = "0.6.2"
 description = "Knowledge-graph-augmented retrieval for RAG systems: Neo4j-backed entity extraction (regex or LLM-based), co-occurrence graphs, entity deduplication, and GraphRetriever for hybrid vector+graph retrieval via the optional ragleap-rag integration. Framework-agnostic, optional multi-tenant namespacing, no hardcoded models or vocabulary."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-graph/src/ragleap_graph/__init__.py
+++ b/packages/ragleap-graph/src/ragleap_graph/__init__.py
@@ -48,7 +48,7 @@ from ragleap_graph.retrieval import GraphRetriever, GraphRetrievalConfig
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 # Hard ceiling on traversal depth — prevents both runaway queries and,
 # since max_depth is string-interpolated into Cypher (see note above),
@@ -870,6 +870,13 @@ class GraphIndex:
         entities from that path are always stored with entity_type
         "UNKNOWN" and will only show up here if entity_type="UNKNOWN" is
         searched for explicitly.
+
+        Matching is case-insensitive (v0.6.2+) - searching "customer"
+        finds entities stored with entity_type "Customer" or "CUSTOMER".
+        entity_type is stored exactly as the model produced it, with no
+        casing normalization at write time, so exact-match-only search
+        was previously unreliable for a caller who didn't already know
+        the precise stored casing.
         """
         if not self.driver:
             logger.warning("Neo4j driver not available")
@@ -885,7 +892,7 @@ class GraphIndex:
                 result = session.run(
                     """
                     MATCH (e:Entity {namespace: $namespace})
-                    WHERE e.entity_type = $entity_type
+                    WHERE toLower(e.entity_type) = toLower($entity_type)
                     RETURN e.name AS entity_id,
                            e.display_name AS entity_name,
                            e.entity_type AS entity_type

--- a/packages/ragleap-graph/tests/test_ragleap_graph.py
+++ b/packages/ragleap-graph/tests/test_ragleap_graph.py
@@ -454,6 +454,43 @@ def test_co_occurs_with_per_document_contribution_tracking():
 
 
 @pytest.mark.skipif(not HAS_LIVE_NEO4J, reason="No live Neo4j credentials in environment")
+def test_find_entities_by_type_is_case_insensitive():
+    """
+    Regression test for a known limitation: find_entities_by_type()
+    did exact-string-match only, so "Customer" and "customer" were
+    treated as different types even though entity_type is stored
+    exactly as the LLM (or "UNKNOWN") produced it, with no normalization
+    applied at write time - a caller has no reliable way to predict the
+    exact casing without already knowing it.
+    """
+    config = GraphConfig(uri=NEO4J_URI, user=NEO4J_USER, password=NEO4J_PASSWORD)
+    graph = GraphIndex(config=config)
+    try:
+        with graph.driver.session() as session:
+            session.run(
+                "MERGE (e:Entity {name: $name, namespace: $ns}) "
+                "SET e.display_name = $display, e.entity_type = $et",
+                name="acme corp", ns=TEST_NAMESPACE, display="Acme Corp", et="Customer",
+            )
+
+        exact = graph.find_entities_by_type("Customer", namespace=TEST_NAMESPACE)
+        assert len(exact) == 1
+
+        lower = graph.find_entities_by_type("customer", namespace=TEST_NAMESPACE)
+        assert len(lower) == 1
+
+        upper = graph.find_entities_by_type("CUSTOMER", namespace=TEST_NAMESPACE)
+        assert len(upper) == 1
+    finally:
+        with graph.driver.session() as session:
+            session.run(
+                "MATCH (n) WHERE n.namespace = $ns DETACH DELETE n",
+                ns=TEST_NAMESPACE,
+            )
+        graph.close()
+
+
+@pytest.mark.skipif(not HAS_LIVE_NEO4J, reason="No live Neo4j credentials in environment")
 def test_find_relations_direction_parameter():
     """
     Regression test for find_relations(direction=) (v0.5.3). Known


### PR DESCRIPTION
Closes a known limitation: `find_entities_by_type()` did exact-string-match only, so `"Customer"` and `"customer"` were treated as different types even though `entity_type` is stored exactly as the model produced it, with no casing normalization at write time.

**The fix**: `toLower()` comparison on both sides in the Cypher query.

**Verification**: reproduced live before any code changed (searching `"customer"` against a stored `"Customer"` type returned 0 results). Regression test confirmed failing (`assert 0 == 1`) before the fix, passing after.

Full suite: 82 passed, 1 skipped (unrelated), zero regressions.

Published to PyPI as 0.6.2 before this PR.