### PR TITLE
feat: role-to-autonomy wiring via deterministic escalation trigger

### DIFF
--- a/channels/discord/router.py
+++ b/channels/discord/router.py
@@ -14,6 +14,7 @@ from core.chat import ask
 from core.workflows import call_n8n_workflows
 from core.autonomy import process_approval_response
 from core.employees.feedback import record_last_reply, get_last_reply, detect_feedback_command
+from core.employees.triggers import detect_escalation_request
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +89,19 @@ def handle_incoming_message(channel_id, message_text: str) -> str:
         reply = "Thanks for the feedback!" if feedback else "Thanks, I'll do better next time."
         send_discord_message(channel_id, reply)
         return reply
+
+    if detect_escalation_request(message_text):
+        from core.autonomy import execute_or_request
+        escalation = execute_or_request(
+            action_type="escalate_to_owner", channel="discord", target=str(channel_id),
+            content=f"Customer asked to speak with a human.\nMessage: {message_text}",
+            subject="Escalation request",
+        )
+        if escalation.get("status") in ("executed", "pending_approval"):
+            reply = "I've flagged this for a team member -- they'll follow up with you soon."
+            send_discord_message(channel_id, reply)
+            return reply
+        # else: escalation not configured for this action/channel -- fall through to a normal answer
 
     try:
         result = ask(message_text, role="support")

--- a/channels/telegram/router.py
+++ b/channels/telegram/router.py
@@ -16,6 +16,7 @@ from core.chat import ask
 from core.workflows import call_n8n_workflows
 from core.autonomy import process_approval_response
 from core.employees.feedback import record_last_reply, get_last_reply, detect_feedback_command
+from core.employees.triggers import detect_escalation_request
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +97,19 @@ def handle_incoming_message(chat_id, message_text: str) -> str:
         reply = "Thanks for the feedback!" if feedback else "Thanks, I'll do better next time."
         send_telegram_message(chat_id, reply)
         return reply
+
+    if detect_escalation_request(message_text):
+        from core.autonomy import execute_or_request
+        escalation = execute_or_request(
+            action_type="escalate_to_owner", channel="telegram", target=str(chat_id),
+            content=f"Customer asked to speak with a human.\nMessage: {message_text}",
+            subject="Escalation request",
+        )
+        if escalation.get("status") in ("executed", "pending_approval"):
+            reply = "I've flagged this for a team member -- they'll follow up with you soon."
+            send_telegram_message(chat_id, reply)
+            return reply
+        # else: escalation not configured for this action/channel -- fall through to a normal answer
 
     if message_text.strip() == "/start":
         welcome = (

--- a/channels/whatsapp/router.py
+++ b/channels/whatsapp/router.py
@@ -19,6 +19,7 @@ from core.chat import ask
 from core.workflows import call_n8n_workflows
 from core.autonomy import process_approval_response
 from core.employees.feedback import record_last_reply, get_last_reply, detect_feedback_command
+from core.employees.triggers import detect_escalation_request
 
 logger = logging.getLogger(__name__)
 
@@ -145,6 +146,19 @@ def handle_incoming_message(from_phone: str, message_text: str) -> str:
         reply = "Thanks for the feedback!" if feedback else "Thanks, I'll do better next time."
         send_whatsapp_message(from_phone, reply)
         return reply
+
+    if detect_escalation_request(message_text):
+        from core.autonomy import execute_or_request
+        escalation = execute_or_request(
+            action_type="escalate_to_owner", channel="whatsapp", target=from_phone,
+            content=f"Customer asked to speak with a human.\nMessage: {message_text}",
+            subject="Escalation request",
+        )
+        if escalation.get("status") in ("executed", "pending_approval"):
+            reply = "I've flagged this for a team member -- they'll follow up with you soon."
+            send_whatsapp_message(from_phone, reply)
+            return reply
+        # else: escalation not configured for this action/channel -- fall through to a normal answer
 
     try:
         result = ask(message_text, role="support")

--- a/core/employees/triggers.py
+++ b/core/employees/triggers.py
@@ -1,0 +1,41 @@
+"""
+Deterministic triggers that let a role's response automatically dispatch
+an autonomous action via core.autonomy.execute_or_request() -- respecting
+whatever mode/allowlists the owner has configured (default: off, meaning
+this changes nothing until the owner explicitly opts in via
+/autonomy/configure).
+
+No LLM judgment call here on purpose, matching the rest of the
+Autonomous Loop's design: a fixed, auditable phrase match, not a model
+deciding on its own whether to escalate. That keeps every trigger fully
+predictable and reviewable, the same way autonomy.py's mode/allowlist
+gates are.
+
+Deliberately narrow for a first version: one trigger (explicit request
+for a human), one action_type ("escalate_to_owner"). More triggers are
+a natural follow-up once this pattern is proven in real use, not
+something to guess at speculatively here.
+"""
+import logging
+
+logger = logging.getLogger(__name__)
+
+ESCALATION_PHRASES = {
+    "talk to a human", "speak to a human", "speak to someone",
+    "talk to someone", "real person", "human agent", "human support",
+    "this isn't helping", "this is not helping", "not what i need",
+    "let me speak to a person", "connect me to a person",
+}
+
+
+def detect_escalation_request(message: str) -> bool:
+    """
+    True if the message explicitly asks for human help, using a fixed
+    phrase match -- not an LLM judgment call. Deliberately conservative:
+    a missed real escalation request is safer here than escalating a
+    routine question by mistake.
+    """
+    if not message:
+        return False
+    normalized = message.strip().lower()
+    return any(phrase in normalized for phrase in ESCALATION_PHRASES)


### PR DESCRIPTION
Closes the role-to-autonomy gap: execute_or_request() was only reachable via a manual API call before this. Adds one narrow, well-scoped trigger (explicit request for a human) wired into WhatsApp/Telegram/Discord, fully respecting the existing mode/allowlist gates from Phase B -- default behavior is unchanged until the owner opts in. Also fixes a real gap found while testing: the Phase B autonomy tables were never created on the live DB. Full semi-mode round trip live-verified against the real database, see commit message.