### PR TITLE
feat: wire Autonomous Loop approval checks into all 3 text channels

### DIFF
--- a/channels/discord/router.py
+++ b/channels/discord/router.py
@@ -12,6 +12,7 @@ import requests
 
 from core.chat import ask
 from core.workflows import call_n8n_workflows
+from core.autonomy import process_approval_response
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +69,14 @@ def handle_incoming_message(channel_id, message_text: str) -> str:
         reply = "Please send a question and I'll do my best to answer from the documents I have."
         send_discord_message(channel_id, reply)
         return reply
+
+    try:
+        approval_reply = process_approval_response(message_text)
+        if approval_reply is not None:
+            send_discord_message(channel_id, approval_reply)
+            return approval_reply
+    except Exception as e:
+        logger.warning(f"Discord: approval-check error: {e}")
 
     try:
         result = ask(message_text)

--- a/channels/telegram/router.py
+++ b/channels/telegram/router.py
@@ -14,6 +14,7 @@ import requests
 
 from core.chat import ask
 from core.workflows import call_n8n_workflows
+from core.autonomy import process_approval_response
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +77,14 @@ def handle_incoming_message(chat_id, message_text: str) -> str:
         reply = "Please send a question and I'll do my best to answer from the documents I have."
         send_telegram_message(chat_id, reply)
         return reply
+
+    try:
+        approval_reply = process_approval_response(message_text)
+        if approval_reply is not None:
+            send_telegram_message(chat_id, approval_reply)
+            return approval_reply
+    except Exception as e:
+        logger.warning(f"Telegram: approval-check error: {e}")
 
     if message_text.strip() == "/start":
         welcome = (

--- a/channels/whatsapp/router.py
+++ b/channels/whatsapp/router.py
@@ -17,6 +17,7 @@ import requests
 
 from core.chat import ask
 from core.workflows import call_n8n_workflows
+from core.autonomy import process_approval_response
 
 logger = logging.getLogger(__name__)
 
@@ -125,6 +126,14 @@ def handle_incoming_message(from_phone: str, message_text: str) -> str:
         reply = "Please send a question and I'll do my best to answer from the documents I have."
         send_whatsapp_message(from_phone, reply)
         return reply
+
+    try:
+        approval_reply = process_approval_response(message_text)
+        if approval_reply is not None:
+            send_whatsapp_message(from_phone, approval_reply)
+            return approval_reply
+    except Exception as e:
+        logger.warning(f"WhatsApp: approval-check error: {e}")
 
     try:
         result = ask(message_text)


### PR DESCRIPTION
Completes the gap flagged in PR #172 — `core/autonomy.py` existed but nothing called it.

Telegram, WhatsApp, and Discord now check incoming messages against `process_approval_response()` before falling through to normal chat, so a `YES <id>`/`NO <id>` reply from the owner actually completes the semi-mode approval flow end to end.

Non-fatal by design: wrapped in try/except per channel, matching the existing `call_n8n_workflows()` error-handling pattern already used in these same files.

**Not included:** Voice (no discrete text-message handler for this pattern — see `_send_via_channel`'s existing note), an API route to configure `autonomy_settings`, and tests. These remain open follow-ups for Phase B.