### PR TITLE
feat: wire support role into all 4 channel handlers

### DIFF
--- a/channels/discord/router.py
+++ b/channels/discord/router.py
@@ -79,7 +79,7 @@ def handle_incoming_message(channel_id, message_text: str) -> str:
         logger.warning(f"Discord: approval-check error: {e}")
 
     try:
-        result = ask(message_text)
+        result = ask(message_text, role="support")
         answer = result.get("answer", "Sorry, I couldn't generate an answer.")
     except Exception as e:
         logger.error(f"Discord: error answering message from channel {channel_id}: {e}", exc_info=True)

--- a/channels/telegram/router.py
+++ b/channels/telegram/router.py
@@ -97,7 +97,7 @@ def handle_incoming_message(chat_id, message_text: str) -> str:
     send_typing_action(chat_id)
 
     try:
-        result = ask(message_text)
+        result = ask(message_text, role="support")
         answer = result.get("answer", "Sorry, I couldn't generate an answer.")
     except Exception as e:
         logger.error(f"Telegram: error answering message from chat {chat_id}: {e}", exc_info=True)

--- a/channels/voice/router.py
+++ b/channels/voice/router.py
@@ -164,7 +164,7 @@ async def handle_call(ws):
 
                     if transcript and len(transcript) > 2:
                         try:
-                            result = ask(transcript)
+                            result = ask(transcript, role="support")
                             answer = result.get("answer", "Sorry, I couldn't generate an answer.")
                         except Exception as e:
                             logger.error(f"Voice: error answering: {e}", exc_info=True)

--- a/channels/whatsapp/router.py
+++ b/channels/whatsapp/router.py
@@ -136,7 +136,7 @@ def handle_incoming_message(from_phone: str, message_text: str) -> str:
         logger.warning(f"WhatsApp: approval-check error: {e}")
 
     try:
-        result = ask(message_text)
+        result = ask(message_text, role="support")
         answer = result.get("answer", "Sorry, I couldn't generate an answer.")
     except Exception as e:
         logger.error(f"WhatsApp: error answering message from {from_phone}: {e}", exc_info=True)


### PR DESCRIPTION
Closes the actual missing link: no channel handler was passing a role to chat.ask() at all, so the AI Employees system built across the last 3 PRs was fully disconnected from real customer-facing channels. See commit message for full honest scoping -- notably, this does NOT wire in automatic outcome feedback, since there's no genuine success/failure signal in these channels yet and faking one would misrepresent the outcome-weighting feature.