### PR TITLE
feat(graph): add find_lineage() for per-document edge contribution lookup (0.6.4)

### DIFF
--- a/packages/ragleap-graph/CHANGELOG.md
+++ b/packages/ragleap-graph/CHANGELOG.md
@@ -5,6 +5,12 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.6.4]
+### Added
+- `find_lineage(entity_a, entity_b, relation_type=None, namespace=None, limit=25)` - exposes the per-document `:PairWeight`/`:RelationWeight` contribution-tracking nodes introduced in v0.6.0 for idempotent weight aggregation, which previously had no public read path. Returns a list of per-document contributions (`document_id`, `relation_type`, `weight`, and `relation_name` for `RELATES_AS` entries) for the edge(s) between two entities. Entity order is irrelevant - both `CO_OCCURS_WITH` and `RELATES_AS` are checked in both directions, since callers generally won't know which side was extracted as subject vs. object. Returns `[]` if the pair has never co-occurred or been related.
+### Verified
+- Regression test (`test_find_lineage`) added and run live against a real Neo4j instance, seeding `:PairWeight`/`:RelationWeight` nodes directly via Cypher (bypassing `upsert_document()`, which this method doesn't touch anyway) for a deterministic setup. Covers: multiple contributing documents aggregating correctly, direction-agnostic lookup (`find_lineage(a, b)` == `find_lineage(b, a)`), `relation_type=` filtering narrowing `RELATES_AS` results while leaving `CO_OCCURS_WITH` untouched, and the never-linked-pair empty case. Full suite re-run: 85 passed, 1 skipped (unrelated, no `GEMINI_API_KEY`) - zero regressions.
+
 ## [0.6.3]
 ### Fixed
 - `entity_types=` was guidance only, not enforced: if the model returned a type outside the caller-supplied list (even with prompt guidance nudging it toward that list), the out-of-vocabulary type was accepted as-is. Now enforced: any type not in `entity_types=` is coerced to `"UNKNOWN"`, the same value regex-extracted entities already use when there's no reliable type available - consistent behavior, not a new special case. Enforcement only applies when `entity_types=` is actually set; without it, any type the model returns is still accepted as-is (unchanged default).

--- a/packages/ragleap-graph/pyproject.toml
+++ b/packages/ragleap-graph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-graph"
-version = "0.6.3"
+version = "0.6.4"
 description = "Knowledge-graph-augmented retrieval for RAG systems: Neo4j-backed entity extraction (regex or LLM-based), co-occurrence graphs, entity deduplication, and GraphRetriever for hybrid vector+graph retrieval via the optional ragleap-rag integration. Framework-agnostic, optional multi-tenant namespacing, no hardcoded models or vocabulary."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-graph/src/ragleap_graph/__init__.py
+++ b/packages/ragleap-graph/src/ragleap_graph/__init__.py
@@ -48,7 +48,7 @@ from ragleap_graph.retrieval import GraphRetriever, GraphRetrievalConfig
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.6.3"
+__version__ = "0.6.4"
 
 # Hard ceiling on traversal depth — prevents both runaway queries and,
 # since max_depth is string-interpolated into Cypher (see note above),
@@ -915,6 +915,89 @@ class GraphIndex:
         except Exception as e:
             logger.error(f"Entity-by-type search error: {e}", exc_info=True)
             return []
+
+    def find_lineage(
+        self,
+        entity_a: str,
+        entity_b: str,
+        relation_type: Optional[str] = None,
+        namespace: Optional[str] = None,
+        limit: int = 25,
+    ) -> List[Dict[str, Any]]:
+        """
+        Return per-document contributions to the edge(s) between entity_a
+        and entity_b, surfacing the :PairWeight (CO_OCCURS_WITH) and
+        :RelationWeight (RELATES_AS) tracking nodes introduced in v0.6.0
+        for idempotent weight aggregation. Previously had no public read
+        path - this exposes it.
+
+        entity_a/entity_b order does not matter - checked in both
+        directions for both relation kinds, since callers generally
+        won't know which side was extracted as subject vs. object.
+
+        Returns [] if the pair has never co-occurred or been related.
+        """
+        if not self.driver:
+            logger.warning("Neo4j driver not available")
+            return []
+        if not entity_a or not entity_a.strip() or not entity_b or not entity_b.strip():
+            return []
+        ns = namespace or ""
+        a_lower = entity_a.lower()
+        b_lower = entity_b.lower()
+        contributions: List[Dict[str, Any]] = []
+        try:
+            with self.driver.session() as session:
+                pair_result = session.run(
+                    """
+                    MATCH (pw:PairWeight {namespace: $namespace})
+                    WHERE (pw.entity_a = $a AND pw.entity_b = $b)
+                       OR (pw.entity_a = $b AND pw.entity_b = $a)
+                    RETURN pw.document_id AS document_id, pw.weight AS weight
+                    LIMIT $limit
+                    """,
+                    namespace=ns,
+                    a=a_lower,
+                    b=b_lower,
+                    limit=max(1, int(limit)),
+                )
+                for row in pair_result:
+                    contributions.append({
+                        "document_id": row["document_id"],
+                        "relation_type": "CO_OCCURS_WITH",
+                        "weight": row["weight"],
+                    })
+
+                relation_result = session.run(
+                    """
+                    MATCH (rw:RelationWeight {namespace: $namespace})
+                    WHERE ((rw.subject = $a AND rw.object = $b)
+                        OR (rw.subject = $b AND rw.object = $a))
+                      AND ($relation_type IS NULL OR rw.relation_type = $relation_type)
+                    RETURN rw.document_id AS document_id,
+                           rw.relation_type AS relation_name,
+                           rw.weight AS weight
+                    LIMIT $limit
+                    """,
+                    namespace=ns,
+                    a=a_lower,
+                    b=b_lower,
+                    relation_type=relation_type,
+                    limit=max(1, int(limit)),
+                )
+                for row in relation_result:
+                    contributions.append({
+                        "document_id": row["document_id"],
+                        "relation_type": "RELATES_AS",
+                        "relation_name": row["relation_name"],
+                        "weight": row["weight"],
+                    })
+
+            return contributions[:max(1, int(limit))]
+        except Exception as e:
+            logger.error(f"Lineage lookup error: {e}", exc_info=True)
+            return []
+
 
     def health_check(self) -> bool:
         """Return True if the Neo4j driver is connected and responsive."""

--- a/packages/ragleap-graph/tests/test_ragleap_graph.py
+++ b/packages/ragleap-graph/tests/test_ragleap_graph.py
@@ -564,6 +564,83 @@ def test_find_relations_direction_parameter():
             )
         graph.close()
 
+@pytest.mark.skipif(not HAS_LIVE_NEO4J, reason="No live Neo4j credentials in environment")
+def test_find_lineage():
+    """
+    Regression test for find_lineage() (v0.6.4). Previously the
+    PairWeight/RelationWeight tracking nodes introduced in v0.6.0 for
+    idempotent weight aggregation had no public read path - this test
+    proves find_lineage() actually surfaces them correctly.
+    Writes PairWeight/RelationWeight nodes directly via Cypher (bypassing
+    upsert_document(), which find_lineage() doesn't touch anyway) so this
+    test is deterministic and only needs NEO4J_URI.
+    Simulates two documents both mentioning (Acme Corp, Globex Industries)
+    with a CO_OCCURS_WITH signal, plus one document asserting a
+    RELATES_AS PARTNERED_WITH relation between the same pair.
+    """
+    config = GraphConfig(uri=NEO4J_URI, user=NEO4J_USER, password=NEO4J_PASSWORD)
+    graph = GraphIndex(config=config)
+    try:
+        with graph.driver.session() as session:
+            session.run(
+                """
+                MERGE (pw:PairWeight {namespace: $ns, document_id: $doc1, entity_a: $a, entity_b: $b})
+                SET pw.weight = $w1
+                """,
+                ns=TEST_NAMESPACE, doc1="doc-1", a="acme corp", b="globex industries", w1=0.6,
+            )
+            session.run(
+                """
+                MERGE (pw:PairWeight {namespace: $ns, document_id: $doc2, entity_a: $a, entity_b: $b})
+                SET pw.weight = $w2
+                """,
+                ns=TEST_NAMESPACE, doc2="doc-2", a="acme corp", b="globex industries", w2=0.4,
+            )
+            session.run(
+                """
+                MERGE (rw:RelationWeight {namespace: $ns, document_id: $doc3, subject: $subj, relation_type: $rel, object: $obj})
+                SET rw.weight = $w3
+                """,
+                ns=TEST_NAMESPACE, doc3="doc-3", subj="acme corp", rel="PARTNERED_WITH", obj="globex industries", w3=1.0,
+            )
+
+        results = graph.find_lineage("Acme Corp", "Globex Industries", namespace=TEST_NAMESPACE)
+        assert len(results) == 3
+        co_occurs = [r for r in results if r["relation_type"] == "CO_OCCURS_WITH"]
+        relates = [r for r in results if r["relation_type"] == "RELATES_AS"]
+        assert len(co_occurs) == 2
+        assert {r["document_id"] for r in co_occurs} == {"doc-1", "doc-2"}
+        assert {r["weight"] for r in co_occurs} == {0.6, 0.4}
+        assert len(relates) == 1
+        assert relates[0]["document_id"] == "doc-3"
+        assert relates[0]["relation_name"] == "PARTNERED_WITH"
+        assert relates[0]["weight"] == 1.0
+
+        swapped = graph.find_lineage("Globex Industries", "Acme Corp", namespace=TEST_NAMESPACE)
+        assert len(swapped) == 3
+        assert {r["document_id"] for r in swapped} == {"doc-1", "doc-2", "doc-3"}
+
+        filtered_out = graph.find_lineage(
+            "Acme Corp", "Globex Industries", namespace=TEST_NAMESPACE, relation_type="SOMETHING_ELSE"
+        )
+        assert len(filtered_out) == 2
+        assert all(r["relation_type"] == "CO_OCCURS_WITH" for r in filtered_out)
+
+        filtered_match = graph.find_lineage(
+            "Acme Corp", "Globex Industries", namespace=TEST_NAMESPACE, relation_type="PARTNERED_WITH"
+        )
+        assert len(filtered_match) == 3
+
+        empty = graph.find_lineage("Acme Corp", "Nonexistent Entity", namespace=TEST_NAMESPACE)
+        assert empty == []
+    finally:
+        with graph.driver.session() as session:
+            session.run(
+                "MATCH (n) WHERE n.namespace = $ns DETACH DELETE n",
+                ns=TEST_NAMESPACE,
+            )
+        graph.close()
+
 
 # ---------------------------------------------------------------------------
 # Entity typing (v0.5.0)


### PR DESCRIPTION
Exposes the PairWeight/RelationWeight tracking nodes introduced in v0.6.0 for per-document contribution lookup, previously unreachable via any public method. Live-verified against real Neo4j (see test_find_lineage). Full suite: 85 passed, 1 skipped (unrelated, no GEMINI_API_KEY). Published to PyPI as ragleap-graph 0.6.4.