### PR TITLE
docs: mermaid architecture diagrams + auto-stats for ragleap-rag and ragleap-graph

### DIFF
--- a/packages/ragleap-graph/README.md
+++ b/packages/ragleap-graph/README.md
@@ -27,6 +27,48 @@ docs = graph.find_documents_by_entities(["Acme Corp"])
 related = graph.search_related_entities(["Acme Corp"], max_depth=2)
 ```
 
+<!-- AUTO-STATS:START -->
+**Current: v0.6.5** · 87 tests (86 passed, 1 skipped)
+<!-- AUTO-STATS:END -->
+
+## Architecture
+
+```mermaid
+flowchart TD
+    classDef write fill:#1e3a5f,stroke:#4a90d9,color:#fff
+    classDef read fill:#1a4d3a,stroke:#22c55e,color:#fff
+    classDef hybrid fill:#3d2645,stroke:#a855f7,color:#fff
+    classDef store fill:#4d3319,stroke:#f59e0b,color:#fff
+
+    subgraph Write["Write path"]
+        Doc["graph.upsert_document(...)"]:::write --> Extract["Entity/relation extraction<br/>regex default, LLM via method='llm'"]:::write
+        Extract --> Dedup["EntityDeduplicator (optional)<br/>dedup_enabled=True"]:::write
+    end
+
+    Dedup --> Neo4j["Neo4j graph<br/>Entity, Document,<br/>PairWeight, RelationWeight"]:::store
+    Neo4j --> Edges["CONTAINS, CO_OCCURS_WITH,<br/>RELATES_AS edges"]:::store
+
+    subgraph Read["Read path"]
+        FindDocs["find_documents_by_entities()"]:::read
+        SearchRel["search_related_entities()"]:::read
+        FindRel["find_relations()"]:::read
+        FindType["find_entities_by_type()"]:::read
+        Lineage["find_lineage()<br/>per-document contribution lookup"]:::read
+    end
+    Neo4j --> FindDocs
+    Neo4j --> SearchRel
+    Neo4j --> FindRel
+    Neo4j --> FindType
+    Neo4j --> Lineage
+
+    subgraph HybridRet["Hybrid retrieval"]
+        Retriever["GraphRetriever(graph, rag)"]:::hybrid --> VectorChunks["Vector chunks (ragleap-rag)"]:::hybrid
+        Retriever --> GraphContext["Graph context<br/>related_documents, related_entities"]:::hybrid
+        VectorChunks --> Combined["Combined result<br/>already_in_vector_results flag"]:::hybrid
+        GraphContext --> Combined
+    end
+```
+
 ## LLM-based extraction and dedup (v0.2.0+)
 
 The default entity extraction is regex/heuristic-based (fast, free, zero
@@ -56,7 +98,7 @@ avoids it at the source.
 
 ## Status
 
-v0.2.0. Ported from a real production `GraphService`, adapted for standalone open-source use — see `HANDOFF.md` for the full design history. `ragleap-rag` >=0.12.0 is an optional dependency, required only for `method="llm"`.
+v0.6.5. Ported from a real production `GraphService`, adapted for standalone open-source use — see `HANDOFF.md` for the full design history. `ragleap-rag` >=0.12.0 is an optional dependency, required only for `method="llm"`.
 
 ## License
 

--- a/packages/ragleap-rag/README.md
+++ b/packages/ragleap-rag/README.md
@@ -632,50 +632,35 @@ Each worker process talks to the same Postgres database and, optionally, shares 
 See `examples/05_celery_background_tasks.py` for the full runnable version.
 
 ## How it fits together
-             +------------------+
-             | Text, 28 formats |
-             |  URLs, images,   |
-             |   audio, video   |
-             +--------+---------+
-                      |
-             +--------v---------+
-             |  rag.ingest(...)  |   chunk -> embed -> store
-             +--------+---------+
-                      |
-             +--------v---------+
-             |  Vector backend   |   pgvector (default), or FAISS/Pinecone/
-             |  (pluggable)      |   Weaviate/Qdrant/Milvus via vector_backend=
-             +--------+---------+
-                      |
-             +--------v---------+
-             |   rag.ask(...)    |
-             +--------+---------+
-                      |
-             +--------v---------+
-             | query_rewrite=    |   optional: "contextual"/"hyde"/"multi_query"
-             | (optional)        |   transforms the query before retrieval
-             +--------+---------+
-                      |
-             +--------v---------+
-             |  Hybrid retrieve  |   dense + sparse (RRF) - degrades to
-             |                   |   dense-only if the backend can't do sparse
-             +--------+---------+          |
-                      |                     v
-             +--------v---------+   +---------------+
-             |   Generation      |-->| Fallback chain |
-             |  (temp/prompt/    |   | (if primary    |
-             |   response_format)|   |  fails)        |
-             +--------+---------+   +---------------+
-                      |
-             +--------v---------+
-             |  Cost tracking +  |   real token usage -> cost_usd; output
-             |  guardrails       |   guardrails run on the answer
-             +--------+---------+
-                      |
-             +--------v---------+
-             |  Conversation     |   optional: session_id ->
-             |  memory (Postgres)|   prior turns injected as context
-             +-------------------+
+
+<!-- AUTO-STATS:START -->
+**Current: v0.12.2** · 244 tests
+<!-- AUTO-STATS:END -->
+
+```mermaid
+flowchart TD
+    classDef ingest fill:#1e3a5f,stroke:#4a90d9,color:#fff
+    classDef query fill:#3d2645,stroke:#a855f7,color:#fff
+    classDef store fill:#1a4d3a,stroke:#22c55e,color:#fff
+
+    subgraph Ingest["Ingestion"]
+        Sources["Text, 28 formats,<br/>URLs, images, audio, video"]:::ingest
+        Sources --> Ingest1["rag.ingest(...)<br/>chunk -> embed -> store"]:::ingest
+    end
+
+    Ingest1 --> VectorStore["Vector backend (pluggable)<br/>pgvector default, or FAISS/Pinecone/<br/>Weaviate/Qdrant/Milvus via vector_backend="]:::store
+
+    subgraph Query["Query"]
+        Ask["rag.ask(...)"]:::query --> Rewrite["query_rewrite= (optional)<br/>contextual, hyde, multi_query"]:::query
+        Rewrite --> Hybrid["Hybrid retrieve<br/>dense + sparse (RRF)"]:::query
+        Hybrid --> Gen["Generation<br/>temp / prompt / response_format"]:::query
+        Gen --> Fallback["Fallback chain<br/>on primary provider failure"]:::query
+        Gen --> Cost["Cost tracking + guardrails<br/>real token usage -> cost_usd"]:::query
+        Cost --> Memory["Conversation memory (Postgres)<br/>optional session_id"]:::query
+    end
+
+    VectorStore --> Hybrid
+```
 
 ## Supported LLM providers
 


### PR DESCRIPTION
Replaces ragleap-rag's ASCII diagram with a styled mermaid flowchart matching the root README's style. Adds a new mermaid diagram to ragleap-graph's README (write/read/hybrid-retrieval paths), which had none. Both get an AUTO-STATS marker block for version+test-count, intended to be regenerated from real release data. Fixes a stale v0.2.0 status line in ragleap-graph (real current v0.6.5).