### PR TITLE
feat: outcome-weighted memory for AI Employee roles

### DIFF
--- a/core/chat.py
+++ b/core/chat.py
@@ -49,7 +49,7 @@ def _prepare(query: str, top_k: int, hybrid: bool):
     return chunks, detected_language, False
 
 
-def _build_system_prompt(role: Optional[str], query: str, base_system_prompt: Optional[str]) -> Optional[str]:
+def _build_system_prompt(role: Optional[str], query: str, base_system_prompt: Optional[str]):
     """
     When a role is given, layers the role's personality and role-scoped
     context (owner instructions, business profile, learned patterns) on
@@ -68,10 +68,10 @@ def _build_system_prompt(role: Optional[str], query: str, base_system_prompt: Op
     role until this fix).
     """
     if not role:
-        return base_system_prompt
+        return base_system_prompt, []
 
     personality = employee_skills.get_role_personality(role)
-    role_context = employee_skills.get_role_skills(role=role, query=query)
+    role_context, role_memory_ids = employee_skills.get_role_skills_with_ids(role=role, query=query)
 
     grounding = base_system_prompt or (
         "You are a helpful assistant. Answer questions using the business "
@@ -96,7 +96,7 @@ def _build_system_prompt(role: Optional[str], query: str, base_system_prompt: Op
     if role_context:
         parts.append("Business and role context (treat as authoritative, alongside retrieved documents):\n" + role_context)
     parts.append(grounding)
-    return "\n\n".join(parts)
+    return "\n\n".join(parts), role_memory_ids
 
 
 def _augment_query_with_reminder(role, query):
@@ -149,13 +149,14 @@ def ask(
             "detected_language": detected_language,
         }
 
-    effective_system_prompt = _build_system_prompt(role, query, system_prompt)
+    effective_system_prompt, role_memory_ids = _build_system_prompt(role, query, system_prompt)
     generation_query = _augment_query_with_reminder(role, query)
     result = generator.generate_answer(
         generation_query, chunks, temperature=temperature, system_prompt=effective_system_prompt, max_tokens=max_tokens
     )
     result["chunks_used"] = len(chunks)
     result["detected_language"] = detected_language
+    result["role_memory_ids"] = role_memory_ids
     return result
 
 
@@ -181,7 +182,7 @@ def ask_stream(
         yield "Sorry, I couldn't process your question (embedding failed)."
         return
 
-    effective_system_prompt = _build_system_prompt(role, query, system_prompt)
+    effective_system_prompt, _role_memory_ids = _build_system_prompt(role, query, system_prompt)
     generation_query = _augment_query_with_reminder(role, query)
     yield from generator.generate_answer_stream(
         generation_query, chunks, temperature=temperature, system_prompt=effective_system_prompt, max_tokens=max_tokens

--- a/core/employees/learning.py
+++ b/core/employees/learning.py
@@ -7,6 +7,26 @@ from core.employees._db import get_connection
 logger = logging.getLogger(__name__)
 
 
+def record_role_memory_outcome(memory_ids, success: bool, weight: float = 0.05):
+    """
+    Closes the loop on outcome-weighted memory: call once the real
+    outcome of a role-generated response is known (conversation
+    resolved well / owner approved an autonomous action / vs. the
+    opposite). Reinforces or decays the specific memory entries that
+    were retrieved to produce that response, via chat.ask()'s
+    returned role_memory_ids -- so future retrieval for this role
+    naturally favors what has actually worked.
+
+    This does not change any model weights and is not learning in
+    the training sense -- it is an adaptive importance signal on top
+    of the existing retrieval system.
+    """
+    if not memory_ids:
+        return 0
+    delta = weight if success else -weight
+    return memory.reinforce_memories(memory_ids, delta)
+
+
 def learn_from_owner_instruction(instruction_text: str):
     if not instruction_text or len(instruction_text.strip()) < 10:
         return

--- a/core/employees/memory.py
+++ b/core/employees/memory.py
@@ -60,6 +60,44 @@ def write_learned_skill(text, tags, importance=0.7, source="interaction",
         conn.close()
 
 
+def reinforce_memories(ids: List[str], delta: float) -> int:
+    """
+    Nudge importance for specific memory entries based on a real
+    outcome (positive delta = the memory contributed to a good
+    outcome, negative = it did not). Clamped to [0.1, 1.0] so no
+    single event can zero out or max out a memory permanently.
+    Returns the number of rows updated.
+
+    This is NOT model training -- no weights change. It is an
+    adaptive importance signal layered on the existing retrieval
+    system: entries that keep contributing to good outcomes surface
+    more often, entries that do not gradually surface less.
+    """
+    if not ids:
+        return 0
+    conn = get_connection()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            UPDATE employee_memory
+            SET importance = LEAST(1.0, GREATEST(0.1, importance + %s))
+            WHERE id = ANY(%s::uuid[])
+            """,
+            (delta, ids),
+        )
+        updated = cur.rowcount
+        conn.commit()
+        cur.close()
+        return updated
+    except Exception as e:
+        conn.rollback()
+        logger.error(f"reinforce_memories error: {e}")
+        return 0
+    finally:
+        conn.close()
+
+
 def get_owner_instructions() -> str:
     rows = tag_search(["owner_instruction"], top_k=3)
     if not rows:

--- a/core/employees/skills.py
+++ b/core/employees/skills.py
@@ -31,6 +31,34 @@ def get_role_skills(role: str = "general", query: str = None, top_k: int = 8) ->
     return memory.format_context(owner_block, entries)
 
 
+def get_role_skills_with_ids(role: str = "general", query: str = None, top_k: int = 8):
+    """
+    Same retrieval as get_role_skills(), but also returns the
+    employee_memory row IDs that were actually used -- so a caller
+    can later report back whether they led to a good outcome via
+    core.employees.learning.record_role_memory_outcome().
+
+    Returns (formatted_context: str, memory_ids: List[str]).
+    """
+    owner_block = memory.get_owner_instructions()
+
+    def _dedupe(entries):
+        return [e for e in entries if "owner_instruction" not in (e.get("tags") or [])]
+
+    tags = ROLE_SKILL_TAGS.get(role, ROLE_SKILL_TAGS["general"])
+    entries = []
+    if query and len(query.strip()) > 5:
+        try:
+            entries = _dedupe(memory.semantic_search(query, top_k))
+        except Exception as e:
+            logger.debug(f"Semantic search failed, falling back to tag search: {e}")
+    if not entries:
+        entries = _dedupe(memory.tag_search(tags, top_k))
+    text = memory.format_context(owner_block, entries)
+    ids = [e["id"] for e in entries]
+    return text, ids
+
+
 def get_role_personality(role: str = "support") -> str:
     r = roles.get_role(role)
     if r and r.get("personality"):


### PR DESCRIPTION
Adds an adaptive feedback loop on the existing role-scoped memory system. See commit message for full scoping -- this is honestly NOT model training or autonomous learning, it's importance-weighting based on real outcomes. Live-verified against the actual DB (see commit message for the exact before/after importance value).

No caller wiring yet -- channel handlers need a follow-up PR to actually call record_role_memory_outcome() once an interaction's outcome is known. This PR is the mechanism only.