### PR TITLE
docs(readme): stacked layout + fix release badge showing wrong package's version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,16 @@
-# RagLeap Core 🧠 — Autonomous AI Agents, Self-Hosted
-
 <div align="center">
-  <img src="assets/logo.png" alt="RagLeap Core logo" width="96">
-</div>
 
-<div align="center">
+<img src="assets/logo.png" alt="RagLeap Core logo" width="120">
+
+# RagLeap Core
+
+**AUTONOMOUS AI AGENTS. NOT JUST RAG.**
 
 [![license MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE) [![status 9 AI employees + AI manager + multi-channel + integrations + KG + self-learning](https://img.shields.io/badge/status-9%20AI%20employees%20%2B%20AI%20manager%20%2B%20multi--channel%20%2B%20integrations%20%2B%20KG%20%2B%20self--learning-brightgreen)](https://github.com/antonyrag/ragleap-core)
-[![Core Release](https://img.shields.io/github/v/release/antonyrag/ragleap-core?label=ragleap-core&color=blue)](https://github.com/antonyrag/ragleap-core/releases/latest)
+[![Core Release](https://img.shields.io/github/v/release/antonyrag/ragleap-core?filter=v*&label=ragleap-core&color=blue)](https://github.com/antonyrag/ragleap-core/releases/latest)
 [![PyPI ragleap-rag](https://img.shields.io/pypi/v/ragleap-rag?label=ragleap-rag)](https://pypi.org/project/ragleap-rag/) [![Downloads](https://img.shields.io/pepy/dt/ragleap-rag?label=downloads)](https://pypi.org/project/ragleap-rag/)
 [![PyPI ragleap-graph](https://img.shields.io/pypi/v/ragleap-graph?label=ragleap-graph)](https://pypi.org/project/ragleap-graph/) [![Downloads](https://img.shields.io/pepy/dt/ragleap-graph?label=downloads)](https://pypi.org/project/ragleap-graph/)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://github.com/antonyrag/ragleap-core)
-
-</div>
-
-<div align="center">
-
-**AUTONOMOUS AI AGENTS. NOT JUST RAG.**
 
 </div>
 


### PR DESCRIPTION
Two fixes:

1. **Layout** — consolidates the header into one stacked centered block (icon → title → tagline → badges), matching how LangChain presents theirs, instead of the disjointed floating-divs version from #210/#212.
2. **Badge bug fix** — the Core Release badge was showing `ragleap-graph`'s version, not `ragleap-core`'s. Cause: this repo publishes releases for all 3 packages (core/rag/graph) as one shared release stream, and GitHub's 'latest release' API just returns whichever was published most recently overall — currently a ragleap-graph tag. Fixed with shields.io's `?filter=v*` param, which restricts the badge to only match core's own `v0.x.x`-style tags (ragleap-rag/-graph tags use a different prefix, so they're naturally excluded).