### PR TITLE
feat: sensitive-domain AI Employee guardrail (Phase C)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,20 @@ look at the existing pattern first:
 
 Be respectful and constructive. See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
+## Building a sensitive-domain AI Employee role
+
+If you're adding a new AI Employee role type that touches a sensitive
+domain — health, financial, or legal — add it to `SENSITIVE_DOMAIN_ROLES`
+in `core/employees/defaults.py` as part of your PR. This locks the
+Autonomous Loop's mode to `semi` or `off` for that role type by default,
+regardless of the workspace's general autonomy settings.
+
+Please read the "Vision: Vertical AI Employees" section in
+[ROADMAP.md](ROADMAP.md) before starting significant work in this area —
+it lays out real open questions (data-handling boundaries, regulatory
+scope, escalation guarantees) that should inform the design, not just
+the guardrail flag.
+
 ## Questions
 
 Open a [Discussion](../../discussions) or reach out via [ragleap.com](https://ragleap.com).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,6 +115,54 @@ The longer-term package roadmap beyond `ragleap-rag` and `ragleap-graph`. Nothin
 
 This section exists so the vision is written down honestly — ambitious, but explicitly unscoped — rather than either hidden or overclaimed. Anyone interested in helping shape the actual design (not just the code) is welcome to open a Discussion; the scoping pass above needs to happen before any implementation work starts.
 
+## Vision: Vertical AI Employees (healthcare, financial, legal)
+
+Contributors have asked about domain-specific AI Employee roles —
+things like a healthcare intake assistant, a financial advisory agent,
+or a legal intake bot — with real auto-triggering behavior through the
+Autonomous Loop (see Phase B above), not just Q&A.
+
+This is a genuinely different risk category from something like a
+Slack connector: a wrong auto-triggered action in these domains
+carries real regulatory, financial, or legal-liability weight. So this
+is being sequenced deliberately:
+
+1. Land a structural, code-level guardrail first (`SENSITIVE_DOMAIN_ROLES`
+   in `core/employees/defaults.py`) — any role type marked sensitive-domain
+   has its Autonomous Loop mode locked to `semi` or `off`, regardless of
+   what the workspace's general autonomy settings say.
+2. Write the open compliance-boundary questions down honestly (below),
+   rather than pretending they're already answered.
+3. Validate the overall pattern on one lower-stakes example role (support
+   or scheduling suggested) before opening healthcare/financial/legal
+   templates to contributors.
+4. Only then invite wide contribution on actual vertical role templates.
+
+As of this guardrail landing, no vertical role template exists yet —
+`SENSITIVE_DOMAIN_ROLES` is an empty set, ready for contributors to opt
+new sensitive role types into, not a set of shipped roles.
+
+Open questions that need real answers before any vertical role ships:
+
+- **Data handling boundaries** — how do we validate that a role's data
+  access actually stays within a defined boundary (e.g. a healthcare
+  intake role only touching intake-relevant fields), rather than just
+  trusting the system prompt to behave?
+- **Regulatory scope** — which jurisdictions' rules (HIPAA-like, financial
+  advisory licensing, legal-practice rules) apply, and how does a
+  self-hosted, contributor-built role avoid inadvertently practicing a
+  regulated profession?
+- **Escalation and human-in-the-loop guarantees** — beyond the Autonomous
+  Loop's existing approval protocol, what additional guarantees does a
+  sensitive-domain role need before an action executes?
+- **Liability and disclosure** — what should a self-hosted operator be
+  told about the risk they're taking on by enabling one of these roles?
+
+This section exists so the vision is written down honestly — real
+interest, real risk, explicitly unscoped until the guardrail and the
+questions above are actually addressed. Anyone interested in helping
+shape this is welcome to open a Discussion.
+
 ## Not planned for RagLeap Core
 
 These remain part of the commercial hosted product at [ragleap.com](https://ragleap.com), consistent with the open-core model. Note: this repo *does* include single-tenant WhatsApp/Telegram/Discord/Voice channel adapters (see Phase 4 above) — the items below are what the hosted platform adds on top of them, not duplicates of what's already open:

--- a/STUDENT_PROJECTS.md
+++ b/STUDENT_PROJECTS.md
@@ -56,10 +56,13 @@ or start a [Discussion](../../discussions), and we'll help scope it together.
 - **Multi-language voice quality** — the Voice channel's known limitation
   (OpenAI TTS is English-tuned) is a real, unsolved problem. A proper
   language-detection + provider-routing solution is genuinely open research.
-- **Autonomous agent capabilities** — RagLeap's core today is Q&A only.
-  What would a scoped, honest first step toward agentic actions (not
-  full Manager AI) look like, kept safely within a single-tenant,
-  self-hosted context?
+- **Vertical AI Employee roles with enforced safety guardrails** — the
+  Autonomous Loop (see ROADMAP.md) makes RagLeap's core capable of real
+  agentic actions today, not just Q&A. The open research question is how
+  a domain-specific role (healthcare, financial, legal) can have its data
+  handling *validated* to stay within a defined boundary, rather than
+  just trusting the system prompt — see `SENSITIVE_DOMAIN_ROLES` and the
+  "Vision: Vertical AI Employees" section in ROADMAP.md for context.
 
 ---
 

--- a/core/employees/defaults.py
+++ b/core/employees/defaults.py
@@ -54,6 +54,20 @@ DEFAULT_ROLES = [
      "personality": "You are the AI Operations Agent for this business. You manage integrations, database actions, workflow automations, and operational tasks. You are systematic, reliable, and always log what actions you take."},
 ]
 
+# Roles that touch a sensitive domain (health, financial, legal) - a
+# structural guardrail, not just a documentation convention. Any role
+# type listed here should have core.autonomy's mode locked to "semi"
+# (or "off") when paired with the Autonomous Loop, regardless of what
+# the workspace's general autonomy_settings say. See RFC discussion
+# #171 and ROADMAP.md's "Vision: Vertical AI Employees" section.
+#
+# No role in DEFAULT_ROLES above is sensitive-domain today - "finance"
+# handles invoice/payment *conversations*, not medical, legal, or
+# account-holding actions. This set exists for contributors adding new
+# role types (e.g. a future "healthcare_intake" or "legal_intake" role)
+# to opt into the safety default from day one, not as an afterthought.
+SENSITIVE_DOMAIN_ROLES = set()
+
 DEFAULT_MEMORY_SEEDS = [
     {"tags": ["business", "identity", "core"], "importance": 1.0,
      "text": "BUSINESS PROFILE: This deployment has not yet completed its business profile. The AI will auto-learn from uploaded documents, customer conversations, and integration usage to build this profile automatically. Owner can also fill it in to boost accuracy immediately."},


### PR DESCRIPTION
Adds the structural guardrail (SENSITIVE_DOMAIN_ROLES) discussed in RFC #171, plus honest documentation of the open compliance questions before any vertical role template gets built. See ROADMAP.md's new 'Vision: Vertical AI Employees' section for full context.