### PR TITLE
docs: reflect AI Employees runtime in README + ROADMAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ RagLeap Core is the foundation layer of the full RagLeap platform. Here's how it
 |                  RagLeap (Hosted Platform)                   |
 |                                                                |
 |  [locked] Manager AI — private executive assistant           |
-|  [locked] AI Employees — role-based persistent memory        |
+|  [locked] Multi-tenant AI Employees + Manager AI integration |
 |  [locked] n8n Workflow Automation                            |
 |  [locked] Persistent Memory (cross-channel, cross-session)   |
 |  [locked] Multi-tenant Billing, Teams & Permissions           |
@@ -190,7 +190,7 @@ RagLeap Core covers document upload, retrieval, and web chat. The hosted platfor
 | Area | What it adds |
 |---|---|
 | **Manager AI** | A private executive assistant for the owner — sees documents, analytics, team permissions, and database connections; can send emails, generate reports, and manage settings by conversation, reachable via Web, WhatsApp, Telegram, or phone call |
-| **AI Employees** | Specialized AI roles seeded per workspace, each with its own permanent memory, so support and sales conversations draw on different context automatically |
+| **AI Employees** | Single-tenant runtime (9 roles, pgvector-backed learned memory) is open in this repo's `core/employees/`; the hosted platform adds multi-tenant per-workspace seeding and Manager AI integration on top |
 | **Voice AI** | Real inbound phone calls via Twilio — speech-to-text, RAG-grounded response, text-to-speech, with owner vs. customer call routing |
 | **Multi-channel bots (multi-tenant)** | WhatsApp (Twilio or Gupshup), Telegram, and Discord — single-tenant versions are in this repo; the hosted version adds multi-tenancy, per-workspace routing, and shared config across channels |
 | **Persistent Memory** | Facts and preferences that persist across sessions and channels, not just within a single conversation |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,6 +45,7 @@ RagLeap's production RAG engine originally lived inside a larger private Django 
 - [x] Provider fallback chain
 - [x] Real token usage reporting + context-size budget trimming
 - [x] Web chat widget
+- [x] AI Employees runtime — single-tenant, BYOK role-based agents: 9 default roles, business profile (owner-filled + auto-learned), pgvector-backed learned memory (`core/employees/`). Not yet wired into `core/chat.py` — see tracked issue.
 
 ## Phase 5 — Community (in progress)
 
@@ -72,7 +73,7 @@ RagLeap's production RAG engine originally lived inside a larger private Django 
 These remain part of the commercial hosted product at [ragleap.com](https://ragleap.com), consistent with the open-core model. Note: this repo *does* include single-tenant WhatsApp/Telegram/Discord/Voice channel adapters (see Phase 4 above) — the items below are what the hosted platform adds on top of them, not duplicates of what's already open:
 
 - Multi-tenant channel routing (this repo's channel adapters are single-tenant, one bot/config per deployment)
-- AI Employees (role-based persistent memory system, seeded per workspace)
+- Multi-tenant AI Employees orchestration — per-workspace seeding at scale (single-tenant AI Employees runtime is open in this repo, see Phase 4)
 - Manager AI (executive-assistant layer with cross-channel reach)
 - Persistent memory that spans sessions and channels (this repo's memory is per-conversation)
 - n8n workflow automation triggered from conversations


### PR DESCRIPTION
Follow-up to #130 — corrects two places that still described the AI Employees runtime as fully hosted-only, now that the single-tenant version is open in core/employees/. No code changes, docs only.