### PR TITLE
feat: n8n workflow automation (single-tenant)

### DIFF
--- a/channels/discord/router.py
+++ b/channels/discord/router.py
@@ -11,6 +11,7 @@ import logging
 import requests
 
 from core.chat import ask
+from core.workflows import call_n8n_workflows
 
 logger = logging.getLogger(__name__)
 
@@ -76,4 +77,10 @@ def handle_incoming_message(channel_id, message_text: str) -> str:
         answer = "Sorry, something went wrong answering your question. Please try again."
 
     send_discord_message(channel_id, answer)
+
+    try:
+        call_n8n_workflows(channel="discord", message=message_text, ai_reply=answer)
+    except Exception as e:
+        logger.warning(f"n8n workflow trigger failed (non-fatal): {e}")
+
     return answer

--- a/channels/telegram/router.py
+++ b/channels/telegram/router.py
@@ -13,6 +13,7 @@ import logging
 import requests
 
 from core.chat import ask
+from core.workflows import call_n8n_workflows
 
 logger = logging.getLogger(__name__)
 
@@ -94,4 +95,10 @@ def handle_incoming_message(chat_id, message_text: str) -> str:
         answer = "Sorry, something went wrong answering your question. Please try again."
 
     send_telegram_message(chat_id, answer)
+
+    try:
+        call_n8n_workflows(channel="telegram", message=message_text, ai_reply=answer)
+    except Exception as e:
+        logger.warning(f"n8n workflow trigger failed (non-fatal): {e}")
+
     return answer

--- a/channels/whatsapp/router.py
+++ b/channels/whatsapp/router.py
@@ -16,6 +16,7 @@ import logging
 import requests
 
 from core.chat import ask
+from core.workflows import call_n8n_workflows
 
 logger = logging.getLogger(__name__)
 
@@ -133,4 +134,10 @@ def handle_incoming_message(from_phone: str, message_text: str) -> str:
         answer = "Sorry, something went wrong answering your question. Please try again."
 
     send_whatsapp_message(from_phone, answer)
+
+    try:
+        call_n8n_workflows(channel="whatsapp", message=message_text, ai_reply=answer)
+    except Exception as e:
+        logger.warning(f"n8n workflow trigger failed (non-fatal): {e}")
+
     return answer

--- a/core/api.py
+++ b/core/api.py
@@ -18,6 +18,7 @@ from core.employees import profile as employee_profile
 from core.employees import roles as employee_roles
 from core.employees import skills as employee_skills
 from core.employees import learning as employee_learning
+from core import workflows
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("ragleap-core.api")
@@ -59,6 +60,22 @@ class ProfileUpdateRequest(BaseModel):
     tone_preference: str | None = None
     primary_language: str | None = None
     owner_instructions: str | None = None
+
+
+class WorkflowCreateRequest(BaseModel):
+    name: str
+    webhook_url: str
+    description: str = ""
+    channels: list[str] = []
+    is_active: bool = False
+
+
+class WorkflowUpdateRequest(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    webhook_url: str | None = None
+    channels: list[str] | None = None
+    is_active: bool | None = None
 
 
 class RoleUpdateRequest(BaseModel):
@@ -398,3 +415,41 @@ def get_employee_context(role: str, query: str | None = None, top_k: int = 8):
         "context": employee_skills.get_role_skills(role=role, query=query, top_k=top_k),
         "capability_summary": employee_skills.get_capability_summary(),
     }
+
+
+@app.get("/n8n-workflows")
+def list_n8n_workflows(channel: str | None = None, active_only: bool = False):
+    return {"workflows": workflows.list_workflows(channel=channel, active_only=active_only)}
+
+
+@app.post("/n8n-workflows")
+def create_n8n_workflow(req: WorkflowCreateRequest):
+    return workflows.create_workflow(
+        name=req.name, webhook_url=req.webhook_url, description=req.description,
+        channels=req.channels, is_active=req.is_active,
+    )
+
+
+@app.get("/n8n-workflows/{workflow_id}")
+def get_n8n_workflow(workflow_id: str):
+    wf = workflows.get_workflow(workflow_id)
+    if wf is None:
+        raise HTTPException(status_code=404, detail="Workflow not found.")
+    return wf
+
+
+@app.patch("/n8n-workflows/{workflow_id}")
+def update_n8n_workflow(workflow_id: str, req: WorkflowUpdateRequest):
+    updates = {k: v for k, v in req.dict().items() if v is not None}
+    wf = workflows.update_workflow(workflow_id, **updates)
+    if wf is None:
+        raise HTTPException(status_code=404, detail="Workflow not found.")
+    return wf
+
+
+@app.delete("/n8n-workflows/{workflow_id}")
+def delete_n8n_workflow(workflow_id: str):
+    deleted = workflows.delete_workflow(workflow_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Workflow not found.")
+    return {"deleted": True}

--- a/core/workflows.py
+++ b/core/workflows.py
@@ -1,0 +1,159 @@
+"""
+n8n workflow automation for RagLeap Core.
+Single-tenant port of production's n8n_bridge.py — no workspace_id, plain
+SQL instead of Django ORM. Fires a webhook after the AI replies on a
+matching channel. Never raises — a broken workflow config should never
+break the main chat flow, same guarantee as production.
+"""
+import json
+import logging
+from typing import Dict, List, Optional
+
+import requests
+
+from core.employees._db import get_connection
+
+logger = logging.getLogger(__name__)
+
+
+def call_n8n_workflows(channel: str, message: str, ai_reply: str = "", context: Optional[Dict] = None) -> List[Dict]:
+    """
+    Finds all active n8n workflows configured for this channel and calls
+    each webhook. Returns a list of {"workflow": name, "status": "ok"} for
+    successful calls. Silent on failure — logs and continues, never raises.
+    """
+    results = []
+    try:
+        workflows = list_workflows(channel=channel, active_only=True)
+        for wf in workflows:
+            try:
+                resp = requests.post(
+                    wf["webhook_url"],
+                    json={
+                        "channel": channel,
+                        "message": message,
+                        "ai_reply": ai_reply,
+                        "context": context or {},
+                    },
+                    timeout=10,
+                )
+                if resp.ok:
+                    results.append({"workflow": wf["name"], "status": "ok"})
+                    logger.info(f"n8n workflow '{wf['name']}' triggered OK for {channel}")
+                else:
+                    logger.warning(f"n8n workflow '{wf['name']}' returned {resp.status_code}")
+            except Exception as e:
+                logger.warning(f"n8n workflow '{wf['name']}' failed: {e}")
+    except Exception as e:
+        logger.error(f"call_n8n_workflows error: {e}")
+    return results
+
+
+def list_workflows(channel: Optional[str] = None, active_only: bool = False) -> List[Dict]:
+    conn = get_connection()
+    try:
+        cur = conn.cursor()
+        sql = "SELECT id, name, description, webhook_url, channels, is_active, created_at, updated_at FROM n8n_workflows"
+        clauses = []
+        if active_only:
+            clauses.append("is_active = true")
+        if channel:
+            clauses.append("channels ? %s")
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
+        sql += " ORDER BY created_at"
+        cur.execute(sql, (channel,) if channel else ())
+        rows = cur.fetchall()
+        cur.close()
+        return [_row_to_dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def get_workflow(workflow_id: str) -> Optional[Dict]:
+    conn = get_connection()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT id, name, description, webhook_url, channels, is_active, created_at, updated_at FROM n8n_workflows WHERE id = %s",
+            (workflow_id,),
+        )
+        row = cur.fetchone()
+        cur.close()
+        return _row_to_dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def create_workflow(name: str, webhook_url: str, description: str = "", channels: Optional[List[str]] = None, is_active: bool = False) -> Dict:
+    conn = get_connection()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO n8n_workflows (name, description, webhook_url, channels, is_active)
+            VALUES (%s, %s, %s, %s::jsonb, %s)
+            RETURNING id
+            """,
+            (name, description, webhook_url, json.dumps(channels or []), is_active),
+        )
+        new_id = cur.fetchone()[0]
+        conn.commit()
+        cur.close()
+    finally:
+        conn.close()
+    return get_workflow(str(new_id))
+
+
+def update_workflow(workflow_id: str, name: Optional[str] = None, description: Optional[str] = None,
+                     webhook_url: Optional[str] = None, channels: Optional[List[str]] = None,
+                     is_active: Optional[bool] = None) -> Optional[Dict]:
+    updates, params = [], []
+    if name is not None:
+        updates.append("name = %s"); params.append(name)
+    if description is not None:
+        updates.append("description = %s"); params.append(description)
+    if webhook_url is not None:
+        updates.append("webhook_url = %s"); params.append(webhook_url)
+    if channels is not None:
+        updates.append("channels = %s::jsonb"); params.append(json.dumps(channels))
+    if is_active is not None:
+        updates.append("is_active = %s"); params.append(is_active)
+    if not updates:
+        return get_workflow(workflow_id)
+    updates.append("updated_at = now()")
+    params.append(workflow_id)
+
+    conn = get_connection()
+    try:
+        cur = conn.cursor()
+        cur.execute(f"UPDATE n8n_workflows SET {', '.join(updates)} WHERE id = %s", params)
+        conn.commit()
+        cur.close()
+    finally:
+        conn.close()
+    return get_workflow(workflow_id)
+
+
+def delete_workflow(workflow_id: str) -> bool:
+    conn = get_connection()
+    try:
+        cur = conn.cursor()
+        cur.execute("DELETE FROM n8n_workflows WHERE id = %s", (workflow_id,))
+        deleted = cur.rowcount > 0
+        conn.commit()
+        cur.close()
+        return deleted
+    finally:
+        conn.close()
+
+
+def _row_to_dict(row) -> Dict:
+    from datetime import datetime
+    keys = ["id", "name", "description", "webhook_url", "channels", "is_active", "created_at", "updated_at"]
+    d = dict(zip(keys, row))
+    d["id"] = str(d["id"])
+    for k in ("created_at", "updated_at"):
+        if d.get(k) and isinstance(d[k], datetime):
+            d[k] = d[k].isoformat()
+    return d

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -143,3 +143,21 @@ CREATE INDEX IF NOT EXISTS employee_memory_tags_idx
     ON employee_memory USING GIN (tags);
 CREATE INDEX IF NOT EXISTS employee_memory_hash_idx
     ON employee_memory (content_hash, source);
+
+-- n8n workflow automation. Single-tenant — no workspace scoping.
+-- Fires a webhook after the AI replies on a matching channel; caller
+-- (channel adapter) supplies channel/message/ai_reply, this module never
+-- raises — a broken workflow config should never break the main chat flow.
+CREATE TABLE IF NOT EXISTS n8n_workflows (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name        TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    webhook_url TEXT NOT NULL,
+    channels    JSONB NOT NULL DEFAULT '[]',
+    is_active   BOOLEAN NOT NULL DEFAULT false,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS n8n_workflows_active_idx
+    ON n8n_workflows (is_active);


### PR DESCRIPTION
Opens n8n workflow triggering — production's n8n_bridge.py ported single-tenant, wired into whatsapp/telegram/discord channel adapters. Verified end-to-end against a real webhook endpoint (httpbin.org), including correct per-channel filtering. Voice deferred to a follow-up — different protocol shape.