### PR TITLE
fix: open issue 184

### DIFF
--- a/packages/ragleap-graph/docs/adr/0001-backup-restore-ownership.md
+++ b/packages/ragleap-graph/docs/adr/0001-backup-restore-ownership.md
@@ -1,0 +1,159 @@
+# ADR-0001: Backup/Restore Ownership for ragleap-graph
+
+| Field        | Value                                                    |
+|--------------|----------------------------------------------------------|
+| **Status**   | Proposed (pending maintainer sign-off)                   |
+| **Date**     | 2026-08-27                                               |
+| **Context**  | Issue: missing backup/restore tooling for Neo4j graph    |
+| **Relates**  | `docs/operations/backup-and-restore.md`, `docs/design/schema-migrations.md` |
+
+---
+
+## Context and problem statement
+
+`ragleap-graph` stores knowledge-graph data in Neo4j but provides no
+backup or restore functionality. As the library adds schema migrations
+(e.g., `backfill_user_id_defaults()` in v0.6.5, `backfill_composite_key()`
+in v0.6.7), operators need a reliable way to snapshot the graph before
+running potentially destructive changes. The core question is:
+
+**Should backup/restore be `ragleap-graph`'s own responsibility (built
+into the library), or should it be explicitly out of scope (delegated to
+Neo4j's native tooling and the operator's infrastructure)?**
+
+---
+
+## Decision drivers
+
+1. **Maintenance burden**: `neo4j-admin database dump/load` is a
+   mature, well-tested tool maintained by Neo4j Inc. Building a Python
+   wrapper around it means maintaining compatibility across Neo4j 4.x
+   and 5.x, Community and Enterprise editions, Docker and bare-metal
+   deployments, and across `neo4j-admin` CLI changes between versions.
+
+2. **Security and permission boundaries**: `neo4j-admin` operates on
+   the database files directly — it needs filesystem access to the Neo4j
+   data directory and typically requires the database to be stopped
+   (Community Edition). A Python library connecting via Bolt protocol
+   cannot orchestrate this without shell access to the Neo4j host, which
+   is a fundamentally different privilege level than "connect and query."
+
+3. **Footgun risk**: A library-managed backup that works for Docker
+   Compose but fails silently for Kubernetes, bare-metal, or managed
+   Neo4j (Aura) deployments is worse than no backup — it gives a false
+   sense of safety. The operator who believes their backups are handled
+   is more vulnerable than the one who knows they aren't.
+
+4. **Scope alignment**: `ragleap-graph` is a knowledge-graph *retrieval*
+   library (`pyproject.toml`: `Development Status :: 3 - Alpha`). Its
+   core value proposition is entity extraction, graph construction, and
+   graph-augmented retrieval — not database administration. Adding DBA
+   tooling expands the maintenance surface without improving the core
+   use case.
+
+5. **Precedent within the ecosystem**: `ragleap-rag` (the sibling
+   package) stores data in Postgres but does not wrap `pg_dump` /
+   `pg_restore`. It provides `init_schema()` for table creation but
+   delegates all backup/restore to the operator's Postgres
+   infrastructure. Consistency across the ecosystem argues for the same
+   pattern.
+
+---
+
+## Options considered
+
+### Option 1: Built-in Python backup orchestration
+
+Wrap `neo4j-admin dump/load` (or use APOC export procedures) in a
+Python API on `GraphIndex`, e.g.:
+
+```python
+graph.backup(path="/backups/pre-migration.dump")
+graph.restore(path="/backups/pre-migration.dump")
+```
+
+**Pros:**
+- Single-command backup from the same Python process running migrations.
+- Lower barrier for operators unfamiliar with `neo4j-admin`.
+
+**Cons:**
+- Requires shell access to the Neo4j host (subprocess calls or SSH),
+  fundamentally different from Bolt-protocol access.
+- `neo4j-admin` CLI syntax differs between Neo4j 4.x and 5.x, Community
+  and Enterprise, making the wrapper fragile.
+- Docker deployments require `docker exec` into the container — the
+  Python library has no way to know the container name/ID.
+- Managed Neo4j (Aura) does not expose `neo4j-admin` at all.
+- APOC-based exports (`apoc.export.*`) are not available by default
+  (`NEO4J_PLUGINS: '[]'` in the project's `docker-compose.yml`) and
+  produce Cypher/JSON/CSV, not a full database-consistent dump.
+- Significant ongoing maintenance burden for a non-core feature.
+- False sense of safety if the wrapper works in dev but fails in prod.
+
+### Option 2: Documentation + native tooling (recommended)
+
+Provide a clear operational guide (`docs/operations/backup-and-restore.md`)
+documenting the recommended manual procedure using `neo4j-admin`, and
+explicitly declare that `ragleap-graph` does not own this lifecycle.
+
+**Pros:**
+- Zero maintenance burden — Neo4j maintains the tooling.
+- Works across all deployment models (Docker, bare-metal, Kubernetes,
+  managed).
+- Honest about the library's scope — operators know they own this.
+- Pre-migration checklist in the docs creates a clear operational ritual.
+- Consistent with `ragleap-rag`'s approach to Postgres backup.
+
+**Cons:**
+- Higher barrier for operators unfamiliar with `neo4j-admin`.
+- Risk of operators skipping the backup step before migrations (but this
+  risk exists regardless — a built-in backup that the operator forgets
+  to call is equally useless).
+
+---
+
+## Recommendation
+
+**Option 2: Documentation + native tooling.**
+
+The library should:
+
+1. **Ship `docs/operations/backup-and-restore.md`** (done) with a
+   concrete, tested procedure for offline dump and restore.
+2. **Reference the backup doc prominently** in migration error messages
+   and the proposed `MigrationRunner`'s output.
+3. **Not wrap or invoke `neo4j-admin`** from Python code.
+4. **Explicitly state** in the README and migration docs that backup is
+   the operator's responsibility, not the library's.
+
+This recommendation is framed for maintainer sign-off — it should be
+adopted, amended, or rejected by the project maintainer, not treated as
+a unilateral decision.
+
+---
+
+## Consequences
+
+### If accepted
+
+- `ragleap-graph` gains operational documentation but no new Python code
+  for backup/restore.
+- The `MigrationRunner` (per `schema-migrations.md`) will include
+  guidance to dump before migrating, but will not enforce or automate it.
+- Future issues requesting "add a backup button" can be closed with a
+  reference to this ADR and the operational docs.
+
+### If rejected (in favor of Option 1)
+
+- A new `ragleap_graph.backup` module would need to be scoped, covering:
+  which deployment models to support, how to discover the Neo4j
+  container/process, how to handle `neo4j-admin` version differences,
+  and what the testing strategy is across all of these.
+- The issue explicitly lists "do NOT implement a full backup product or
+  wrap `neo4j-admin`" as a non-goal, so rejecting this ADR in favor of
+  Option 1 would need a scope change justification.
+
+---
+
+*This ADR follows the format from
+[Michael Nygard's article](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions).*

--- a/packages/ragleap-graph/docs/design/schema-migrations.md
+++ b/packages/ragleap-graph/docs/design/schema-migrations.md
@@ -1,0 +1,598 @@
+# Schema Migrations — Design Proposal for ragleap-graph
+
+> **Status: Proposal.**
+> This document proposes a lightweight migration framework for
+> `ragleap-graph`'s Neo4j schema. It is a design artifact for maintainer
+> review, not an implemented feature. No code changes are required to
+> ship this document.
+
+---
+
+## 1. Problem statement
+
+`ragleap-graph` has two existing bespoke migrations:
+
+1. **`backfill_user_id_defaults()`** (v0.6.5) — backfills `user_id=""`
+   onto nodes written before `user_id=` support existed.
+2. **`backfill_composite_key()`** (v0.6.7) — backfills `composite_key`
+   onto nodes written before the concurrency fix (issue #183).
+
+Both are idempotent, manually invoked methods on `GraphIndex`. Neither
+tracks whether it has already been run — callers must know to run them,
+and re-running is harmless but wasteful. There is **no** migration
+runner, version table, or schema-tracking mechanism anywhere in the
+codebase (confirmed by searching for `_Migration`, `schema_version`,
+`migration_runner`, and similar patterns across all source files).
+
+As the schema evolves, each new migration requires a new bespoke method
+on `GraphIndex`, its own idempotency logic, its own documentation, and
+its own test coverage — all duplicated patterns. This proposal
+standardizes the pattern so a future contributor can add a migration in
+under 20 lines.
+
+---
+
+## 2. Proposed `Migration` interface
+
+```python
+from abc import ABC, abstractmethod
+from neo4j import Session
+from datetime import datetime
+from typing import Optional
+
+
+class Migration(ABC):
+    """Base class for a single schema migration step."""
+
+    @property
+    @abstractmethod
+    def id(self) -> str:
+        """Unique, sortable migration identifier.
+
+        Convention: 'NNNN_short_description', e.g. '0001_backfill_user_id'.
+        Migrations are applied in lexicographic order of their id.
+        """
+        ...
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Human-readable description of what this migration does."""
+        ...
+
+    @abstractmethod
+    def up(self, session: Session) -> dict:
+        """Apply the migration forward.
+
+        Args:
+            session: An open Neo4j session. The migration owns its own
+                     transaction boundaries within this session.
+
+        Returns:
+            A dict of migration-specific results (e.g. node counts updated).
+            This is logged alongside the migration record for auditability.
+
+        Raises:
+            Any exception — the runner treats all exceptions as hard
+            failures and does NOT proceed to the next migration.
+        """
+        ...
+
+    def down(self, session: Session) -> dict:
+        """Reverse the migration (optional).
+
+        Most graph migrations are not safely reversible (you can't
+        un-backfill a property without knowing what the "before" state
+        was). The default implementation raises NotImplementedError.
+        See Section 7 for the full rationale on rollback strategy.
+        """
+        raise NotImplementedError(
+            f"Migration {self.id} does not support down(). "
+            f"Restore from a database dump instead — see "
+            f"docs/operations/backup-and-restore.md"
+        )
+
+    def is_applied(self, session: Session) -> bool:
+        """Check whether this migration has already been applied.
+
+        Default implementation checks for a :_Migration node with
+        matching id. Override only if the migration needs a different
+        idempotency check (e.g. checking whether the property it
+        backfills already exists on all target nodes).
+        """
+        result = session.run(
+            "MATCH (m:_Migration {id: $id}) RETURN count(m) > 0 AS applied",
+            id=self.id,
+        )
+        return result.single()["applied"]
+```
+
+### Design notes
+
+- **Neo4j `Session` as the boundary**, not `Transaction`. Each migration
+  manages its own transaction boundaries because some migrations need
+  multiple read-then-write passes (e.g. `backfill_composite_key()`
+  reads all nodes, computes keys in Python, then writes back in batches).
+  A single Neo4j transaction spanning all of that would hold locks for
+  too long and risk deadlocks under concurrent access.
+
+- **`id` is a string, not an integer.** String IDs (`0001_...`,
+  `0002_...`) are lexicographically sortable and more descriptive in
+  logs and the graph itself. This matches the convention used by Django
+  migrations, Alembic, and similar frameworks.
+
+- **`down()` is optional and defaults to `NotImplementedError`.** This
+  is a deliberate design choice — see Section 7 for the full rationale.
+
+---
+
+## 3. Migration state tracking
+
+Migration state is tracked **inside the Neo4j graph itself**, using
+`:_Migration` nodes:
+
+```cypher
+CREATE (m:_Migration {
+    id: "0001_backfill_user_id",
+    description: "Backfill user_id='' onto pre-v0.6.5 nodes",
+    applied_at: datetime(),
+    execution_time_ms: 1234,
+    result: '{"Entity": 42, "Document": 10, ...}'
+})
+```
+
+### Why in-graph, not an external file or table?
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **`:_Migration` node in Neo4j** | Co-located with the data it describes; survives dump/restore round-trips; no additional infrastructure | Couples migration tracking to Neo4j availability |
+| **External file (e.g. `.migrations.json`)** | No Neo4j dependency for tracking | Can desync from the actual database state; not included in dump/restore |
+| **Postgres table** | Already available (audit log uses Postgres) | Forces a hard Postgres dependency for graph-only users; cross-database consistency problem |
+
+**Recommendation: `:_Migration` node.** The key advantage is that
+dump/restore (per `backup-and-restore.md`) preserves migration state
+automatically — if you restore a pre-migration dump, the `:_Migration`
+nodes are gone too, so the runner correctly re-applies them.
+
+### Schema for `:_Migration` nodes
+
+| Property           | Type       | Description                                        |
+|--------------------|------------|----------------------------------------------------|
+| `id`               | `String`   | Migration identifier, matches `Migration.id`       |
+| `description`      | `String`   | Human-readable description                         |
+| `applied_at`       | `DateTime` | When the migration was applied (Neo4j `datetime()`) |
+| `execution_time_ms`| `Integer`  | Wall-clock time to execute `up()`                   |
+| `result`           | `String`   | JSON-serialized return value of `up()`              |
+
+The `:_Migration` label is prefixed with `_` to signal it's internal
+infrastructure, consistent with `ragleap-graph`'s convention of treating
+`_`-prefixed names as non-public (see `VERSIONING.md`).
+
+---
+
+## 4. `MigrationRunner` architecture
+
+```python
+import json
+import time
+import logging
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+
+class MigrationRunner:
+    """Discovers and applies pending migrations in order."""
+
+    def __init__(self, driver, migrations: List[Migration]):
+        """
+        Args:
+            driver: An active neo4j.Driver instance. Must not be None.
+            migrations: All known migrations, in the order they should
+                        be applied. The runner sorts by id internally,
+                        but passing them pre-sorted is conventional.
+        """
+        if driver is None:
+            raise RuntimeError(
+                "MigrationRunner requires an active Neo4j driver. "
+                "Cannot run migrations without a database connection."
+            )
+        self.driver = driver
+        self.migrations = sorted(migrations, key=lambda m: m.id)
+
+    def run_pending(self, *, dry_run: bool = False) -> List[dict]:
+        """Apply all pending migrations in order.
+
+        Args:
+            dry_run: If True, report which migrations would run without
+                     actually executing them.
+
+        Returns:
+            A list of result dicts, one per migration applied (or that
+            would be applied in dry_run mode).
+
+        Raises:
+            RuntimeError: If any migration fails. The runner does NOT
+                         continue to the next migration after a failure.
+                         See Section 7 for recovery guidance.
+        """
+        results = []
+
+        with self.driver.session() as session:
+            for migration in self.migrations:
+                if migration.is_applied(session):
+                    logger.debug(f"Migration {migration.id} already applied, skipping")
+                    continue
+
+                if dry_run:
+                    logger.info(f"[DRY RUN] Would apply: {migration.id} — {migration.description}")
+                    results.append({
+                        "id": migration.id,
+                        "description": migration.description,
+                        "status": "pending",
+                    })
+                    continue
+
+                logger.info(f"Applying migration: {migration.id} — {migration.description}")
+                start_ms = time.monotonic_ns() // 1_000_000
+
+                try:
+                    result = migration.up(session)
+                except Exception as e:
+                    logger.error(
+                        f"Migration {migration.id} FAILED: {e}",
+                        exc_info=True,
+                    )
+                    raise RuntimeError(
+                        f"Migration {migration.id} failed: {e}. "
+                        f"The runner has stopped. No subsequent migrations "
+                        f"have been applied. If the graph is in a partial "
+                        f"state, restore from a pre-migration dump — see "
+                        f"docs/operations/backup-and-restore.md"
+                    ) from e
+
+                elapsed_ms = (time.monotonic_ns() // 1_000_000) - start_ms
+
+                # Record the migration as applied
+                session.run(
+                    """
+                    CREATE (m:_Migration {
+                        id: $id,
+                        description: $description,
+                        applied_at: datetime(),
+                        execution_time_ms: $elapsed_ms,
+                        result: $result_json
+                    })
+                    """,
+                    id=migration.id,
+                    description=migration.description,
+                    elapsed_ms=elapsed_ms,
+                    result_json=json.dumps(result, default=str),
+                )
+
+                logger.info(
+                    f"Migration {migration.id} applied successfully "
+                    f"in {elapsed_ms}ms: {result}"
+                )
+                results.append({
+                    "id": migration.id,
+                    "description": migration.description,
+                    "status": "applied",
+                    "elapsed_ms": elapsed_ms,
+                    "result": result,
+                })
+
+        return results
+
+    def status(self) -> List[dict]:
+        """Report the status of all known migrations."""
+        statuses = []
+        with self.driver.session() as session:
+            for migration in self.migrations:
+                applied = migration.is_applied(session)
+                entry = {
+                    "id": migration.id,
+                    "description": migration.description,
+                    "applied": applied,
+                }
+                if applied:
+                    record = session.run(
+                        "MATCH (m:_Migration {id: $id}) "
+                        "RETURN m.applied_at AS applied_at, "
+                        "       m.execution_time_ms AS elapsed_ms",
+                        id=migration.id,
+                    ).single()
+                    if record:
+                        entry["applied_at"] = str(record["applied_at"])
+                        entry["elapsed_ms"] = record["elapsed_ms"]
+                statuses.append(entry)
+        return statuses
+```
+
+### Key design decisions
+
+1. **Fail-loud, fail-fast.** If a migration raises, the runner stops
+   immediately and raises `RuntimeError` with clear guidance. It does
+   **not** silently skip, swallow the error, or continue to the next
+   migration. This matches `ragleap-graph`'s existing philosophy — see
+   how `GraphIndex.__init__` calls `verify_connectivity()` eagerly
+   rather than failing silently on first use.
+
+2. **No automatic backup trigger.** The runner does not call
+   `neo4j-admin dump` or any backup tooling. It can't — `neo4j-admin`
+   requires filesystem access and typically database shutdown, which a
+   Python library running through the Bolt protocol cannot orchestrate.
+   Instead, the error message explicitly points operators to
+   `backup-and-restore.md`.
+
+   > [!IMPORTANT]
+   > **Open question for maintainers:** Should `run_pending()` log a
+   > prominent `WARNING` at the start reminding operators to dump first,
+   > or is the documentation reference in the error message sufficient?
+   > A warning-on-start is cheap insurance but could become noise for
+   > operators who always dump first.
+
+3. **`dry_run` mode.** Lets operators preview what would run before
+   committing. Low implementation cost, high operational value.
+
+4. **Single-session execution.** All migrations run within one driver
+   session (not one transaction — each migration manages its own
+   transaction boundaries). This keeps the runner simple while giving
+   migrations full control over batching.
+
+---
+
+## 5. Worked example: refactoring `backfill_user_id_defaults()`
+
+This shows what the existing `backfill_user_id_defaults()` (v0.6.5)
+**would look like** as a registered migration. This is a **design
+illustration, not a refactoring PR** — the existing method would
+continue to work as-is alongside the migration framework during a
+transition period.
+
+```python
+class Migration0001_BackfillUserIdDefaults(Migration):
+    """Backfill user_id='' onto pre-v0.6.5 nodes missing the property."""
+
+    @property
+    def id(self) -> str:
+        return "0001_backfill_user_id"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Backfill user_id='' onto Entity/Document/PairWeight/"
+            "RelationWeight nodes written before v0.6.5 user_id= support. "
+            "Without this, legacy nodes are invisible to find_* queries "
+            "and silently duplicated on re-upsert."
+        )
+
+    def up(self, session) -> dict:
+        counts = {}
+        for label in ["Entity", "Document", "PairWeight", "RelationWeight"]:
+            result = session.run(
+                f"""
+                MATCH (n:{label})
+                WHERE n.user_id IS NULL
+                SET n.user_id = ""
+                RETURN count(n) AS updated
+                """,
+            )
+            record = result.single()
+            counts[label] = record["updated"] if record else 0
+        return counts
+
+    # down() intentionally not implemented:
+    # Removing user_id from nodes that had it set to "" would break
+    # every query path that filters on coalesce(user_id, '') — the
+    # nodes would become invisible again, which is the exact bug this
+    # migration fixes. Restoring from a dump is the safe rollback path.
+```
+
+And the second existing migration:
+
+```python
+class Migration0002_BackfillCompositeKey(Migration):
+    """Backfill composite_key onto pre-v0.6.7 nodes for concurrency safety."""
+
+    @property
+    def id(self) -> str:
+        return "0002_backfill_composite_key"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Backfill composite_key (SHA256 hash of identity fields) onto "
+            "nodes written before v0.6.7. Required for the single-property "
+            "uniqueness constraints that close the concurrent-duplicate "
+            "race (issue #183)."
+        )
+
+    def up(self, session) -> dict:
+        # This would reuse the same logic as the current
+        # backfill_composite_key() method — read nodes missing
+        # composite_key, compute keys in Python via _composite_key(),
+        # write back in batches via elementId().
+        #
+        # The full implementation is identical to the existing method
+        # body at __init__.py L1304-L1403, just with `self` references
+        # replaced by direct session usage and _composite_key() import.
+        #
+        # Not duplicated here to keep this design doc honest about what
+        # it is (a proposal, not a refactoring PR).
+        raise NotImplementedError("Worked example — see __init__.py L1304-L1403")
+
+    # down() intentionally not implemented:
+    # Removing composite_key would leave nodes outside the uniqueness
+    # constraint, re-exposing the concurrency bug (issue #183).
+```
+
+### Registration
+
+```python
+# In a future ragleap_graph/migrations/__init__.py (or similar)
+
+ALL_MIGRATIONS = [
+    Migration0001_BackfillUserIdDefaults(),
+    Migration0002_BackfillCompositeKey(),
+]
+```
+
+### Usage
+
+```python
+from ragleap_graph import GraphIndex, GraphConfig
+from ragleap_graph.migrations import ALL_MIGRATIONS, MigrationRunner
+
+graph = GraphIndex(config=GraphConfig(...))
+runner = MigrationRunner(graph.driver, ALL_MIGRATIONS)
+
+# Preview what would run
+pending = runner.run_pending(dry_run=True)
+print(f"{len(pending)} migrations pending")
+
+# Apply (after taking a dump per backup-and-restore.md)
+results = runner.run_pending()
+```
+
+---
+
+## 6. Concurrency assumptions
+
+> [!WARNING]
+> **Migrations are NOT safe to run concurrently with application writes.**
+> Run migrations during a maintenance window with `upsert_document()`
+> traffic stopped. See issue #183 for the broader concurrency context.
+
+Specific concerns:
+
+1. **`backfill_user_id_defaults()`** writes `SET n.user_id = ""` to nodes
+   where `user_id IS NULL`. A concurrent `upsert_document()` could race
+   to create a new node without `user_id` between the migration's read
+   and write, leaving that node un-backfilled. Since the migration is
+   idempotent, re-running it after the write window closes is safe — but
+   the operator must know to do so.
+
+2. **`backfill_composite_key()`** reads all nodes missing `composite_key`,
+   computes keys in Python, and writes them back in batches. A concurrent
+   write creating a new node without `composite_key` between read and
+   write would be missed. The same re-run solution applies.
+
+3. **The `MigrationRunner` itself** is not re-entrant. Two runners
+   executing concurrently could both see the same migration as "not
+   applied" and both attempt to run it. Since migrations are idempotent,
+   this is wasteful but not corrupting — however, both would create
+   `:_Migration` tracking nodes, leaving duplicates. A future
+   enhancement could add a uniqueness constraint on `:_Migration.id` to
+   prevent this, but it's not worth the complexity until there's a real
+   multi-instance deployment pattern that would trigger it.
+
+**Recommended operational pattern:**
+
+```
+1. Stop application traffic
+2. Dump the database (per backup-and-restore.md)
+3. Run migrations
+4. Verify (health_check + spot-check node counts)
+5. Resume application traffic
+```
+
+---
+
+## 7. Restore-mid-migration: failure and recovery strategy
+
+### What happens if a migration fails partway?
+
+**Proposed approach: Fail-fast + restore from dump.**
+
+The runner stops immediately on any exception. It does **not** attempt
+to roll back via `down()`, resume from a partial state, or continue to
+the next migration.
+
+### Why not automated rollback via `down()`?
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **Automated `down()` on failure** | Clean, self-contained recovery | Graph mutations are rarely cleanly reversible — `SET user_id = ""` can't be undone without knowing the "before" state (which was `NULL`, but how do you distinguish "was NULL before migration" from "was NULL because it was just created"?). Partial `down()` execution is itself a failure mode. |
+| **Resume from partial state** | No data loss, no dump needed | Requires tracking per-node progress within a migration, dramatically increases complexity. Violates the "under 20 lines" design goal. |
+| **Fail-fast + dump restore** (recommended) | Simple, reliable, leverages existing tooling | Requires operator to have taken a dump first (which they should always do). Longer recovery time for very large graphs. |
+
+**Recommendation: Fail-fast + dump restore.** This is the right choice
+for `ragleap-graph`'s current scale and maturity:
+
+1. The library is pre-1.0 (`Development Status :: 3 - Alpha`).
+2. Existing deployments are small enough that dump/restore takes seconds
+   to low minutes.
+3. Both existing migrations are idempotent — a restored-then-re-run
+   cycle is safe and tested.
+4. Building a resume-capable or rollback-capable runner would be
+   significant engineering for a problem that hasn't occurred yet.
+
+### Recovery procedure
+
+When `run_pending()` raises `RuntimeError`:
+
+1. **Read the error message.** It identifies which migration failed and
+   includes the original exception.
+2. **Assess the damage.** The graph may be in a partial state (e.g.,
+   half the nodes have been backfilled). This is not corruption — it's
+   an incomplete migration.
+3. **Decide: retry or restore.**
+   - If the failure was transient (e.g., Neo4j ran out of memory on a
+     large batch), you can re-run the migration. Idempotent migrations
+     will skip already-processed nodes.
+   - If the failure was a bug in the migration itself, restore from the
+     pre-migration dump (see `backup-and-restore.md`), fix the
+     migration, and re-run.
+4. **After a successful restore**, the `:_Migration` tracking nodes are
+   also restored to their pre-migration state (since they're in the same
+   dump), so `run_pending()` will correctly re-apply the failed migration.
+
+---
+
+## 8. Future considerations (not proposed for v1)
+
+- **CLI entry point**: `python -m ragleap_graph.migrate` for operators
+  who prefer command-line invocation over Python scripts.
+- **Namespace-scoped migrations**: Some migrations (like both current
+  ones) accept `namespace=` to scope the backfill. The `Migration`
+  interface could support this via an optional constructor parameter.
+- **Uniqueness constraint on `:_Migration.id`**: Prevents duplicate
+  tracking nodes from concurrent runner executions (see Section 6).
+- **Pre-migration health checks**: A `check()` method on `Migration`
+  that validates preconditions (e.g., "expected node label exists")
+  before running `up()`.
+- **Integration with `AuditLogger`**: Log migration events to the audit
+  table alongside normal operation audits.
+
+---
+
+## 9. Open questions for maintainers
+
+1. **Should `run_pending()` log a backup warning?** A `WARNING`-level
+   log at the start of `run_pending()` saying "ensure you have a
+   database dump before proceeding" is cheap insurance. Alternatively,
+   the runner could accept a `--i-have-a-backup` flag and refuse to run
+   without it. Both are lightweight; the question is whether the nudge
+   is helpful or annoying.
+
+2. **Where should migration classes live?** Options:
+   - `ragleap_graph/migrations/` (a new subpackage)
+   - `ragleap_graph/_migrations.py` (single file, `_`-prefixed as internal)
+   - Alongside `__init__.py` as `ragleap_graph/schema_migrations.py`
+
+3. **Should the existing `backfill_*()` methods be deprecated once the
+   framework ships?** They could remain as convenience wrappers that
+   internally delegate to the migration framework, or they could be left
+   as-is with a deprecation notice pointing to the runner.
+
+4. **Concurrency guard**: Should the runner attempt to acquire a Neo4j
+   lock (e.g., `MERGE (lock:_MigrationLock {active: true})`) to prevent
+   concurrent runner executions, or is the "run during maintenance
+   window" guidance sufficient?
+
+---
+
+*This is a design proposal, not an implementation commitment. See
+[ADR-0001](../adr/0001-backup-restore-ownership.md) for the related
+decision on backup/restore ownership.*

--- a/packages/ragleap-graph/docs/operations/backup-and-restore.md
+++ b/packages/ragleap-graph/docs/operations/backup-and-restore.md
@@ -1,0 +1,238 @@
+# Backup and Restore — ragleap-graph (Stopgap Procedure)
+
+> **Status: Stopgap.**
+> `ragleap-graph` does **not** currently orchestrate or automate Neo4j backups itself.
+> This document describes a recommended manual procedure using Neo4j's own
+> `neo4j-admin` tooling. It exists so operators have a clear, tested path
+> before running schema migrations or making destructive graph changes —
+> not because `ragleap-graph` manages this lifecycle for you.
+
+---
+
+## 1. Background
+
+`ragleap-graph` stores all knowledge-graph data (`:Entity`, `:Document`,
+`:PairWeight`, `:RelationWeight` nodes and their relationships) in a
+Neo4j database. The library itself has no backup/restore API — it
+delegates all data-at-rest management to Neo4j's native tooling.
+
+As of v0.6.7, the graph also contains per-label `composite_key` uniqueness
+constraints (created idempotently on every `GraphIndex` connect) and
+internal `:_Migration` tracking nodes (proposed — see
+[schema-migrations.md](../design/schema-migrations.md)). Both are part of
+the database state and are included in a full dump.
+
+---
+
+## 2. Where ragleap-graph expects Neo4j data to live
+
+### Docker Compose (default setup)
+
+From the project's `docker-compose.yml`:
+
+```yaml
+neo4j:
+  image: neo4j:5-community
+  volumes:
+    - ragleap_core_neo4j_data:/data
+```
+
+The named volume `ragleap_core_neo4j_data` maps to Neo4j's `/data`
+directory inside the container. Within that:
+
+| Path (inside container)          | Contents                              |
+|----------------------------------|---------------------------------------|
+| `/data/databases/neo4j/`         | The default database's store files    |
+| `/data/transactions/neo4j/`      | Transaction logs                      |
+
+### Bare-metal / self-managed Neo4j
+
+If you're running Neo4j outside Docker, the data directory is controlled
+by `server.directories.data` in `neo4j.conf` (typically
+`/var/lib/neo4j/data` on Linux, `C:\neo4j\data` on Windows). The
+database name is `neo4j` unless you've explicitly created a different one.
+
+### Environment variables
+
+`ragleap-graph` connects via `GraphConfig(uri=, user=, password=)`,
+typically sourced from environment variables:
+
+| Variable          | Default                   | Purpose                    |
+|-------------------|---------------------------|----------------------------|
+| `NEO4J_URI`       | `bolt://localhost:7687`   | Bolt protocol endpoint     |
+| `NEO4J_USER`      | `neo4j`                   | Authentication username    |
+| `NEO4J_PASSWORD`  | *(empty)*                 | Authentication password    |
+
+These are connection-level settings only — the backup procedure operates
+on the database files, not through the Bolt protocol.
+
+---
+
+## 3. Online vs. offline dump tradeoffs
+
+| Approach | Command | Requires DB shutdown? | Neo4j Edition | Consistency guarantee |
+|---|---|---|---|---|
+| **Offline dump** | `neo4j-admin database dump` | **Yes** — database must be stopped | Community + Enterprise | Full — no concurrent writes during dump |
+| **Online dump** | `neo4j-admin database dump --to-stdout` (4.x) or backup commands (5.x Enterprise) | No | Enterprise only (online backup) | Transaction-consistent snapshot |
+| **Volume snapshot** | Docker volume / filesystem snapshot | Recommended to stop first | Any | Depends on filesystem (crash-consistent at best) |
+
+**For most `ragleap-graph` deployments** (Community Edition, Docker Compose),
+the offline dump is the recommended approach. The downtime window is
+typically seconds to low minutes for graphs under a few hundred thousand
+nodes.
+
+---
+
+## 4. Pre-migration checklist — dump before you migrate
+
+Run this checklist **before** executing any migration (e.g.,
+`backfill_user_id_defaults()`, `backfill_composite_key()`, or any future
+migration registered with the proposed migration framework).
+
+### Checklist
+
+- [ ] **Confirm the Neo4j version**: `neo4j-admin --version`. Dump/load
+      command syntax differs between Neo4j 4.x and 5.x.
+- [ ] **Stop application writes**: Shut down all `ragleap-graph`
+      application instances (or pause traffic) so no `upsert_document()`
+      calls are in flight during the dump.
+- [ ] **Stop the Neo4j database** (Community Edition):
+  ```bash
+  # Docker Compose
+  docker compose stop neo4j
+
+  # Bare-metal
+  neo4j stop
+  ```
+- [ ] **Run the dump**:
+  ```bash
+  # Neo4j 5.x (Community) — from the host, into the container
+  docker compose exec neo4j neo4j-admin database dump neo4j \
+      --to-path=/data/backups/
+
+  # Or, bare-metal
+  neo4j-admin database dump neo4j --to-path=/var/lib/neo4j/backups/
+  ```
+  The dump file will be named `neo4j.dump` (matching the database name).
+- [ ] **Copy the dump to a safe location** outside the Neo4j data volume:
+  ```bash
+  # Docker — copy out of the container
+  docker compose cp neo4j:/data/backups/neo4j.dump ./backups/neo4j-$(date +%Y%m%d-%H%M%S).dump
+
+  # Bare-metal
+  cp /var/lib/neo4j/backups/neo4j.dump ~/backups/neo4j-$(date +%Y%m%d-%H%M%S).dump
+  ```
+- [ ] **Verify the dump file** is non-empty and has a reasonable size
+      relative to your known data volume.
+- [ ] **Restart Neo4j**:
+  ```bash
+  docker compose start neo4j
+  # or: neo4j start
+  ```
+- [ ] **Verify connectivity** before running the migration:
+  ```python
+  from ragleap_graph import GraphIndex, GraphConfig
+  g = GraphIndex(config=GraphConfig(uri="bolt://localhost:7688",
+                                     user="neo4j", password="ragleapgraph"))
+  assert g.health_check(), "Neo4j is not responding after restart"
+  ```
+- [ ] **Now run the migration.** If it fails partway, see the restore
+      procedure below.
+
+---
+
+## 5. Restore walkthrough
+
+Use this procedure if a migration or other operation has left the graph
+in a bad state and you need to roll back to the pre-migration dump.
+
+### Step 1: Stop everything
+
+```bash
+# Stop the application
+docker compose stop app
+
+# Stop Neo4j
+docker compose stop neo4j
+```
+
+### Step 2: Drop the current (corrupted/partial) database
+
+For Neo4j 5.x Community, the simplest approach is to remove the database
+directory and let `load` recreate it:
+
+```bash
+# Docker — remove the database files inside the volume
+docker compose run --rm neo4j bash -c \
+    "rm -rf /data/databases/neo4j /data/transactions/neo4j"
+```
+
+> [!CAUTION]
+> This **permanently destroys** the current database contents. Only do
+> this if you have a verified dump file from the pre-migration checklist.
+
+### Step 3: Load the dump
+
+```bash
+# Neo4j 5.x
+docker compose run --rm neo4j neo4j-admin database load neo4j \
+    --from-path=/data/backups/ --overwrite-destination
+
+# Bare-metal
+neo4j-admin database load neo4j \
+    --from-path=/var/lib/neo4j/backups/ --overwrite-destination
+```
+
+### Step 4: Restart and verify
+
+```bash
+docker compose start neo4j
+# Wait for healthcheck to pass (configured as 10s interval, 10 retries)
+
+docker compose start app
+```
+
+Verify the graph is back to pre-migration state:
+
+```python
+from ragleap_graph import GraphIndex, GraphConfig
+
+g = GraphIndex(config=GraphConfig(uri="bolt://localhost:7688",
+                                   user="neo4j", password="ragleapgraph"))
+assert g.health_check()
+
+# Spot-check: confirm node counts match expectations
+with g.driver.session() as s:
+    for label in ["Document", "Entity", "PairWeight", "RelationWeight"]:
+        count = s.run(f"MATCH (n:{label}) RETURN count(n) AS c").single()["c"]
+        print(f"{label}: {count} nodes")
+```
+
+### Step 5: Investigate the migration failure
+
+Before re-running the failed migration:
+1. Check the migration's error output / logs.
+2. If the migration itself has a bug, fix the migration code first.
+3. Re-run the pre-migration checklist (dump again before retrying).
+
+---
+
+## 6. What this document does NOT cover
+
+- **Automated/scheduled backups**: Out of scope for `ragleap-graph`.
+  Use your infrastructure's native scheduling (cron, Kubernetes CronJob,
+  cloud-provider snapshot policies).
+- **Point-in-time recovery**: Requires Neo4j Enterprise Edition's
+  transaction log archiving. Not available on Community Edition.
+- **Cross-version Neo4j upgrades**: `neo4j-admin database dump/load` is
+  version-specific. For major Neo4j version upgrades, consult Neo4j's
+  own [migration guide](https://neo4j.com/docs/operations-manual/current/upgrade/).
+- **Postgres backup**: The audit log (if enabled via `AuditConfig`) is
+  stored in Postgres, not Neo4j. Back up Postgres separately using
+  `pg_dump` / `pg_restore`.
+
+---
+
+*Last updated: v0.6.7. This procedure should be reviewed whenever the
+Neo4j data model changes (new node labels, new constraints) or when
+`ragleap-graph` adds its own migration framework.*


### PR DESCRIPTION
## What does this PR do?

This PR addresses the open issue regarding missing backup/restore procedures and schema-migration tooling for ragleap-graph. Per the issue's constraints, this is a docs + design PR with zero runtime code changes or dependency additions.

It ships three new artifacts under packages/ragleap-graph/docs/:

docs/operations/backup-and-restore.md — Stopgap operational documentation for manual Neo4j backups and restores.
docs/design/schema-migrations.md — Design proposal for a lightweight schema migration registry and runner.
docs/adr/0001-backup-restore-ownership.md — ADR detailing scope ownership and recommending delegating backups to native database tooling.

## Related issue

Closes #184

## Checklist

- [x] I've tested this change locally
- [x] I've updated documentation if needed
- [x] My changes follow the existing code style
