### PR TITLE
feat(voice): wire feedback-command detection into the Voice channel

### DIFF
--- a/channels/voice/router.py
+++ b/channels/voice/router.py
@@ -17,7 +17,8 @@ import json
 import logging
 
 from core.chat import ask
-from core.employees.feedback import record_last_reply
+from core.employees.feedback import record_last_reply, get_last_reply, detect_feedback_command
+from core.employees.learning import record_role_memory_outcome
 from core.employees.channel_roles import resolve_role
 from channels.voice.audio import transcribe_audio, text_to_speech
 from channels.voice.config import get_voice_config
@@ -165,13 +166,20 @@ async def handle_call(ws):
                         transcript = ""
 
                     if transcript and len(transcript) > 2:
-                        try:
-                            result = ask(transcript, role=resolve_role("voice", transcript))
-                            answer = result.get("answer", "Sorry, I couldn't generate an answer.")
-                            record_last_reply("voice", stream_sid, result.get("role_memory_ids", []))
-                        except Exception as e:
-                            logger.error(f"Voice: error answering: {e}", exc_info=True)
-                            answer = "Sorry, something went wrong. Please try again."
+                        feedback = detect_feedback_command(transcript)
+                        if feedback is not None:
+                            last_ids = get_last_reply("voice", stream_sid)
+                            if last_ids:
+                                record_role_memory_outcome(last_ids, success=feedback)
+                            answer = "Thanks for the feedback!" if feedback else "Thanks, I'll do better next time."
+                        else:
+                            try:
+                                result = ask(transcript, role=resolve_role("voice", transcript))
+                                answer = result.get("answer", "Sorry, I couldn't generate an answer.")
+                                record_last_reply("voice", stream_sid, result.get("role_memory_ids", []))
+                            except Exception as e:
+                                logger.error(f"Voice: error answering: {e}", exc_info=True)
+                                answer = "Sorry, something went wrong. Please try again."
 
                         logger.info(f"Voice: answer: {answer[:120]}")
                         await speak_reply(ws, stream_sid, answer, cfg)


### PR DESCRIPTION
Wires `detect_feedback_command()` into the Voice channel's transcript-handling path, matching the existing WhatsApp/Telegram/Discord pattern from #195.

- On each transcribed utterance, checks for a feedback command first.
- If detected: looks up the last `role_memory_ids` recorded for that `stream_sid` via `get_last_reply("voice", stream_sid)`, calls `record_role_memory_outcome`, and speaks a short thanks — skipping the normal `ask()` call.
- If not detected: falls through to the existing answer flow unchanged.

Verified: patch applied via checksum-verified transfer, `py_compile` clean, diff reviewed manually before commit. Not yet live-tested against a real call — recommend a manual Twilio test call before merge if that's feasible, since this can't be exercised via the FastAPI TestClient the way HTTP-based channels were.