### PR TITLE
docs: reflect n8n workflow automation as open

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ WhatsApp, Telegram, and Discord bots are included in this repo too — single-te
 | 🔁 **Provider fallback** | Automatically retries with a backup LLM provider if the primary fails |
 | 💰 **Token usage reporting** | Real per-call token counts from the provider, plus context-size budget trimming |
 | 🧑‍💼 **AI Employees** | Role-based agents (9 default roles) with persistent business-context memory, wired into `/chat` via `role=<role>` |
+| 🔗 **n8n workflow automation** | Fire a webhook after the AI replies on WhatsApp/Telegram/Discord — no-code automations triggered directly from a conversation |
 ## Architecture
 
 RagLeap Core is the foundation layer of the full RagLeap platform. Here's how it fits into the bigger picture:
@@ -108,7 +109,6 @@ RagLeap Core is the foundation layer of the full RagLeap platform. Here's how it
 |                                                                |
 |  [locked] Manager AI — private executive assistant           |
 |  [locked] Multi-tenant AI Employees + Manager AI integration |
-|  [locked] n8n Workflow Automation                            |
 |  [locked] Persistent Memory (cross-channel, cross-session)   |
 |  [locked] Multi-tenant Billing, Teams & Permissions           |
 |  [locked] Audit History / Compliance logging                 |
@@ -171,7 +171,8 @@ ragleap-core/
 │   ├── ingest.py          # chunk -> embed -> store pipeline
 │   ├── parsers.py         # PDF/DOCX/TXT text extraction
 │   ├── employees/         # AI Employees — roles, business profile, learned memory
-│   └── api.py             # FastAPI app — /health, /upload, /chat, /profile, /employees, /webhook/*
+│   ├── workflows.py       # n8n workflow automation — webhook triggers
+│   └── api.py             # FastAPI app — /health, /upload, /chat, /profile, /employees, /n8n-workflows, /webhook/*
 ├── channels/              # Messaging + voice channel adapters
 │   ├── whatsapp/          # Twilio + Gupshup
 │   ├── telegram/
@@ -198,7 +199,7 @@ RagLeap Core covers document upload, retrieval, and web chat. The hosted platfor
 | **Persistent Memory** | Facts and preferences that persist across sessions and channels, not just within a single conversation |
 | **Advanced AI Settings** | Model selection (Gemini/OpenAI/Claude), temperature tuning, bring-your-own-key per provider, and automatic failover across a fallback key pool |
 | **Team Chat** | Internal team messaging board per workspace, separate from customer-facing AI chat |
-| **n8n Workflows** | Trigger no-code automations directly from a conversation, across every channel |
+| **n8n Workflows** | Single-tenant webhook triggers (WhatsApp/Telegram/Discord) are open in this repo's `core/workflows.py`; the hosted platform adds multi-tenant per-workspace routing and Voice channel coverage |
 | **222+ Languages** | This repo includes language detection (langdetect, ~55 languages) across all channels; the hosted platform extends this to 222+ languages with per-user persisted preferences |
 | **Integrations & Database Connectors** | This repo includes 9 raw connectors (MySQL, PostgreSQL, MongoDB, REST API, Salesforce, HubSpot, Shopify, Google Sheets, Stripe) with on-demand sync; the hosted platform adds AI-suggested automations per channel and developer-level custom automation workflows on top |
 | **Analytics Dashboard** | Per-provider usage breakdown (OpenAI, Gemini, Claude), query volume, token costs, and daily trends |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,6 +46,7 @@ RagLeap's production RAG engine originally lived inside a larger private Django 
 - [x] Real token usage reporting + context-size budget trimming
 - [x] Web chat widget
 - [x] AI Employees runtime — single-tenant, BYOK role-based agents: 9 default roles, business profile (owner-filled + auto-learned), pgvector-backed learned memory (`core/employees/`). Wired into `core/chat.py` and the `/chat`/`/chat/stream` API routes via #133.
+- [x] n8n workflow automation — single-tenant webhook triggers (`core/workflows.py`), wired into whatsapp/telegram/discord channel adapters. Voice channel not yet wired (different protocol shape). See #141.
 
 ## Phase 5 — Community (in progress)
 
@@ -76,7 +77,7 @@ These remain part of the commercial hosted product at [ragleap.com](https://ragl
 - Multi-tenant AI Employees orchestration — per-workspace seeding at scale (single-tenant AI Employees runtime is open in this repo, see Phase 4)
 - Manager AI (executive-assistant layer with cross-channel reach) — the assistant persona itself is a real candidate to open eventually, but it's entangled with locked features (analytics, team permissions, database connections) that genuinely are SaaS-only; needs its own scoping pass before any code starts, not committed to a timeline yet
 - Persistent memory that spans sessions and channels (this repo's memory is per-conversation)
-- n8n workflow automation triggered from conversations
+- Multi-tenant n8n workflow routing (per-workspace) and Voice channel coverage (single-tenant text-channel automation is open in this repo, see Phase 4)
 - Multi-tenant billing and subscription management
 - Observability & hallucination detection dashboard
 - Managed hosting, support, and SLAs


### PR DESCRIPTION
Follow-up to #141 — updates README/ROADMAP to reflect that single-tenant n8n workflow automation is now open, not locked.