### PR TITLE
feat(integrations): add Slack connector (Phase A)

### DIFF
--- a/core/integrations/factory.py
+++ b/core/integrations/factory.py
@@ -7,6 +7,7 @@ from core.integrations.sql_connectors import MySQLConnector, PostgreSQLConnector
 from core.integrations.mongodb import MongoDBConnector
 from core.integrations.rest_api import RestAPIConnector
 from core.integrations.csv_connector import CSVConnector
+from core.integrations.slack_connector import SlackConnector
 from core.integrations.crm_connectors import (
     SalesforceConnector,
     HubSpotConnector,
@@ -26,6 +27,7 @@ CONNECTOR_MAP = {
     'shopify': ShopifyConnector,
     'google_sheets': GoogleSheetsConnector,
     'stripe': StripeConnector,
+    'slack': SlackConnector,
 }
 
 

--- a/core/integrations/slack_connector.py
+++ b/core/integrations/slack_connector.py
@@ -1,0 +1,88 @@
+"""
+Slack connector for RagLeap Core integrations.
+
+Uses Slack's Web API directly over HTTP (requests) rather than the
+slack_sdk package — consistent with RestAPIConnector's approach and
+avoids adding a new dependency for what is a plain bearer-token REST API.
+
+Field usage:
+    api_key         -> Bot User OAuth Token (starts with xoxb-)
+    api_endpoint    -> channel ID to fetch messages from (required only
+                       when query_template='messages')
+    query_template  -> resource type: 'channels' (default), 'users', or 'messages'
+"""
+import logging
+from typing import Dict, List, Tuple
+
+import requests
+
+from core.integrations.base import BaseDatabaseConnector
+
+logger = logging.getLogger(__name__)
+
+SLACK_API_BASE = "https://slack.com/api"
+
+
+class SlackConnector(BaseDatabaseConnector):
+    """Connector for Slack workspaces using the Slack Web API (Bot token)."""
+
+    def _headers(self) -> Dict[str, str]:
+        token = (self.data_source.api_key or '').strip()
+        if not token:
+            raise ValueError("Slack connector requires api_key (Bot User OAuth Token, starts with xoxb-)")
+        return {"Authorization": f"Bearer {token}"}
+
+    def _call(self, method: str, params: Dict = None) -> Dict:
+        resp = requests.get(f"{SLACK_API_BASE}/{method}", headers=self._headers(), params=params or {}, timeout=15)
+        resp.raise_for_status()
+        data = resp.json()
+        if not data.get("ok"):
+            raise ValueError(f"Slack API error ({method}): {data.get('error', 'unknown_error')}")
+        return data
+
+    def test_connection(self) -> Tuple[bool, str]:
+        try:
+            data = self._call("auth.test")
+            team = data.get("team", "unknown workspace")
+            user = data.get("user", "unknown bot")
+            return True, f"Slack connected: {user} in {team}"
+        except ValueError as e:
+            return False, str(e)
+        except Exception as e:
+            return False, f"Slack connection failed: {e}"
+
+    def fetch_data(self, user_identifier: str = None) -> List[Dict]:
+        resource = (self.data_source.query_template or 'channels').strip().lower() or 'channels'
+        try:
+            if resource == 'channels':
+                data = self._call("conversations.list", {"limit": 200, "types": "public_channel,private_channel"})
+                return data.get("channels", [])
+            elif resource == 'users':
+                data = self._call("users.list", {"limit": 200})
+                return data.get("members", [])
+            elif resource == 'messages':
+                channel_id = (self.data_source.api_endpoint or '').strip()
+                if not channel_id:
+                    raise ValueError("Slack 'messages' fetch requires api_endpoint (channel ID)")
+                data = self._call("conversations.history", {"channel": channel_id, "limit": 200})
+                messages = data.get("messages", [])
+                if user_identifier:
+                    messages = [m for m in messages if m.get("user") == user_identifier]
+                return messages
+            else:
+                raise ValueError(
+                    f"Unsupported Slack query_template: {resource}. Use 'channels', 'users', or 'messages'."
+                )
+        except ValueError:
+            raise
+        except Exception as e:
+            logger.error(f"SlackConnector.fetch_data error: {e}")
+            raise
+
+    def introspect_schema(self) -> Dict:
+        resources = ['channels', 'users', 'messages']
+        tables = [{'name': r, 'label': r.title(), 'columns': []} for r in resources]
+        return {'tables': tables, 'filtered_count': 0}
+
+    def execute_query(self, query: str) -> List[Dict]:
+        return self.fetch_data()

--- a/tests/test_slack_connector.py
+++ b/tests/test_slack_connector.py
@@ -1,0 +1,90 @@
+"""
+Tests for core/integrations/slack_connector.py — the Slack Web API connector.
+Pure unit tests against a mocked requests.get; no live Slack workspace or
+DB needed (unlike test_autonomy.py, this connector talks to an external
+API, not Postgres, so there's nothing to fixture-reset).
+"""
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from core.integrations.slack_connector import SlackConnector
+from core.integrations.base import DataSource
+
+
+def _mock_response(payload):
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = payload
+    return resp
+
+
+def test_missing_token_fails_gracefully():
+    ds = DataSource(id="1", name="test", source_type="slack", api_key=None)
+    ok, msg = SlackConnector(ds).test_connection()
+    assert ok is False
+    assert "api_key" in msg
+
+
+def test_connection_success():
+    ds = DataSource(id="1", name="test", source_type="slack", api_key="xoxb-fake")
+    with patch("core.integrations.slack_connector.requests.get") as mock_get:
+        mock_get.return_value = _mock_response({"ok": True, "team": "TestCo", "user": "ragleap-bot"})
+        ok, msg = SlackConnector(ds).test_connection()
+    assert ok is True
+    assert "TestCo" in msg
+
+
+def test_slack_api_error_surfaces_message():
+    ds = DataSource(id="1", name="test", source_type="slack", api_key="xoxb-fake")
+    with patch("core.integrations.slack_connector.requests.get") as mock_get:
+        mock_get.return_value = _mock_response({"ok": False, "error": "invalid_auth"})
+        ok, msg = SlackConnector(ds).test_connection()
+    assert ok is False
+    assert "invalid_auth" in msg
+
+
+def test_fetch_channels_default():
+    ds = DataSource(id="1", name="test", source_type="slack", api_key="xoxb-fake")
+    with patch("core.integrations.slack_connector.requests.get") as mock_get:
+        mock_get.return_value = _mock_response({"ok": True, "channels": [{"id": "C1", "name": "general"}]})
+        data = SlackConnector(ds).fetch_data()
+    assert data == [{"id": "C1", "name": "general"}]
+
+
+def test_fetch_users():
+    ds = DataSource(id="1", name="test", source_type="slack", api_key="xoxb-fake", query_template="users")
+    with patch("core.integrations.slack_connector.requests.get") as mock_get:
+        mock_get.return_value = _mock_response({"ok": True, "members": [{"id": "U1", "name": "alice"}]})
+        data = SlackConnector(ds).fetch_data()
+    assert data == [{"id": "U1", "name": "alice"}]
+
+
+def test_fetch_messages_requires_channel_id():
+    ds = DataSource(id="1", name="test", source_type="slack", api_key="xoxb-fake", query_template="messages")
+    with pytest.raises(ValueError, match="api_endpoint"):
+        SlackConnector(ds).fetch_data()
+
+
+def test_fetch_messages_filters_by_user():
+    ds = DataSource(
+        id="1", name="test", source_type="slack", api_key="xoxb-fake",
+        query_template="messages", api_endpoint="C123",
+    )
+    with patch("core.integrations.slack_connector.requests.get") as mock_get:
+        mock_get.return_value = _mock_response({
+            "ok": True,
+            "messages": [{"user": "U1", "text": "hi"}, {"user": "U2", "text": "hey"}],
+        })
+        data = SlackConnector(ds).fetch_data(user_identifier="U1")
+    assert data == [{"user": "U1", "text": "hi"}]
+
+
+def test_unsupported_query_template_raises():
+    ds = DataSource(id="1", name="test", source_type="slack", api_key="xoxb-fake", query_template="bogus")
+    with pytest.raises(ValueError, match="Unsupported Slack query_template"):
+        SlackConnector(ds).fetch_data()


### PR DESCRIPTION
Adds a Slack connector for RagLeap Core's data-source integrations, closing one of the 8 connectors requested in Discussion #169 / issue #27.

**Pattern:** Follows `HubSpotConnector`/`StripeConnector` (bearer-token auth via `api_key`), but uses plain `requests` like `RestAPIConnector` rather than pulling in `slack_sdk` — Slack's Web API is a simple REST API, so no new dependency needed.

**Field usage:**
- `api_key` — Bot User OAuth Token (`xoxb-...`)
- `api_endpoint` — channel ID (only required when `query_template='messages'`)
- `query_template` — `'channels'` (default), `'users'`, or `'messages'`

**Testing:** 8 unit tests against a mocked Slack Web API (`tests/test_slack_connector.py`) covering missing-token handling, successful auth, Slack-side API errors, each resource type, user-filtered message fetching, and an unsupported `query_template`. Full `tests/` suite (17 tests) verified passing locally. Registered in `factory.py`'s `CONNECTOR_MAP` under `'slack'`.