### PR TITLE
fix(ragleap-rag): normalize Milvus similarity_score to [0,1] - v0.12.3

### DIFF
--- a/packages/ragleap-rag/CHANGELOG.md
+++ b/packages/ragleap-rag/CHANGELOG.md
@@ -5,6 +5,12 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.12.3] - 2026-08-23
+
+### Fixed
+
+- Milvus backend's `similarity_score` is now normalized to `[0, 1]`, matching `pgvector`/`weaviate`'s convention. Milvus with `metric_type="COSINE"` returns raw cosine similarity in the field it labels "distance" - verified against Milvus's own documentation, this was already correctly ordered (higher = more similar), not backwards, but its range was inconsistent: raw cosine similarity spans `[-1, 1]`, while `pgvector` (`1 - distance/2`) and `weaviate_backend.py` (`1.0 - distance`) already normalize to `[0, 1]`. A caller filtering on `similarity_score` (e.g. `score > 0.5`) would behave correctly for those two backends but break silently for Milvus's negative scores. Fixed via the standard `(x + 1) / 2` linear transform - preserves exact ranking order, adds consistent range. New regression test (`test_search_dense_normalizes_cosine_similarity_to_unit_range`) confirms the transform at all three boundaries (identical/orthogonal/opposite vectors -> 1.0/0.5/0.0). This is a breaking change to output values for anyone depending on Milvus's previous raw `[-1, 1]` scores - acceptable pre-1.0, and this inconsistency was already a documented, known limitation rather than a silent surprise.
+
 ## [0.12.1] - 2026-08-08
 
 ### Fixed

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.12.2"
+version = "0.12.3"
 description = "Self-hosted RAG engine: hybrid dense+sparse retrieval, 28-format ingestion (docs, URLs, images, audio, video), 6 vector backends, 8 embedding providers, 12+ generation providers with automatic fallback, query rewriting (HyDE/contextual/multi-query), structured JSON output, real per-call cost tracking, and standalone retrieval via retrieve(). Composable with the optional ragleap-graph package for knowledge-graph-augmented retrieval. BYOK, no vendor lock-in, no hardcoded model defaults."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -45,7 +45,7 @@ from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.12.2"
+__version__ = "0.12.3"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult", "TranscriptionConfig", "VectorBackend", "PgVectorBackend"]
 
 

--- a/packages/ragleap-rag/src/ragleap/vectorstores/milvus_backend.py
+++ b/packages/ragleap-rag/src/ragleap/vectorstores/milvus_backend.py
@@ -191,7 +191,14 @@ class MilvusBackend(VectorBackend):
             document_id, document_name, chunk_index, text = row
             results.append({
                 "chunk_id": vector_key, "text": text,
-                "similarity_score": round(float(distance), 4) if distance is not None else None,
+                # Milvus with metric_type="COSINE" returns raw cosine
+                # similarity in [-1, 1] (verified against Milvus docs,
+                # not a true distance - higher is already "more similar").
+                # Normalized to [0, 1] here to match pgvector/weaviate's
+                # convention, since a caller filtering on similarity_score
+                # (e.g. "score > 0.5") would otherwise behave inconsistently
+                # across backends for negative Milvus scores.
+                "similarity_score": round((float(distance) + 1) / 2, 4) if distance is not None else None,
                 "document_id": document_id, "document_name": document_name, "chunk_index": chunk_index,
             })
         return results

--- a/packages/ragleap-rag/tests/test_milvus_backend.py
+++ b/packages/ragleap-rag/tests/test_milvus_backend.py
@@ -121,7 +121,50 @@ def test_search_dense_returns_chunks_with_text_from_sqlite(tmp_path):
 
     assert len(results) == 1
     assert results[0]["text"] == "real text"
-    assert results[0]["similarity_score"] == 0.87
+    # Milvus COSINE raw distance 0.87 normalized to [0,1]: (0.87 + 1) / 2
+    assert results[0]["similarity_score"] == 0.935
+
+
+def test_search_dense_normalizes_cosine_similarity_to_unit_range(tmp_path):
+    """
+    Regression test for the similarity_score normalization fix. Milvus
+    with metric_type="COSINE" returns raw cosine similarity in [-1, 1]
+    (verified against Milvus's own docs - not a true distance). This
+    confirms the linear [-1,1] -> [0,1] transform at its boundaries and
+    midpoint, matching pgvector/weaviate's normalized-range convention.
+    """
+    backend = _make_backend(tmp_path)
+    backend._dimensions = 2
+    backend._client = MagicMock()
+
+    backend._conn.execute(
+        "INSERT INTO chunks (vector_key, document_id, document_name, chunk_index, text, token_count, metadata) "
+        "VALUES ('doc1:0', 'doc1', 'test.txt', 0, 'identical vector', 5, '{}')"
+    )
+    backend._conn.execute(
+        "INSERT INTO chunks (vector_key, document_id, document_name, chunk_index, text, token_count, metadata) "
+        "VALUES ('doc1:1', 'doc1', 'test.txt', 1, 'orthogonal vector', 5, '{}')"
+    )
+    backend._conn.execute(
+        "INSERT INTO chunks (vector_key, document_id, document_name, chunk_index, text, token_count, metadata) "
+        "VALUES ('doc1:2', 'doc1', 'test.txt', 2, 'opposite vector', 5, '{}')"
+    )
+    backend._conn.commit()
+
+    # Cosine similarity of 1.0 (identical), 0.0 (orthogonal), -1.0 (opposite)
+    backend._client.search.return_value = [[
+        {"id": "doc1:0", "distance": 1.0},
+        {"id": "doc1:1", "distance": 0.0},
+        {"id": "doc1:2", "distance": -1.0},
+    ]]
+
+    results = backend.search_dense(embedding=[0.1, 0.2], top_k=5)
+
+    assert len(results) == 3
+    by_text = {r["text"]: r["similarity_score"] for r in results}
+    assert by_text["identical vector"] == 1.0
+    assert by_text["orthogonal vector"] == 0.5
+    assert by_text["opposite vector"] == 0.0
 
 
 def test_search_dense_skips_orphaned_hits(tmp_path):


### PR DESCRIPTION
## Problem

Milvus's `similarity_score` was passed through raw from Milvus's `search()` response. With `metric_type="COSINE"` (this backend's configured metric), that raw value is cosine similarity itself, ranging `[-1, 1]`.

Verified against Milvus's own documentation before making this change: the field, despite being labeled "distance" in Milvus's API, is genuinely cosine similarity for this metric type - so the existing ordering (higher = more similar) was already correct, not backwards.

The real inconsistency was range, not direction: `pgvector` (`1 - distance/2`) and `weaviate_backend.py` (`1.0 - distance`) both normalize their output to `[0, 1]`. Milvus's raw `[-1, 1]` range meant a caller filtering on `similarity_score` (e.g. `score > 0.5`) would behave correctly for those two backends but silently misbehave for Milvus's negative scores.

## Fix

Standard `(x + 1) / 2` linear transform - preserves exact ranking order, produces a consistent `[0, 1]` range matching pgvector/weaviate.

## Testing

- Updated the existing incidental test assertion (raw distance 0.87 -> normalized 0.935)
- Added `test_search_dense_normalizes_cosine_similarity_to_unit_range`, covering all 3 boundary cases: identical vectors -> 1.0, orthogonal -> 0.5, opposite -> 0.0
- Full 245-test suite passes

## Breaking change note

This changes real output values for anyone depending on Milvus's previous raw `[-1,1]` scores. Acceptable pre-1.0 (`v0.12.3`); this inconsistency was already a documented, known limitation in project history rather than a silent surprise.

Version bumped: `pyproject.toml` + `__init__.py` -> 0.12.3. Already built, twine-checked, and published to PyPI - verified live via the version-specific JSON endpoint (https://pypi.org/pypi/ragleap-rag/0.12.3/json).