### PR TITLE
docs(readme): v0.3.0 visual refresh + autonomous-agent positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,22 @@
-# RagLeap Core
+# RagLeap Core 🧠 — Autonomous AI Agents, Self-Hosted
 
-**The open-source AI business manager. 9 AI Employees, One AI Manager, one memory.**
+<div align="center">
+  <img src="assets/banner.svg" alt="RagLeap Core — Autonomous AI Agents, Self-Hosted" width="900">
+</div>
 
-RagLeap Core is the open-source engine behind RagLeap — a self-hosted, agentic system with 9 role-based AI Employees (AI Manager, Personal Secretary, Customer Support, Telecaller, DB Analyst, Broadcast Agent, Personal Assistant, AI COO, AI Engineer) with self-learning memory, auto-trigger workflows, full/semi autonomy and think-act-decide capacity that run your business from your own documents on your own server, with no vendor lock-in.
-
-[Quickstart](#quickstart) · [Docs](https://docs.ragleap.com) · [Website](https://ragleap.com) · [Hosted Version](https://ragleap.com) · [Packages](https://packages.ragleap.com/)
+<div align="center">
 
 [![license MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE) [![status 9 AI employees + AI manager + multi-channel + integrations + KG + self-learning](https://img.shields.io/badge/status-9%20AI%20employees%20%2B%20AI%20manager%20%2B%20multi--channel%20%2B%20integrations%20%2B%20KG%20%2B%20self--learning-brightgreen)](https://github.com/antonyrag/ragleap-core)
-[![Core Release](https://img.shields.io/badge/ragleap--core-v0.2.0-blue)](https://github.com/antonyrag/ragleap-core/releases/tag/v0.2.0)
+[![Core Release](https://img.shields.io/badge/ragleap--core-v0.3.0-blue)](https://github.com/antonyrag/ragleap-core/releases/tag/v0.3.0)
 [![PyPI ragleap-rag](https://img.shields.io/pypi/v/ragleap-rag?label=ragleap-rag)](https://pypi.org/project/ragleap-rag/) [![Downloads](https://img.shields.io/pepy/dt/ragleap-rag?label=downloads)](https://pypi.org/project/ragleap-rag/)
 [![PyPI ragleap-graph](https://img.shields.io/pypi/v/ragleap-graph?label=ragleap-graph)](https://pypi.org/project/ragleap-graph/) [![Downloads](https://img.shields.io/pepy/dt/ragleap-graph?label=downloads)](https://pypi.org/project/ragleap-graph/)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://github.com/antonyrag/ragleap-core)
+
+</div>
+
+RagLeap Core is the open-source engine behind RagLeap — a self-hosted, agentic system of 9 role-based AI Employees (AI Manager, Personal Secretary, Customer Support, Telecaller, DB Analyst, Broadcast Agent, Personal Assistant, AI COO, AI Engineer) that think, decide, and act on their own: self-learning memory, auto-trigger workflows, full/semi autonomy, and a think-act-decide loop that runs your business from your own documents on your own server, with no vendor lock-in.
+
+[Quickstart](#quickstart) · [Docs](https://docs.ragleap.com) · [Website](https://ragleap.com) · [Hosted Version](https://ragleap.com) · [Packages](https://packages.ragleap.com/)
 
 ---
 

--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -1,0 +1,29 @@
+<svg viewBox="0 0 920 220" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="iconGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2563eb"/>
+      <stop offset="100%" stop-color="#0891b2"/>
+    </linearGradient>
+  </defs>
+
+  <!-- card background -->
+  <rect x="1" y="1" width="918" height="218" rx="14" fill="#f6f8fa" stroke="#d0d7de" stroke-width="1"/>
+
+  <!-- icon: circular mark with a leaping arc + node, evoking "RAG" (retrieval nodes) + "Leap" (arc) -->
+  <g transform="translate(60, 40)">
+    <circle cx="70" cy="70" r="70" fill="url(#iconGrad)"/>
+    <!-- leap arc -->
+    <path d="M 28 96 Q 70 28 112 96" fill="none" stroke="#ffffff" stroke-width="9" stroke-linecap="round"/>
+    <!-- three nodes representing linked documents / retrieval -->
+    <circle cx="28" cy="96" r="9" fill="#ffffff"/>
+    <circle cx="70" cy="52" r="9" fill="#ffffff"/>
+    <circle cx="112" cy="96" r="9" fill="#ffffff"/>
+  </g>
+
+  <!-- wordmark + tagline -->
+  <g transform="translate(230, 0)">
+    <text x="0" y="98" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="56" font-weight="700" fill="#1f2328">RagLeap Core</text>
+    <text x="2" y="132" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="22" font-weight="700" letter-spacing="1" fill="#0891b2">AUTONOMOUS AI AGENTS. NOT JUST RAG.</text>
+    <text x="2" y="164" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="18" fill="#57606a">Self-hosted AI Employees with memory, autonomy, and real actions.</text>
+  </g>
+</svg>


### PR DESCRIPTION
Restructures the README header to a centered banner + badges layout (matching OpenClaw/LangChain-style presentation), and updates the Core Release badge to v0.3.0.

**Visual:** New `assets/banner.svg` — self-contained SVG card (icon + wordmark + tagline), centered above a centered badge row, following the H1 → banner → badges → description → links order.

**Positioning:** Tagline now reads "Autonomous AI Agents. Not Just RAG." — reflects the actual feature set (memory, autonomy modes, escalation triggers, think-act-decide loop) that the RAG framing was underselling.

**Version:** v0.2.0 -> v0.3.0, covering everything merged since the last tag: outcome-weighted memory (#189/#190/#195), escalation trigger (#198), channel-role routing (#191/#201), voice feedback wiring (#208), Slack connector (#209), plus external APScheduler sync (#196).