### PR TITLE
docs: add PyPI download badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ RagLeap Core is the open-source engine behind RagLeap — a self-hosted RAG (ret
 [![Core Release](https://img.shields.io/badge/ragleap--core-v0.2.0-blue)](https://github.com/antonyrag/ragleap-core/releases/tag/v0.2.0)
 [![PyPI ragleap-rag](https://img.shields.io/pypi/v/ragleap-rag?label=ragleap-rag)](https://pypi.org/project/ragleap-rag/)
 [![PyPI ragleap-graph](https://img.shields.io/pypi/v/ragleap-graph?label=ragleap-graph)](https://pypi.org/project/ragleap-graph/)
+[![Downloads](https://img.shields.io/pypi/dm/ragleap-rag?label=ragleap-rag%20downloads)](https://pypi.org/project/ragleap-rag/)
+[![Downloads](https://img.shields.io/pypi/dm/ragleap-graph?label=ragleap-graph%20downloads)](https://pypi.org/project/ragleap-graph/)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://github.com/antonyrag/ragleap-core)
 [![Contributors](https://img.shields.io/github/contributors/antonyrag/ragleap-core)](https://github.com/antonyrag/ragleap-core/graphs/contributors)
 [![Good First Issues](https://img.shields.io/github/issues/antonyrag/ragleap-core/good%20first%20issue)](https://github.com/antonyrag/ragleap-core/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)


### PR DESCRIPTION
Adds live shields.io download-count badges for ragleap-rag and ragleap-graph, auto-updating from PyPI stats.