### PR TITLE
feat: add scheduled background sync using APScheduler

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -5,7 +5,11 @@ Minimal HTTP interface over the existing CLI pipeline (core.ingest / core.chat).
 import os
 import shutil
 import logging
+import asyncio
+from datetime import datetime, timezone
+from contextlib import asynccontextmanager
 
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from fastapi import FastAPI, UploadFile, File, Form, HTTPException, Request, Response
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
@@ -25,10 +29,51 @@ from core import autonomy
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("ragleap-core.api")
 
+async def _sync_job():
+    try:
+        sources = integrations_service.list_data_sources()
+        for src in sources:
+            if not src.get("is_active"):
+                continue
+                
+            sync_interval_minutes = src.get("sync_interval_minutes") or 360
+            last_sync_at_str = src.get("last_sync_at")
+            
+            should_sync = False
+            if not last_sync_at_str:
+                should_sync = True
+            else:
+                last_sync_at = datetime.fromisoformat(last_sync_at_str)
+                if last_sync_at.tzinfo is None:
+                    last_sync_at = last_sync_at.replace(tzinfo=timezone.utc)
+                now = datetime.now(timezone.utc)
+                diff_minutes = (now - last_sync_at).total_seconds() / 60
+                if diff_minutes >= sync_interval_minutes:
+                    should_sync = True
+                    
+            if should_sync:
+                # Per maintainer discussion: we ignore sync failures and retry on the next tick
+                # regardless. If they continue failing, last_sync_status will just remain 'failed'.
+                logger.info("Background sync triggered for source %s (%s)", src['name'], src['id'])
+                await asyncio.to_thread(integrations_service.sync_data_source, src['id'])
+    except Exception as e:
+        logger.error("Error in background sync job: %s", e)
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    scheduler = AsyncIOScheduler()
+    scheduler.add_job(_sync_job, "interval", minutes=5)
+    scheduler.start()
+    logger.info("Background sync scheduler started.")
+    yield
+    scheduler.shutdown()
+    logger.info("Background sync scheduler stopped.")
+
 app = FastAPI(
     title="RagLeap Core API",
     description="Minimal self-hosted RAG pipeline — BYOK, no platform fallback keys.",
     version="0.1.0",
+    lifespan=lifespan,
 )
 
 ALLOWED_EXTENSIONS = {".txt", ".pdf", ".docx"}

--- a/core/integrations/service.py
+++ b/core/integrations/service.py
@@ -155,7 +155,7 @@ def list_data_sources() -> List[Dict[str, Any]]:
         cur.execute(
             """
             SELECT id, name, source_type, is_active, last_sync_at,
-                   last_sync_status, last_sync_record_count
+                   last_sync_status, last_sync_record_count, sync_interval_minutes
             FROM data_sources ORDER BY created_at DESC
             """
         )
@@ -166,6 +166,7 @@ def list_data_sources() -> List[Dict[str, Any]]:
                 "id": str(r[0]), "name": r[1], "source_type": r[2],
                 "is_active": r[3], "last_sync_at": r[4].isoformat() if r[4] else None,
                 "last_sync_status": r[5], "last_sync_record_count": r[6],
+                "sync_interval_minutes": r[7],
             }
             for r in rows
         ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ audioop-lts>=0.2; python_version >= "3.13"
 neo4j>=5.0
 langdetect>=1.0.9
 pytest>=8.0
+apscheduler>=3.10.0
 
 # Integrations (all optional — connectors degrade gracefully if a specific
 # SDK isn't installed; only install the ones for the sources you use)


### PR DESCRIPTION
Fixes #28

This adds a background sync scheduler using APScheduler inside the FastAPI lifespan context, as discussed in the issue comments. It checks all active sources every 5 minutes and runs the sync if they've passed their `sync_interval_minutes`. The actual sync call is wrapped in `asyncio.to_thread` to avoid blocking the event loop.

Tested locally and everything looks good! Let me know if you need any adjustments.
