### PR TITLE
feat: CSV data source connector (closes #26)

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import logging
 
-from fastapi import FastAPI, UploadFile, File, HTTPException, Request, Response
+from fastapi import FastAPI, UploadFile, File, Form, HTTPException, Request, Response
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
@@ -14,6 +14,7 @@ from core.ingest import ingest_document
 from core.parsers import extract_text
 from core.chat import ask, ask_stream
 from core.integrations import service as integrations_service
+from core.integrations.factory import get_connector
 from core.employees import profile as employee_profile
 from core.employees import roles as employee_roles
 from core.employees import skills as employee_skills
@@ -453,3 +454,45 @@ def delete_n8n_workflow(workflow_id: str):
     if not deleted:
         raise HTTPException(status_code=404, detail="Workflow not found.")
     return {"deleted": True}
+
+
+MAX_CSV_SIZE_BYTES = 10 * 1024 * 1024  # 10 MB — stored as a Postgres TEXT column, keep it sane
+
+
+@app.post("/integrations/csv")
+async def create_csv_integration(
+    name: str = Form(...),
+    user_identifier_field: str = Form("user_id"),
+    file: UploadFile = File(...),
+):
+    """
+    Create a CSV data source from an uploaded file. Separate from the
+    JSON-only POST /integrations route since this takes actual file
+    content, not connection parameters.
+    """
+    if not (file.filename or "").lower().endswith(".csv"):
+        raise HTTPException(status_code=400, detail="Only .csv files are supported.")
+    try:
+        raw_bytes = await file.read()
+        if len(raw_bytes) == 0:
+            raise HTTPException(status_code=400, detail="Uploaded CSV is empty.")
+        if len(raw_bytes) > MAX_CSV_SIZE_BYTES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"CSV too large ({len(raw_bytes) / 1024 / 1024:.1f} MB). Max size is {MAX_CSV_SIZE_BYTES / 1024 / 1024:.0f} MB.",
+            )
+        csv_text = raw_bytes.decode("utf-8-sig")
+        result = integrations_service.create_csv_data_source(
+            name=name, csv_content=csv_text, csv_filename=file.filename,
+            user_identifier_field=user_identifier_field,
+        )
+        return result
+    except HTTPException:
+        raise
+    except UnicodeDecodeError:
+        raise HTTPException(status_code=400, detail="CSV must be UTF-8 encoded.")
+    except Exception as exc:
+        logger.exception("CSV data source creation failed for %s", file.filename)
+        raise HTTPException(status_code=500, detail=f"Failed to create CSV data source: {exc}") from exc
+    finally:
+        await file.close()

--- a/core/integrations/base.py
+++ b/core/integrations/base.py
@@ -75,6 +75,8 @@ class DataSource:
     field_mappings: Dict[str, str] = field(default_factory=dict)
     user_identifier_field: str = "user_id"
     documents_table_name: str = "documents"
+    csv_content: Optional[str] = None
+    csv_filename: Optional[str] = None
 
 
 class BaseDatabaseConnector(ABC):

--- a/core/integrations/csv_connector.py
+++ b/core/integrations/csv_connector.py
@@ -1,0 +1,53 @@
+"""
+CSV connector for RagLeap Core integrations.
+Content is stored directly in Postgres (data_sources.csv_content) rather
+than on disk — the app container has no persistent volume mount, so a
+file saved to the container filesystem would be lost on the next
+`docker compose up --build`.
+"""
+import csv
+import io
+import logging
+from typing import Dict, List, Tuple
+
+from core.integrations.base import BaseDatabaseConnector
+
+logger = logging.getLogger(__name__)
+
+
+class CSVConnector(BaseDatabaseConnector):
+    """CSV connector — reads rows from CSV content stored in the database."""
+
+    def test_connection(self) -> Tuple[bool, str]:
+        content = self.data_source.csv_content
+        if not content:
+            return False, "No CSV content stored for this data source."
+        try:
+            reader = csv.DictReader(io.StringIO(content))
+            headers = reader.fieldnames
+            if not headers:
+                return False, "CSV content has no header row."
+            next(reader, None)  # confirm at least one row is parseable
+            return True, f"CSV readable with columns: {', '.join(headers)}"
+        except Exception as e:
+            return False, f"Failed to parse CSV content: {e}"
+
+    def fetch_data(self, user_identifier: str = None) -> List[Dict]:
+        content = self.data_source.csv_content
+        if not content:
+            raise ValueError("No CSV content stored for this data source.")
+
+        records = []
+        try:
+            reader = csv.DictReader(io.StringIO(content))
+            for row in reader:
+                if user_identifier:
+                    id_field = self.data_source.user_identifier_field
+                    if str(row.get(id_field, '')).strip() != str(user_identifier):
+                        continue
+                records.append(dict(row))
+        except Exception as e:
+            logger.error(f"CSV parse error: {e}")
+            raise
+
+        return records

--- a/core/integrations/factory.py
+++ b/core/integrations/factory.py
@@ -6,6 +6,7 @@ from core.integrations.base import BaseDatabaseConnector, DataSource
 from core.integrations.sql_connectors import MySQLConnector, PostgreSQLConnector
 from core.integrations.mongodb import MongoDBConnector
 from core.integrations.rest_api import RestAPIConnector
+from core.integrations.csv_connector import CSVConnector
 from core.integrations.crm_connectors import (
     SalesforceConnector,
     HubSpotConnector,
@@ -19,6 +20,7 @@ CONNECTOR_MAP = {
     'postgresql': PostgreSQLConnector,
     'mongodb': MongoDBConnector,
     'rest_api': RestAPIConnector,
+    'csv': CSVConnector,
     'salesforce': SalesforceConnector,
     'hubspot': HubSpotConnector,
     'shopify': ShopifyConnector,

--- a/core/integrations/service.py
+++ b/core/integrations/service.py
@@ -26,7 +26,7 @@ def _row_to_data_source(row) -> DataSource:
     """Build a DataSource from a DB row, decrypting credentials."""
     (id_, name, source_type, connection_string, api_endpoint, api_key,
      api_headers, query_template, field_mappings, user_identifier_field,
-     documents_table_name) = row
+     documents_table_name, csv_content, csv_filename) = row
     return DataSource(
         id=str(id_),
         name=name,
@@ -39,6 +39,8 @@ def _row_to_data_source(row) -> DataSource:
         field_mappings=field_mappings or {},
         user_identifier_field=user_identifier_field,
         documents_table_name=documents_table_name,
+        csv_content=csv_content,
+        csv_filename=csv_filename,
     )
 
 
@@ -89,6 +91,41 @@ def create_data_source(
         conn.close()
 
 
+def create_csv_data_source(
+    name: str,
+    csv_content: str,
+    csv_filename: str,
+    user_identifier_field: str = "user_id",
+) -> Dict[str, Any]:
+    """
+    Create a CSV data source. Unlike create_data_source(), this takes raw
+    CSV text directly rather than connection parameters — content is
+    stored in Postgres (no persistent disk volume exists in
+    docker-compose.yml for the app container).
+    """
+    conn = _get_connection()
+    try:
+        cur = conn.cursor()
+        data_source_id = str(uuid.uuid4())
+        cur.execute(
+            """
+            INSERT INTO data_sources
+                (id, name, source_type, user_identifier_field, csv_content, csv_filename)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            """,
+            (data_source_id, name, "csv", user_identifier_field, csv_content, csv_filename),
+        )
+        conn.commit()
+        cur.close()
+        logger.info(f"Created CSV data source '{name}' ({len(csv_content)} chars)")
+        return {"id": data_source_id, "name": name, "source_type": "csv"}
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
 def get_data_source(data_source_id: str) -> Optional[DataSource]:
     """Fetch a single data source by ID, with credentials decrypted."""
     conn = _get_connection()
@@ -98,7 +135,7 @@ def get_data_source(data_source_id: str) -> Optional[DataSource]:
             """
             SELECT id, name, source_type, connection_string, api_endpoint, api_key,
                    api_headers, query_template, field_mappings, user_identifier_field,
-                   documents_table_name
+                   documents_table_name, csv_content, csv_filename
             FROM data_sources WHERE id = %s
             """,
             (data_source_id,),

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -161,3 +161,9 @@ CREATE TABLE IF NOT EXISTS n8n_workflows (
 
 CREATE INDEX IF NOT EXISTS n8n_workflows_active_idx
     ON n8n_workflows (is_active);
+
+-- CSV connector content storage — no persistent disk volume exists in
+-- docker-compose.yml, so CSV content lives in Postgres like everything
+-- else in Core, rather than on the container filesystem.
+ALTER TABLE data_sources ADD COLUMN IF NOT EXISTS csv_content TEXT;
+ALTER TABLE data_sources ADD COLUMN IF NOT EXISTS csv_filename TEXT;


### PR DESCRIPTION
Adds a CSV connector to core/integrations/, matching the existing MySQL/Salesforce/etc. pattern — an uploaded CSV is treated as structured per-record data, synced into synced_context_data. Content is stored in Postgres rather than on disk, since the app container has no persistent volume mount. Verified end-to-end: real upload, real column detection, real per-record sync confirmed by querying the DB directly.