### PR TITLE
feat: channel-to-role routing (owner config + safe intent detection)

### DIFF
--- a/channels/discord/router.py
+++ b/channels/discord/router.py
@@ -15,6 +15,7 @@ from core.workflows import call_n8n_workflows
 from core.autonomy import process_approval_response
 from core.employees.feedback import record_last_reply, get_last_reply, detect_feedback_command
 from core.employees.triggers import detect_escalation_request
+from core.employees.channel_roles import resolve_role
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +105,7 @@ def handle_incoming_message(channel_id, message_text: str) -> str:
         # else: escalation not configured for this action/channel -- fall through to a normal answer
 
     try:
-        result = ask(message_text, role="support")
+        result = ask(message_text, role=resolve_role("discord", message_text))
         answer = result.get("answer", "Sorry, I couldn't generate an answer.")
         record_last_reply("discord", str(channel_id), result.get("role_memory_ids", []))
     except Exception as e:

--- a/channels/telegram/router.py
+++ b/channels/telegram/router.py
@@ -17,6 +17,7 @@ from core.workflows import call_n8n_workflows
 from core.autonomy import process_approval_response
 from core.employees.feedback import record_last_reply, get_last_reply, detect_feedback_command
 from core.employees.triggers import detect_escalation_request
+from core.employees.channel_roles import resolve_role
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +123,7 @@ def handle_incoming_message(chat_id, message_text: str) -> str:
     send_typing_action(chat_id)
 
     try:
-        result = ask(message_text, role="support")
+        result = ask(message_text, role=resolve_role("telegram", message_text))
         answer = result.get("answer", "Sorry, I couldn't generate an answer.")
         record_last_reply("telegram", str(chat_id), result.get("role_memory_ids", []))
     except Exception as e:

--- a/channels/voice/router.py
+++ b/channels/voice/router.py
@@ -18,6 +18,7 @@ import logging
 
 from core.chat import ask
 from core.employees.feedback import record_last_reply
+from core.employees.channel_roles import resolve_role
 from channels.voice.audio import transcribe_audio, text_to_speech
 from channels.voice.config import get_voice_config
 
@@ -165,7 +166,7 @@ async def handle_call(ws):
 
                     if transcript and len(transcript) > 2:
                         try:
-                            result = ask(transcript, role="support")
+                            result = ask(transcript, role=resolve_role("voice", transcript))
                             answer = result.get("answer", "Sorry, I couldn't generate an answer.")
                             record_last_reply("voice", stream_sid, result.get("role_memory_ids", []))
                         except Exception as e:

--- a/channels/whatsapp/router.py
+++ b/channels/whatsapp/router.py
@@ -20,6 +20,7 @@ from core.workflows import call_n8n_workflows
 from core.autonomy import process_approval_response
 from core.employees.feedback import record_last_reply, get_last_reply, detect_feedback_command
 from core.employees.triggers import detect_escalation_request
+from core.employees.channel_roles import resolve_role
 
 logger = logging.getLogger(__name__)
 
@@ -161,7 +162,7 @@ def handle_incoming_message(from_phone: str, message_text: str) -> str:
         # else: escalation not configured for this action/channel -- fall through to a normal answer
 
     try:
-        result = ask(message_text, role="support")
+        result = ask(message_text, role=resolve_role("whatsapp", message_text))
         answer = result.get("answer", "Sorry, I couldn't generate an answer.")
         record_last_reply("whatsapp", from_phone, result.get("role_memory_ids", []))
     except Exception as e:

--- a/core/api.py
+++ b/core/api.py
@@ -23,6 +23,7 @@ from core.employees import profile as employee_profile
 from core.employees import roles as employee_roles
 from core.employees import skills as employee_skills
 from core.employees import learning as employee_learning
+from core.employees import channel_roles as employee_channel_roles
 from core import workflows
 from core import autonomy
 
@@ -147,6 +148,10 @@ class RoleUpdateRequest(BaseModel):
     skill_tags: list[str] | None = None
     personality: str | None = None
     is_active: bool | None = None
+
+
+class ChannelRoleRequest(BaseModel):
+    role: str
 
 
 class MemoryFeedbackRequest(BaseModel):
@@ -496,6 +501,31 @@ def get_employee_role(role: str):
 def update_employee_role(role: str, req: RoleUpdateRequest):
     updates = {k: v for k, v in req.dict().items() if v is not None}
     return employee_roles.upsert_role(role, **updates)
+
+
+@app.get("/channels/{channel}/role")
+def get_channel_role_config(channel: str):
+    """
+    Get the owner-configured default AI Employee role for this channel
+    (falls back to 'support' if never explicitly set).
+    """
+    return {"channel": channel, "role": employee_channel_roles.get_channel_role(channel)}
+
+
+@app.post("/channels/{channel}/role")
+def set_channel_role_config(channel: str, req: ChannelRoleRequest):
+    """
+    Assign a default AI Employee role to this channel (e.g. telegram ->
+    manager, whatsapp -> support). Any of the 9 default roles or a
+    custom role created via PATCH /employees/{role} can be assigned --
+    this is a deliberate owner choice, unlike the automatic
+    intent-based routing which is restricted to customer-safe roles
+    only (see core/employees/channel_roles.py).
+    """
+    ok = employee_channel_roles.set_channel_role(channel, req.role)
+    if not ok:
+        raise HTTPException(status_code=500, detail="Failed to update channel role")
+    return {"channel": channel, "role": req.role}
 
 
 @app.get("/employees/{role}/context")

--- a/core/employees/channel_roles.py
+++ b/core/employees/channel_roles.py
@@ -1,0 +1,106 @@
+"""
+Owner-configurable default role per channel, plus a deterministic
+intent-based override for a safe subset of customer-facing roles.
+
+Design choice, stated plainly: automatic intent detection is
+deliberately scoped to roles already marked customer-facing in their
+own DEFAULT_ROLES channels config (support, sales, marketing) -- not
+extended to manager/ceo/hr/finance/operations/secretary, which carry
+internal business context (owner instructions, approval workflows,
+strategic info) that shouldn't be exposed to an arbitrary inbound
+message just because it happened to match a keyword. The owner can
+still explicitly assign any of the 9 roles as a channel's default via
+set_channel_role() -- that's a deliberate choice, not something
+triggered by untrusted text.
+
+This is the routing layer, not the role-creation layer: custom roles
+can already be created via PATCH /employees/{role} (see
+core/employees/roles.py::upsert_role) -- this module decides which
+role a given message actually reaches, which was the real missing
+piece, not the ability to define new roles.
+"""
+import logging
+from typing import Optional
+
+from core.employees._db import get_connection
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ROLE = "support"
+
+# Roles safe for automatic intent-based routing -- customer-facing only.
+INTENT_SAFE_ROLES = {"support", "sales", "marketing"}
+
+INTENT_KEYWORDS = {
+    "sales": {"price", "pricing", "buy", "purchase", "demo", "quote", "discount", "plan"},
+    "marketing": {"campaign", "promotion", "newsletter", "partnership", "collaborate"},
+}
+
+
+def get_channel_role(channel: str) -> str:
+    """Owner-configured default role for this channel, or 'support' if unset."""
+    conn = get_connection()
+    try:
+        cur = conn.cursor()
+        cur.execute("SELECT role FROM channel_role_config WHERE channel = %s", (channel,))
+        row = cur.fetchone()
+        cur.close()
+        return row[0] if row else DEFAULT_ROLE
+    except Exception as e:
+        logger.error(f"get_channel_role error: {e}")
+        return DEFAULT_ROLE
+    finally:
+        conn.close()
+
+
+def set_channel_role(channel: str, role: str) -> bool:
+    """Owner explicitly assigns a default role to a channel. Any of the 9 roles allowed here."""
+    conn = get_connection()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO channel_role_config (channel, role, updated_at)
+            VALUES (%s, %s, now())
+            ON CONFLICT (channel) DO UPDATE SET role = EXCLUDED.role, updated_at = now()
+            """,
+            (channel, role),
+        )
+        conn.commit()
+        cur.close()
+        return True
+    except Exception as e:
+        conn.rollback()
+        logger.error(f"set_channel_role error: {e}")
+        return False
+    finally:
+        conn.close()
+
+
+def detect_intent_role(message: str) -> Optional[str]:
+    """
+    Deterministic keyword match against a safe subset of customer-facing
+    roles only (see INTENT_SAFE_ROLES). Returns None if no strong match --
+    caller should fall back to the channel's configured default role.
+    """
+    if not message:
+        return None
+    normalized = message.strip().lower()
+    for role, keywords in INTENT_KEYWORDS.items():
+        if role not in INTENT_SAFE_ROLES:
+            continue
+        if any(kw in normalized for kw in keywords):
+            return role
+    return None
+
+
+def resolve_role(channel: str, message: str) -> str:
+    """
+    The actual routing decision a channel handler should use: an intent
+    match (safe roles only) takes priority, otherwise the channel's
+    configured default, otherwise 'support'.
+    """
+    intent_role = detect_intent_role(message)
+    if intent_role:
+        return intent_role
+    return get_channel_role(channel)

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -213,6 +213,15 @@ CREATE TABLE IF NOT EXISTS role_reply_log (
     PRIMARY KEY (channel, chat_id)
 );
 
+-- Owner-configured default AI Employee role per channel (e.g. telegram ->
+-- manager, whatsapp -> support). Falls back to 'support' when unset. See
+-- core/employees/channel_roles.py for the routing logic that uses this.
+CREATE TABLE IF NOT EXISTS channel_role_config (
+    channel     TEXT PRIMARY KEY,
+    role        TEXT NOT NULL DEFAULT 'support',
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
 -- CSV connector content storage — no persistent disk volume exists in
 -- docker-compose.yml, so CSV content lives in Postgres like everything
 -- else in Core, rather than on the container filesystem.


### PR DESCRIPTION
Closes the real gap keeping 8 of 9 AI Employee roles unreachable: every channel hardcoded role="support". Adds owner-configurable per-channel defaults (any role) plus deterministic intent detection restricted to customer-safe roles only (support/sales/marketing) -- manager/ceo/hr/finance/operations/secretary are deliberately excluded from automatic routing since they carry internal business context. Full reasoning in the module docstring. Live-verified end-to-end including the new API endpoints, see commit message.