### PR TITLE
fix: render mermaid diagrams on GitHub Pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,10 @@
+# Minimal Jekyll config for GitHub Pages.
+# No theme - just enough to apply a default layout (for mermaid.js) to
+# every page, since GitHub Pages serves README.md as the site index by
+# default with zero styling/scripts otherwise.
+markdown: kramdown
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: "default"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{ page.title | default: site.title | default: "RagLeap Core" }}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body { max-width: 900px; margin: 0 auto; padding: 2rem 1rem; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; line-height: 1.6; color: #1f2328; }
+    pre { background: #f6f8fa; padding: 1rem; border-radius: 6px; overflow-x: auto; }
+    code { background: #f6f8fa; padding: 0.2em 0.4em; border-radius: 4px; }
+    pre code { background: none; padding: 0; }
+    img { max-width: 100%; }
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border: 1px solid #d1d9e0; padding: 0.5rem; }
+    .mermaid { background: #f6f8fa; padding: 1rem; border-radius: 6px; }
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      // Kramdown renders ```mermaid fences as <pre><code class="language-mermaid">.
+      // mermaid.js expects <pre class="mermaid">, so convert them first.
+      document.querySelectorAll("pre > code.language-mermaid").forEach(function (codeEl) {
+        var pre = codeEl.parentElement;
+        var div = document.createElement("div");
+        div.className = "mermaid";
+        div.textContent = codeEl.textContent;
+        pre.replaceWith(div);
+      });
+      mermaid.initialize({ startOnLoad: true, theme: "default" });
+    });
+  </script>
+</head>
+<body>
+{{ content }}
+</body>
+</html>


### PR DESCRIPTION
Diagrams in README.md render fine on GitHub's repo viewer but showed as raw text on the GitHub Pages site (antonyrag.github.io/ragleap-core/), since Pages runs plain Jekyll with no mermaid support by default.

Adds a minimal `_config.yml` + `_layouts/default.html` that loads mermaid.js and converts kramdown's rendered code blocks into the format mermaid.js expects.

Docs/site config only, no application code changes.