### PR TITLE
fix(graph): enforce entity_types= instead of guidance-only (0.6.3)

### DIFF
--- a/packages/ragleap-graph/CHANGELOG.md
+++ b/packages/ragleap-graph/CHANGELOG.md
@@ -5,6 +5,12 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.6.3]
+### Fixed
+- `entity_types=` was guidance only, not enforced: if the model returned a type outside the caller-supplied list (even with prompt guidance nudging it toward that list), the out-of-vocabulary type was accepted as-is. Now enforced: any type not in `entity_types=` is coerced to `"UNKNOWN"`, the same value regex-extracted entities already use when there's no reliable type available - consistent behavior, not a new special case. Enforcement only applies when `entity_types=` is actually set; without it, any type the model returns is still accepted as-is (unchanged default).
+### Verified
+- Regression test added first, confirmed failing (`assert 'Employee' == 'UNKNOWN'`), then confirmed passing after the fix. A second regression-guard test confirms the unchanged default behavior (no `entity_types=` set) still accepts any type. Full suite re-run: 84 passed, 1 skipped (unrelated) - zero regressions.
+
 ## [0.6.2]
 ### Fixed
 - `find_entities_by_type()` did exact-string-match only, so `"Customer"` and `"customer"` were treated as different types even though `entity_type` is stored exactly as the model produced it, with no casing normalization at write time - a caller had no reliable way to predict the exact stored casing without already knowing it. Now case-insensitive (`toLower()` comparison on both sides in the Cypher query).

--- a/packages/ragleap-graph/pyproject.toml
+++ b/packages/ragleap-graph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-graph"
-version = "0.6.2"
+version = "0.6.3"
 description = "Knowledge-graph-augmented retrieval for RAG systems: Neo4j-backed entity extraction (regex or LLM-based), co-occurrence graphs, entity deduplication, and GraphRetriever for hybrid vector+graph retrieval via the optional ragleap-rag integration. Framework-agnostic, optional multi-tenant namespacing, no hardcoded models or vocabulary."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-graph/src/ragleap_graph/__init__.py
+++ b/packages/ragleap-graph/src/ragleap_graph/__init__.py
@@ -48,7 +48,7 @@ from ragleap_graph.retrieval import GraphRetriever, GraphRetrievalConfig
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 
 # Hard ceiling on traversal depth — prevents both runaway queries and,
 # since max_depth is string-interpolated into Cypher (see note above),

--- a/packages/ragleap-graph/src/ragleap_graph/extraction.py
+++ b/packages/ragleap-graph/src/ragleap_graph/extraction.py
@@ -259,7 +259,21 @@ class LLMEntityExtractor:
             if not name or name.lower() in seen:
                 continue
             seen.add(name.lower())
-            entities.append(ExtractedEntity(name=name, type=str(item.get("type", "UNKNOWN"))))
+            raw_type = str(item.get("type", "UNKNOWN"))
+            # v0.6.3: entity_types= is now enforced, not just guidance.
+            # A model can and will occasionally return a type outside
+            # the caller-supplied list even with prompt guidance -
+            # coerce those to "UNKNOWN" rather than accepting an
+            # arbitrary out-of-vocabulary value, consistent with how
+            # regex-extracted entities already use "UNKNOWN" when there
+            # is no reliable type available. Only applies when
+            # entity_types= is actually set - without it, any type the
+            # model returns is accepted as-is (unchanged default).
+            if self._config.entity_types and raw_type not in self._config.entity_types:
+                entity_type = "UNKNOWN"
+            else:
+                entity_type = raw_type
+            entities.append(ExtractedEntity(name=name, type=entity_type))
         return entities
 
 

--- a/packages/ragleap-graph/tests/test_extraction.py
+++ b/packages/ragleap-graph/tests/test_extraction.py
@@ -539,3 +539,150 @@ def test_llm_extractor_still_returns_type_field_from_response():
     entities = LLMEntityExtractor(config).extract("Acme Corp is a customer.")
     assert len(entities) == 1
     assert entities[0].type == "Customer"
+
+
+def test_llm_extractor_coerces_out_of_vocabulary_type_to_unknown():
+    """
+    Regression test for a known limitation: entity_types= was guidance
+    only, not enforced - if the model returned a type outside the
+    caller-supplied list, that out-of-vocabulary type was accepted
+    as-is rather than being flagged. Now enforced: any type not in the
+    entity_types= list is coerced to "UNKNOWN", the same value
+    regex-extracted entities already use when there's no semantic type
+    available - consistent, not a new special case.
+    """
+    from ragleap_graph.extraction import ExtractionConfig, LLMEntityExtractor
+    FakeGenerationService.next_response = {
+        "answer": json.dumps({"entities": [{"name": "Jane Doe", "type": "Employee"}]}),
+        "provider_used": "gemini",
+        "structured": {"entities": [{"name": "Jane Doe", "type": "Employee"}]},
+        "structured_valid": True,
+        "structured_enforcement": "native",
+    }
+    config = ExtractionConfig(
+        method="llm",
+        provider=FakeProviderConfig(provider="gemini"),
+        entity_types=["Customer", "Product"],
+    )
+    entities = LLMEntityExtractor(config).extract("Jane Doe works here.")
+    assert len(entities) == 1
+    assert entities[0].type == "UNKNOWN"
+
+
+def test_llm_extractor_without_entity_types_accepts_any_type():
+    """Regression guard: enforcement only applies when entity_types= is
+    actually set. Without it, any type the model returns is accepted
+    as-is - the existing, unchanged default path."""
+    from ragleap_graph.extraction import ExtractionConfig, LLMEntityExtractor
+    FakeGenerationService.next_response = {
+        "answer": json.dumps({"entities": [{"name": "Jane Doe", "type": "Employee"}]}),
+        "provider_used": "gemini",
+        "structured": {"entities": [{"name": "Jane Doe", "type": "Employee"}]},
+        "structured_valid": True,
+        "structured_enforcement": "native",
+    }
+    config = ExtractionConfig(
+        method="llm",
+        provider=FakeProviderConfig(provider="gemini"),
+    )
+    entities = LLMEntityExtractor(config).extract("Jane Doe works here.")
+    assert len(entities) == 1
+    assert entities[0].type == "Employee"
+
+
+def test_llm_extractor_coerces_out_of_vocabulary_type_to_unknown():
+    """
+    Regression test for a known limitation: entity_types= was guidance
+    only, not enforced - if the model returned a type outside the
+    caller-supplied list, that out-of-vocabulary type was accepted
+    as-is rather than being flagged. Now enforced: any type not in the
+    entity_types= list is coerced to "UNKNOWN", the same value
+    regex-extracted entities already use when there's no semantic type
+    available - consistent, not a new special case.
+    """
+    from ragleap_graph.extraction import ExtractionConfig, LLMEntityExtractor
+    FakeGenerationService.next_response = {
+        "answer": json.dumps({"entities": [{"name": "Jane Doe", "type": "Employee"}]}),
+        "provider_used": "gemini",
+        "structured": {"entities": [{"name": "Jane Doe", "type": "Employee"}]},
+        "structured_valid": True,
+        "structured_enforcement": "native",
+    }
+    config = ExtractionConfig(
+        method="llm",
+        provider=FakeProviderConfig(provider="gemini"),
+        entity_types=["Customer", "Product"],
+    )
+    entities = LLMEntityExtractor(config).extract("Jane Doe works here.")
+    assert len(entities) == 1
+    assert entities[0].type == "UNKNOWN"
+
+
+def test_llm_extractor_without_entity_types_accepts_any_type():
+    """Regression guard: enforcement only applies when entity_types= is
+    actually set. Without it, any type the model returns is accepted
+    as-is - the existing, unchanged default path."""
+    from ragleap_graph.extraction import ExtractionConfig, LLMEntityExtractor
+    FakeGenerationService.next_response = {
+        "answer": json.dumps({"entities": [{"name": "Jane Doe", "type": "Employee"}]}),
+        "provider_used": "gemini",
+        "structured": {"entities": [{"name": "Jane Doe", "type": "Employee"}]},
+        "structured_valid": True,
+        "structured_enforcement": "native",
+    }
+    config = ExtractionConfig(
+        method="llm",
+        provider=FakeProviderConfig(provider="gemini"),
+    )
+    entities = LLMEntityExtractor(config).extract("Jane Doe works here.")
+    assert len(entities) == 1
+    assert entities[0].type == "Employee"
+
+
+def test_llm_extractor_coerces_out_of_vocabulary_type_to_unknown():
+    """
+    Regression test for a known limitation: entity_types= was guidance
+    only, not enforced - if the model returned a type outside the
+    caller-supplied list, that out-of-vocabulary type was accepted
+    as-is rather than being flagged. Now enforced: any type not in the
+    entity_types= list is coerced to "UNKNOWN", the same value
+    regex-extracted entities already use when there's no semantic type
+    available - consistent, not a new special case.
+    """
+    from ragleap_graph.extraction import ExtractionConfig, LLMEntityExtractor
+    FakeGenerationService.next_response = {
+        "answer": json.dumps({"entities": [{"name": "Jane Doe", "type": "Employee"}]}),
+        "provider_used": "gemini",
+        "structured": {"entities": [{"name": "Jane Doe", "type": "Employee"}]},
+        "structured_valid": True,
+        "structured_enforcement": "native",
+    }
+    config = ExtractionConfig(
+        method="llm",
+        provider=FakeProviderConfig(provider="gemini"),
+        entity_types=["Customer", "Product"],
+    )
+    entities = LLMEntityExtractor(config).extract("Jane Doe works here.")
+    assert len(entities) == 1
+    assert entities[0].type == "UNKNOWN"
+
+
+def test_llm_extractor_without_entity_types_accepts_any_type():
+    """Regression guard: enforcement only applies when entity_types= is
+    actually set. Without it, any type the model returns is accepted
+    as-is - the existing, unchanged default path."""
+    from ragleap_graph.extraction import ExtractionConfig, LLMEntityExtractor
+    FakeGenerationService.next_response = {
+        "answer": json.dumps({"entities": [{"name": "Jane Doe", "type": "Employee"}]}),
+        "provider_used": "gemini",
+        "structured": {"entities": [{"name": "Jane Doe", "type": "Employee"}]},
+        "structured_valid": True,
+        "structured_enforcement": "native",
+    }
+    config = ExtractionConfig(
+        method="llm",
+        provider=FakeProviderConfig(provider="gemini"),
+    )
+    entities = LLMEntityExtractor(config).extract("Jane Doe works here.")
+    assert len(entities) == 1
+    assert entities[0].type == "Employee"


### PR DESCRIPTION
Closes a known limitation: entity_types= was guidance only, not enforced. If the model returned a type outside the caller-supplied list, that out-of-vocabulary type was accepted as-is. Now enforced: any type not in entity_types= is coerced to UNKNOWN, same value regex-extracted entities already use. Only applies when entity_types= is set; without it, unchanged. Test-first, confirmed failing then passing. Full suite: zero regressions.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
