### PR TITLE
feat: real outcome signal via feedback commands (👍/👎)

### DIFF
--- a/channels/discord/router.py
+++ b/channels/discord/router.py
@@ -13,6 +13,7 @@ import requests
 from core.chat import ask
 from core.workflows import call_n8n_workflows
 from core.autonomy import process_approval_response
+from core.employees.feedback import record_last_reply, get_last_reply, detect_feedback_command
 
 logger = logging.getLogger(__name__)
 
@@ -78,9 +79,20 @@ def handle_incoming_message(channel_id, message_text: str) -> str:
     except Exception as e:
         logger.warning(f"Discord: approval-check error: {e}")
 
+    feedback = detect_feedback_command(message_text)
+    if feedback is not None:
+        last_ids = get_last_reply("discord", str(channel_id))
+        if last_ids:
+            from core.employees.learning import record_role_memory_outcome
+            record_role_memory_outcome(last_ids, success=feedback)
+        reply = "Thanks for the feedback!" if feedback else "Thanks, I'll do better next time."
+        send_discord_message(channel_id, reply)
+        return reply
+
     try:
         result = ask(message_text, role="support")
         answer = result.get("answer", "Sorry, I couldn't generate an answer.")
+        record_last_reply("discord", str(channel_id), result.get("role_memory_ids", []))
     except Exception as e:
         logger.error(f"Discord: error answering message from channel {channel_id}: {e}", exc_info=True)
         answer = "Sorry, something went wrong answering your question. Please try again."

--- a/channels/telegram/router.py
+++ b/channels/telegram/router.py
@@ -15,6 +15,7 @@ import requests
 from core.chat import ask
 from core.workflows import call_n8n_workflows
 from core.autonomy import process_approval_response
+from core.employees.feedback import record_last_reply, get_last_reply, detect_feedback_command
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +87,16 @@ def handle_incoming_message(chat_id, message_text: str) -> str:
     except Exception as e:
         logger.warning(f"Telegram: approval-check error: {e}")
 
+    feedback = detect_feedback_command(message_text)
+    if feedback is not None:
+        last_ids = get_last_reply("telegram", str(chat_id))
+        if last_ids:
+            from core.employees.learning import record_role_memory_outcome
+            record_role_memory_outcome(last_ids, success=feedback)
+        reply = "Thanks for the feedback!" if feedback else "Thanks, I'll do better next time."
+        send_telegram_message(chat_id, reply)
+        return reply
+
     if message_text.strip() == "/start":
         welcome = (
             "Hi! I'm a document Q&A bot powered by RagLeap Core. "
@@ -99,6 +110,7 @@ def handle_incoming_message(chat_id, message_text: str) -> str:
     try:
         result = ask(message_text, role="support")
         answer = result.get("answer", "Sorry, I couldn't generate an answer.")
+        record_last_reply("telegram", str(chat_id), result.get("role_memory_ids", []))
     except Exception as e:
         logger.error(f"Telegram: error answering message from chat {chat_id}: {e}", exc_info=True)
         answer = "Sorry, something went wrong answering your question. Please try again."

--- a/channels/voice/router.py
+++ b/channels/voice/router.py
@@ -17,6 +17,7 @@ import json
 import logging
 
 from core.chat import ask
+from core.employees.feedback import record_last_reply
 from channels.voice.audio import transcribe_audio, text_to_speech
 from channels.voice.config import get_voice_config
 
@@ -166,6 +167,7 @@ async def handle_call(ws):
                         try:
                             result = ask(transcript, role="support")
                             answer = result.get("answer", "Sorry, I couldn't generate an answer.")
+                            record_last_reply("voice", stream_sid, result.get("role_memory_ids", []))
                         except Exception as e:
                             logger.error(f"Voice: error answering: {e}", exc_info=True)
                             answer = "Sorry, something went wrong. Please try again."

--- a/channels/whatsapp/router.py
+++ b/channels/whatsapp/router.py
@@ -18,6 +18,7 @@ import requests
 from core.chat import ask
 from core.workflows import call_n8n_workflows
 from core.autonomy import process_approval_response
+from core.employees.feedback import record_last_reply, get_last_reply, detect_feedback_command
 
 logger = logging.getLogger(__name__)
 
@@ -135,9 +136,20 @@ def handle_incoming_message(from_phone: str, message_text: str) -> str:
     except Exception as e:
         logger.warning(f"WhatsApp: approval-check error: {e}")
 
+    feedback = detect_feedback_command(message_text)
+    if feedback is not None:
+        last_ids = get_last_reply("whatsapp", from_phone)
+        if last_ids:
+            from core.employees.learning import record_role_memory_outcome
+            record_role_memory_outcome(last_ids, success=feedback)
+        reply = "Thanks for the feedback!" if feedback else "Thanks, I'll do better next time."
+        send_whatsapp_message(from_phone, reply)
+        return reply
+
     try:
         result = ask(message_text, role="support")
         answer = result.get("answer", "Sorry, I couldn't generate an answer.")
+        record_last_reply("whatsapp", from_phone, result.get("role_memory_ids", []))
     except Exception as e:
         logger.error(f"WhatsApp: error answering message from {from_phone}: {e}", exc_info=True)
         answer = "Sorry, something went wrong answering your question. Please try again."

--- a/core/employees/feedback.py
+++ b/core/employees/feedback.py
@@ -1,0 +1,87 @@
+"""
+Real outcome signal for outcome-weighted memory: tracks the last
+role-based reply per (channel, chat_id) so an owner can send a quick
+feedback command afterward (thumbs up/down, "helpful"/"not helpful")
+that gets attributed to the correct employee_memory entries via
+core.employees.learning.record_role_memory_outcome().
+
+Without this, there is no genuine success/failure signal available in
+WhatsApp/Telegram/Discord/Voice -- this module is what makes the
+outcome-weighted memory mechanism (see memory.reinforce_memories)
+actually meaningful for real conversations, not just test calls.
+"""
+import json
+import logging
+from typing import List, Optional
+
+from core.employees._db import get_connection
+
+logger = logging.getLogger(__name__)
+
+POSITIVE_COMMANDS = {"👍", "helpful", "that helped", "good answer", "thanks that worked"}
+NEGATIVE_COMMANDS = {"👎", "not helpful", "that didn't help", "wrong answer", "bad answer"}
+
+
+def record_last_reply(channel: str, chat_id: str, role_memory_ids: List[str]) -> None:
+    """
+    Call this right after sending a role-based reply, so a subsequent
+    feedback command from the same chat can be attributed correctly.
+    No-op if role_memory_ids is empty (no role was set, or nothing was
+    retrieved) -- nothing meaningful to attribute feedback to.
+    """
+    if not role_memory_ids:
+        return
+    conn = get_connection()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO role_reply_log (channel, chat_id, role_memory_ids, created_at)
+            VALUES (%s, %s, %s::jsonb, now())
+            ON CONFLICT (channel, chat_id)
+            DO UPDATE SET role_memory_ids = EXCLUDED.role_memory_ids, created_at = now()
+            """,
+            (channel, chat_id, json.dumps(role_memory_ids)),
+        )
+        conn.commit()
+        cur.close()
+    except Exception as e:
+        conn.rollback()
+        logger.error(f"record_last_reply error: {e}")
+    finally:
+        conn.close()
+
+
+def get_last_reply(channel: str, chat_id: str) -> List[str]:
+    """Returns the role_memory_ids from the most recent reply in this chat, or []."""
+    conn = get_connection()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT role_memory_ids FROM role_reply_log WHERE channel = %s AND chat_id = %s",
+            (channel, chat_id),
+        )
+        row = cur.fetchone()
+        cur.close()
+        return row[0] if row else []
+    except Exception as e:
+        logger.error(f"get_last_reply error: {e}")
+        return []
+    finally:
+        conn.close()
+
+
+def detect_feedback_command(message: str) -> Optional[bool]:
+    """
+    Returns True if the message is a positive feedback command, False if
+    negative, None if it's not a feedback command at all (i.e. treat it
+    as a normal question).
+    """
+    if not message:
+        return None
+    normalized = message.strip().lower()
+    if normalized in POSITIVE_COMMANDS:
+        return True
+    if normalized in NEGATIVE_COMMANDS:
+        return False
+    return None

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -199,6 +199,20 @@ CREATE TABLE IF NOT EXISTS autonomy_log (
 CREATE INDEX IF NOT EXISTS autonomy_log_created_idx
     ON autonomy_log (created_at DESC);
 
+-- Tracks the most recent role-based reply per (channel, chat_id), so
+-- an owner can send a quick feedback command (thumbs up/down,
+-- "helpful"/"not helpful") that gets attributed to the correct
+-- memory entries via core.employees.learning.record_role_memory_outcome().
+-- Without this table there is no real success/failure signal available
+-- in the channels -- see core/employees/feedback.py.
+CREATE TABLE IF NOT EXISTS role_reply_log (
+    channel          TEXT NOT NULL,
+    chat_id          TEXT NOT NULL,
+    role_memory_ids  JSONB NOT NULL DEFAULT '[]',
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (channel, chat_id)
+);
+
 -- CSV connector content storage — no persistent disk volume exists in
 -- docker-compose.yml, so CSV content lives in Postgres like everything
 -- else in Core, rather than on the container filesystem.


### PR DESCRIPTION
Closes the honest gap flagged in the previous PR: WhatsApp/Telegram/Discord now have a genuine success/failure signal (thumbs up/down or helpful/not-helpful text), fully wired to record_role_memory_outcome() from the outcome-weighted-memory PR. Voice intentionally gets partial wiring only -- see commit message for why. Live-verified end-to-end against the real database.