### PR TITLE
feat(graph): add Postgres-backed audit logging (0.6.6)

### DIFF
--- a/packages/ragleap-graph/CHANGELOG.md
+++ b/packages/ragleap-graph/CHANGELOG.md
@@ -5,6 +5,14 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.6.6]
+### Added
+- Audit logging, backed by Postgres, fully opt-in via a new `audit=AuditConfig(database_url=...)` parameter on `GraphIndex.__init__()`. Records one event per call to `upsert_document()` and each of the 6 read methods (`find_relations`, `find_documents_by_entities`, `document_entities`, `find_entities_by_type`, `find_lineage`, `search_related_entities`) - `extract_query_entities()` is untouched, same reasoning as `user_id=` in v0.6.5, since it performs no Neo4j access. Requires the new `audit` extra: `pip install ragleap-graph[audit]`.
+- New `ragleap_graph._audit` module: `AuditConfig` (just `database_url=`, caller-supplied, never hardcoded - self-hosted users bring their own Postgres) and `AuditLogger`, which creates its own `ragleap_graph_audit_log` table (`CREATE TABLE IF NOT EXISTS`, idempotent) on first use.
+- Graceful degradation by design, matching the rest of the library: if `psycopg2` isn't installed, if `database_url` is unreachable, or if a single insert fails, the real Neo4j operation being audited still succeeds - a warning is logged, nothing raises. Audit logging can fail; the feature it's auditing must not fail because of it.
+### Verified
+- Live-verified against real Postgres and real Neo4j together, not mocked. Graceful degradation confirmed across all failure modes: no config, config with no `database_url`, and a genuinely unreachable database - none of them raise. The real success path was proven twice: a manual live insert/query round-trip, and a full regression test (`test_audit_logging_records_every_wired_method`) that calls all 7 real audit-wired methods and confirms exactly 7 correctly-ordered, correctly-tagged rows land in Postgres. Full suite: 87 passed, 1 skipped (unrelated, no `GEMINI_API_KEY`) - zero regressions.
+
 ## [0.6.5]
 ### Added
 - `user_id=` parameter on `upsert_document()` and all read methods (`find_relations()`, `find_documents_by_entities()`, `document_entities()`, `find_entities_by_type()`, `find_lineage()`) for per-user data isolation within a namespace - the split-identity model, matching how `namespace=` already isolates tenants. `Entity`/`Document`/`PairWeight`/`RelationWeight` MERGE keys now include `user_id`, so two different users writing the same entity name get genuinely separate nodes. `extract_query_entities()` is unaffected - it performs no Neo4j access, so `user_id=` does not apply.

--- a/packages/ragleap-graph/pyproject.toml
+++ b/packages/ragleap-graph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-graph"
-version = "0.6.5"
+version = "0.6.6"
 description = "Knowledge-graph-augmented retrieval for RAG systems: Neo4j-backed entity extraction (regex or LLM-based), co-occurrence graphs, entity deduplication, and GraphRetriever for hybrid vector+graph retrieval via the optional ragleap-rag integration. Framework-agnostic, optional multi-tenant namespacing, no hardcoded models or vocabulary."
 readme = "README.md"
 license = "MIT"
@@ -31,6 +31,7 @@ dependencies = [
 test = ["pytest>=8.0.0", "pytest-asyncio>=0.24.0"]
 llm = ["ragleap-rag>=0.11.0"]
 retrieval = ["ragleap-rag>=0.12.0"]
+audit = ["psycopg2-binary>=2.9.0"]
 
 [project.urls]
 Homepage = "https://github.com/antonyrag/ragleap-core"

--- a/packages/ragleap-graph/src/ragleap_graph/__init__.py
+++ b/packages/ragleap-graph/src/ragleap_graph/__init__.py
@@ -32,6 +32,8 @@ try:
 except ImportError:
     GraphDatabase = None
 
+from ._audit import AuditConfig, AuditLogger
+
 # v0.2.0: optional LLM-based entity extraction and dedup. Importing these
 # is always safe with zero new hard dependencies - extraction.py itself
 # only requires ragleap-rag if method="llm" is actually selected at
@@ -48,7 +50,7 @@ from ragleap_graph.retrieval import GraphRetriever, GraphRetrievalConfig
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.6.5"
+__version__ = "0.6.6"
 
 # Hard ceiling on traversal depth — prevents both runaway queries and,
 # since max_depth is string-interpolated into Cypher (see note above),
@@ -101,9 +103,11 @@ class GraphIndex:
         self,
         config: Optional[GraphConfig] = None,
         extraction: Optional[ExtractionConfig] = None,
+        audit: Optional[AuditConfig] = None,
     ):
         self.config = config or GraphConfig()
         self.driver = None
+        self._audit = AuditLogger(audit)
 
         # v0.2.0: entity-extraction strategy. Defaults to ExtractionConfig()
         # which is method="regex", dedup_enabled=False - identical behavior
@@ -153,9 +157,10 @@ class GraphIndex:
             self.driver = None
 
     def close(self) -> None:
-        """Close the Neo4j driver connection."""
+        """Close the Neo4j driver connection and the audit log connection, if any."""
         if self.driver:
             self.driver.close()
+        self._audit.close()
 
     def __enter__(self) -> "GraphIndex":
         return self
@@ -592,6 +597,18 @@ class GraphIndex:
                     summary["relations_indexed"] += 1
 
 
+            self._audit.log(
+                user_id=uid,
+                namespace=ns,
+                action="upsert_document",
+                document_id=str(document_id),
+                entity_count=summary["entities_indexed"],
+                detail={
+                    "relationships_indexed": summary["relationships_indexed"],
+                    "relations_indexed": summary["relations_indexed"],
+                },
+            )
+
             summary["success"] = True
             return summary
 
@@ -652,6 +669,12 @@ class GraphIndex:
                         "graph_score": float(row["graph_score"] or 0.0),
                         "matched_entity_names": list(row["matched_entity_names"] or []),
                     })
+                self._audit.log(
+                    user_id=uid,
+                    namespace=ns,
+                    action="find_documents_by_entities",
+                    detail={"entity_names": normalized, "result_count": len(docs)},
+                )
                 return docs
 
         except Exception as e:
@@ -734,6 +757,12 @@ class GraphIndex:
                         "relationship": row["relationship"],
                         "depth": int(row["depth"]),
                     })
+                self._audit.log(
+                    user_id=uid,
+                    namespace=ns,
+                    action="search_related_entities",
+                    detail={"entity_names": normalized, "max_depth": max_depth, "result_count": len(related)},
+                )
                 return related
 
         except ValueError:
@@ -844,6 +873,12 @@ class GraphIndex:
                         "object": row["object"],
                         "weight": float(row["weight"]),
                     })
+                self._audit.log(
+                    user_id=uid,
+                    namespace=ns,
+                    action="find_relations",
+                    detail={"entity_name": entity_name, "direction": direction, "result_count": len(relations)},
+                )
                 return relations
         except Exception as e:
             logger.error(f"Relation search error: {e}", exc_info=True)
@@ -886,6 +921,13 @@ class GraphIndex:
                         "entity_id": row["entity_id"],
                         "entity_name": row["entity_name"],
                     })
+                self._audit.log(
+                    user_id=uid,
+                    namespace=ns,
+                    action="document_entities",
+                    document_id=str(document_id),
+                    detail={"result_count": len(entities)},
+                )
                 return entities
 
         except Exception as e:
@@ -951,6 +993,12 @@ class GraphIndex:
                         "entity_name": row["entity_name"],
                         "entity_type": row["entity_type"],
                     })
+                self._audit.log(
+                    user_id=uid,
+                    namespace=ns,
+                    action="find_entities_by_type",
+                    detail={"entity_type": entity_type, "result_count": len(entities)},
+                )
                 return entities
 
         except Exception as e:
@@ -1040,6 +1088,12 @@ class GraphIndex:
                         "weight": row["weight"],
                     })
 
+            self._audit.log(
+                user_id=uid,
+                namespace=ns,
+                action="find_lineage",
+                detail={"entity_a": entity_a, "entity_b": entity_b, "result_count": len(contributions)},
+            )
             return contributions[:max(1, int(limit))]
         except Exception as e:
             logger.error(f"Lineage lookup error: {e}", exc_info=True)

--- a/packages/ragleap-graph/src/ragleap_graph/_audit.py
+++ b/packages/ragleap-graph/src/ragleap_graph/_audit.py
@@ -1,0 +1,167 @@
+"""
+Audit logging for ragleap-graph (v0.6.6+), backed by Postgres.
+
+Fully optional. If GraphIndex is constructed without an AuditConfig (or
+with one that has no database_url set), no audit logging occurs and no
+psycopg2 import is even attempted - this module has zero effect unless
+explicitly configured.
+
+Graceful-degradation philosophy matches the rest of ragleap-graph: if
+psycopg2 isn't installed (it's an optional dependency - pip install
+ragleap-graph[audit]), if the database_url is unreachable, or if a
+write fails for any reason, the real Neo4j operation being audited
+still succeeds. Audit logging can fail; the feature it's auditing must
+not fail because of it. A warning is logged so the gap is visible, but
+nothing raises.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("ragleap_graph.audit")
+
+
+@dataclass
+class AuditConfig:
+    """
+    Config for audit logging via Postgres. Pass to GraphIndex(audit=...)
+    to enable. Requires the `audit` extra: pip install ragleap-graph[audit]
+
+    database_url: standard libpq connection string, e.g.
+    "postgresql://user:password@host:5432/dbname". Caller-supplied,
+    never hardcoded - self-hosted users bring their own Postgres, the
+    same as they bring their own Neo4j instance.
+    """
+    database_url: Optional[str] = None
+
+
+_CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS ragleap_graph_audit_log (
+    id BIGSERIAL PRIMARY KEY,
+    occurred_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    user_id TEXT,
+    namespace TEXT,
+    action TEXT NOT NULL,
+    document_id TEXT,
+    entity_count INTEGER,
+    detail JSONB
+)
+"""
+_CREATE_INDEXES_SQL = [
+    "CREATE INDEX IF NOT EXISTS idx_ragleap_graph_audit_user_id ON ragleap_graph_audit_log (user_id)",
+    "CREATE INDEX IF NOT EXISTS idx_ragleap_graph_audit_namespace ON ragleap_graph_audit_log (namespace)",
+    "CREATE INDEX IF NOT EXISTS idx_ragleap_graph_audit_occurred_at ON ragleap_graph_audit_log (occurred_at)",
+]
+_INSERT_SQL = """
+INSERT INTO ragleap_graph_audit_log
+    (user_id, namespace, action, document_id, entity_count, detail)
+VALUES (%s, %s, %s, %s, %s, %s)
+"""
+
+
+class AuditLogger:
+    """
+    Holds (and lazily reconnects) a Postgres connection for audit
+    logging. Every public method swallows its own errors and logs a
+    warning rather than raising - callers never need to guard calls
+    into this class with their own try/except.
+    """
+
+    def __init__(self, config: Optional[AuditConfig]):
+        self.config = config
+        self._conn = None
+        self._schema_ready = False
+        self._warned_no_driver = False
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.config and self.config.database_url)
+
+    def _connect(self):
+        if self._conn is not None:
+            return self._conn
+        if not self.enabled:
+            return None
+        try:
+            import psycopg2
+        except ImportError:
+            if not self._warned_no_driver:
+                logger.warning(
+                    "AuditConfig.database_url is set but psycopg2 is not "
+                    "installed - audit logging is disabled. Install with "
+                    "pip install ragleap-graph[audit] to enable it."
+                )
+                self._warned_no_driver = True
+            return None
+        try:
+            conn = psycopg2.connect(self.config.database_url)
+            conn.autocommit = True
+            self._conn = conn
+            return conn
+        except Exception as e:
+            logger.warning(f"Audit log connection failed, audit logging disabled for this call: {e}")
+            self._conn = None
+            return None
+
+    def _ensure_schema(self, conn) -> bool:
+        if self._schema_ready:
+            return True
+        try:
+            with conn.cursor() as cur:
+                cur.execute(_CREATE_TABLE_SQL)
+                for stmt in _CREATE_INDEXES_SQL:
+                    cur.execute(stmt)
+            self._schema_ready = True
+            return True
+        except Exception as e:
+            logger.warning(f"Audit log schema setup failed, audit logging disabled for this call: {e}")
+            return False
+
+    def log(
+        self,
+        user_id: Optional[str],
+        namespace: Optional[str],
+        action: str,
+        document_id: Optional[str] = None,
+        entity_count: Optional[int] = None,
+        detail: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """
+        Record one audit event. Never raises - any failure (no driver,
+        no connection, bad query) is logged as a warning and swallowed,
+        so this is always safe to call from inside a real operation
+        without a surrounding try/except at the call site.
+        """
+        if not self.enabled:
+            return
+        conn = self._connect()
+        if conn is None:
+            return
+        if not self._ensure_schema(conn):
+            return
+        try:
+            import json
+            with conn.cursor() as cur:
+                cur.execute(
+                    _INSERT_SQL,
+                    (
+                        user_id or None,
+                        namespace or None,
+                        action,
+                        document_id,
+                        entity_count,
+                        json.dumps(detail) if detail is not None else None,
+                    ),
+                )
+        except Exception as e:
+            logger.warning(f"Audit log write failed, continuing without it: {e}")
+            self._conn = None
+
+    def close(self) -> None:
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            except Exception:
+                pass
+            self._conn = None

--- a/packages/ragleap-graph/tests/test_ragleap_graph.py
+++ b/packages/ragleap-graph/tests/test_ragleap_graph.py
@@ -218,6 +218,11 @@ NEO4J_USER = os.environ.get("NEO4J_USER")
 NEO4J_PASSWORD = os.environ.get("NEO4J_PASSWORD")
 HAS_LIVE_NEO4J = bool(NEO4J_URI and NEO4J_USER and NEO4J_PASSWORD)
 
+TEST_DATABASE_URL = os.environ.get(
+    "RAGLEAP_TEST_DATABASE_URL",
+    "postgresql://ragleap_test_user:ragleap_test_pass@127.0.0.1:5432/ragleap_test",
+)
+
 ollama_available = True
 try:
     import requests
@@ -760,3 +765,90 @@ def test_find_entities_by_type_empty_without_driver(graph_no_driver):
 def test_find_entities_by_type_empty_string_returns_empty(graph_no_driver):
     assert graph_no_driver.find_entities_by_type("") == []
     assert graph_no_driver.find_entities_by_type("   ") == []
+
+
+@pytest.mark.skipif(not HAS_LIVE_NEO4J, reason="No live Neo4j credentials in environment")
+def test_audit_logging_records_every_wired_method():
+    """
+    Regression test for audit logging (v0.6.6). Live-verifies against
+    real Postgres AND real Neo4j - not a mock - that all 7 audit-wired
+    methods (upsert_document + 6 read methods) each produce exactly one
+    correctly-tagged row in ragleap_graph_audit_log.
+    Uses a unique namespace/user_id pair so this test's rows are
+    trivially distinguishable from anything else that may exist in the
+    shared test database, and cleans up both Postgres and Neo4j state
+    in the finally block regardless of outcome.
+    """
+    import psycopg2
+
+    from ragleap_graph import GraphConfig, GraphIndex
+    from ragleap_graph._audit import AuditConfig
+
+    audit_ns = "__audit_test_ns__"
+    audit_uid = "audit_test_user"
+    doc_id = "audit-test-doc-1"
+
+    config = GraphConfig(uri=NEO4J_URI, user=NEO4J_USER, password=NEO4J_PASSWORD)
+    audit = AuditConfig(database_url=TEST_DATABASE_URL)
+    graph = GraphIndex(config=config, audit=audit)
+
+    try:
+        summary = graph.upsert_document(
+            document_id=doc_id,
+            title="Audit Test",
+            chunks=[{"text": "Audit Test Corp announced new products today."}],
+            namespace=audit_ns,
+            user_id=audit_uid,
+        )
+        assert summary["success"] is True
+
+        graph.find_relations("Audit Test Corp", namespace=audit_ns, user_id=audit_uid)
+        graph.find_documents_by_entities(["Audit Test Corp"], namespace=audit_ns, user_id=audit_uid)
+        graph.document_entities(doc_id, namespace=audit_ns, user_id=audit_uid)
+        graph.find_entities_by_type("UNKNOWN", namespace=audit_ns, user_id=audit_uid)
+        graph.find_lineage("Audit Test Corp", "Nonexistent Entity", namespace=audit_ns, user_id=audit_uid)
+        graph.search_related_entities(["Audit Test Corp"], namespace=audit_ns, user_id=audit_uid)
+
+        pg_conn = psycopg2.connect(TEST_DATABASE_URL)
+        try:
+            with pg_conn.cursor() as cur:
+                cur.execute(
+                    "SELECT action, user_id, namespace FROM ragleap_graph_audit_log "
+                    "WHERE namespace = %s ORDER BY id",
+                    (audit_ns,),
+                )
+                rows = cur.fetchall()
+        finally:
+            pg_conn.close()
+
+        actions = [r[0] for r in rows]
+        expected_actions = [
+            "upsert_document",
+            "find_relations",
+            "find_documents_by_entities",
+            "document_entities",
+            "find_entities_by_type",
+            "find_lineage",
+            "search_related_entities",
+        ]
+        assert actions == expected_actions, f"Expected {expected_actions}, got {actions}"
+        assert all(r[1] == audit_uid for r in rows)
+        assert all(r[2] == audit_ns for r in rows)
+    finally:
+        with graph.driver.session() as session:
+            session.run(
+                "MATCH (n) WHERE n.namespace = $ns DETACH DELETE n",
+                ns=audit_ns,
+            )
+        graph.close()
+        try:
+            pg_conn = psycopg2.connect(TEST_DATABASE_URL)
+            with pg_conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM ragleap_graph_audit_log WHERE namespace = %s",
+                    (audit_ns,),
+                )
+            pg_conn.commit()
+            pg_conn.close()
+        except Exception:
+            pass

--- a/packages/ragleap-graph/tests/test_ragleap_graph.py
+++ b/packages/ragleap-graph/tests/test_ragleap_graph.py
@@ -230,6 +230,12 @@ try:
 except Exception:
     ollama_available = False
 
+psycopg2_available = True
+try:
+    import psycopg2  # noqa: F401
+except ImportError:
+    psycopg2_available = False
+
 TEST_NAMESPACE = "ragleap_graph_pytest"
 
 
@@ -767,7 +773,10 @@ def test_find_entities_by_type_empty_string_returns_empty(graph_no_driver):
     assert graph_no_driver.find_entities_by_type("   ") == []
 
 
-@pytest.mark.skipif(not HAS_LIVE_NEO4J, reason="No live Neo4j credentials in environment")
+@pytest.mark.skipif(
+    not (HAS_LIVE_NEO4J and psycopg2_available),
+    reason="No live Neo4j credentials, or psycopg2 not installed (pip install ragleap-graph[audit])",
+)
 def test_audit_logging_records_every_wired_method():
     """
     Regression test for audit logging (v0.6.6). Live-verifies against


### PR DESCRIPTION
New audit=AuditConfig(database_url=...) param on GraphIndex, fully opt-in. Records one event per call to upsert_document() and all 6 read methods via a new ragleap_graph._audit module. Graceful degradation: missing psycopg2, unreachable database, or a failed insert never blocks the real Neo4j operation. Requires the new 'audit' extra. Live-verified against real Postgres and Neo4j together - full regression test confirms all 7 methods produce correctly-ordered audit rows. Full suite: 87 passed, 1 skipped. Published to PyPI as ragleap-graph 0.6.6.