### PR TITLE
release: ragleap-rag v0.12.4

### DIFF
--- a/packages/ragleap-rag/CHANGELOG.md
+++ b/packages/ragleap-rag/CHANGELOG.md
@@ -5,6 +5,12 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.12.4] - 2026-08-27
+
+### Fixed
+
+- `chunk_text()`'s `token_count` field now reflects a real LLM token count via `tiktoken` (`cl100k_base`) when available, instead of always being a whitespace-split word count. The previous behavior was a documented, known limitation (`token_count` internally consistent but not what the field name implied). `_tokenize()` itself — which determines chunk windowing (`chunk_size`/`chunk_overlap` are still measured in whitespace-split words) — is unchanged; only what `token_count` reports about the resulting chunk text has changed. A new `token_count_is_exact: bool` field is added alongside the existing `token_count` field: `True` when a real tiktoken count was used, `False` when tiktoken wasn't installed or its encoding couldn't be loaded (e.g. no network egress to fetch the BPE rank file on first use), in which case `token_count` falls back to the previous word-count behavior exactly, never reporting an estimate as exact. New tests (`test_chunk_text_token_count_matches_tiktoken_when_exact`, `test_chunk_text_fallback_word_count_when_tiktoken_unavailable`, `test_chunk_text_fallback_on_encoding_load_failure`) cover both the real-tokenization and fallback paths. `tiktoken` is now a declared core dependency rather than an incidental transitive one. This is a breaking change to `token_count`'s *values* for any caller depending on the previous word-count numbers specifically — acceptable pre-1.0, and this was already a documented, known limitation rather than a silent surprise.
+
 ## [0.12.3] - 2026-08-23
 
 ### Fixed

--- a/packages/ragleap-rag/pyproject.toml
+++ b/packages/ragleap-rag/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-rag"
-version = "0.12.3"
+version = "0.12.4"
 description = "Self-hosted RAG engine: hybrid dense+sparse retrieval, 28-format ingestion (docs, URLs, images, audio, video), 6 vector backends, 8 embedding providers, 12+ generation providers with automatic fallback, query rewriting (HyDE/contextual/multi-query), structured JSON output, real per-call cost tracking, and standalone retrieval via retrieve(). Composable with the optional ragleap-graph package for knowledge-graph-augmented retrieval. BYOK, no vendor lock-in, no hardcoded model defaults."
 readme = "README.md"
 license = "MIT"
@@ -30,6 +30,7 @@ dependencies = [
     "requests>=2.31.0",
     "pypdf>=6.15.0",
     "python-docx>=1.1.0",
+    "tiktoken>=0.12.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/ragleap-rag/src/ragleap/__init__.py
+++ b/packages/ragleap-rag/src/ragleap/__init__.py
@@ -45,7 +45,7 @@ from ragleap import schema as _schema
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.12.3"
+__version__ = "0.12.4"
 __all__ = ["RagLeap", "ProviderConfig", "EmbeddingConfig", "IngestResult", "TranscriptionConfig", "VectorBackend", "PgVectorBackend"]
 
 

--- a/packages/ragleap-rag/src/ragleap/chunker.py
+++ b/packages/ragleap-rag/src/ragleap/chunker.py
@@ -2,9 +2,36 @@
 Text Chunking for ragleap-rag.
 """
 import logging
-from typing import List
+from typing import Dict, List, Tuple
 
 logger = logging.getLogger(__name__)
+
+try:
+    import tiktoken
+    _TIKTOKEN_AVAILABLE = True
+except ImportError:
+    _TIKTOKEN_AVAILABLE = False
+
+_encoding_cache: Dict[str, "tiktoken.Encoding"] = {}
+
+
+def _real_token_count(text: str, model: str = "cl100k_base") -> Tuple[int, bool]:
+    """
+    Real LLM token count via tiktoken when available; falls back to a
+    whitespace-split word count with is_exact=False when tiktoken isn't
+    installed or its encoding can't be loaded (e.g. no network egress
+    to fetch the BPE rank file on first use). Never reports the
+    fallback estimate as exact -- that would reintroduce the same
+    silent-inaccuracy problem this fix closes.
+    """
+    if _TIKTOKEN_AVAILABLE:
+        try:
+            if model not in _encoding_cache:
+                _encoding_cache[model] = tiktoken.get_encoding(model)
+            return len(_encoding_cache[model].encode(text)), True
+        except Exception as e:
+            logger.warning(f"tiktoken encoding unavailable ({e}); falling back to word count")
+    return len(text.split()), False
 
 DEFAULT_CHUNK_SIZE = 512
 DEFAULT_CHUNK_OVERLAP = 50
@@ -49,10 +76,12 @@ class TextChunker:
             chunk_tokens = tokens[start:end]
             chunk_text_content = " ".join(chunk_tokens)
 
+            token_count, token_count_is_exact = _real_token_count(chunk_text_content)
             chunks.append({
                 "text": chunk_text_content,
                 "chunk_index": chunk_index,
-                "token_count": len(chunk_tokens),
+                "token_count": token_count,
+                "token_count_is_exact": token_count_is_exact,
             })
             chunk_index += 1
 

--- a/packages/ragleap-rag/tests/test_chunker.py
+++ b/packages/ragleap-rag/tests/test_chunker.py
@@ -1,0 +1,88 @@
+"""Tests for TextChunker — chunk windowing/overlap, and token_count
+accuracy (real tiktoken counts when available, honest word-count
+fallback with token_count_is_exact=False when tiktoken can't load)."""
+import pytest
+
+from ragleap.chunker import TextChunker
+
+
+def test_chunk_text_basic_windowing():
+    chunker = TextChunker(chunk_size=5, chunk_overlap=1)
+    chunks = chunker.chunk_text("the quick brown fox jumps over the lazy dog today")
+
+    assert [c["chunk_index"] for c in chunks] == list(range(len(chunks)))
+    assert chunks[0]["text"] == "the quick brown fox jumps"
+    assert chunks[1]["text"] == "jumps over the lazy dog"
+
+
+def test_chunk_text_empty_input_returns_empty_list():
+    chunker = TextChunker()
+    assert chunker.chunk_text("") == []
+    assert chunker.chunk_text("   ") == []
+
+
+def test_chunk_text_raises_on_invalid_overlap():
+    with pytest.raises(ValueError):
+        TextChunker(chunk_size=10, chunk_overlap=10)
+
+
+def test_chunk_text_reports_token_count_is_exact_flag():
+    chunker = TextChunker(chunk_size=10, chunk_overlap=2)
+    chunks = chunker.chunk_text("some real text to chunk here for this test")
+
+    for c in chunks:
+        assert "token_count" in c
+        assert "token_count_is_exact" in c
+        assert isinstance(c["token_count_is_exact"], bool)
+        assert c["token_count"] > 0
+
+
+def test_chunk_text_token_count_matches_tiktoken_when_exact():
+    chunker = TextChunker(chunk_size=50, chunk_overlap=5)
+    chunks = chunker.chunk_text("hello world this is a test")
+    chunk = chunks[0]
+
+    if chunk["token_count_is_exact"]:
+        import tiktoken
+        enc = tiktoken.get_encoding("cl100k_base")
+        assert chunk["token_count"] == len(enc.encode(chunk["text"]))
+    else:
+        assert chunk["token_count"] == len(chunk["text"].split())
+
+
+def test_chunk_text_fallback_word_count_when_tiktoken_unavailable(monkeypatch):
+    """Forces the fallback path regardless of the real environment, so
+    this test doesn't depend on network availability at CI/test time --
+    confirms the fallback contract directly (is_exact=False, count ==
+    whitespace split), the same behavior the field had before this fix."""
+    import ragleap.chunker as chunker_module
+
+    monkeypatch.setattr(chunker_module, "_TIKTOKEN_AVAILABLE", False)
+
+    chunker = chunker_module.TextChunker(chunk_size=10, chunk_overlap=2)
+    chunks = chunker.chunk_text("a simple test phrase for the fallback path")
+
+    for c in chunks:
+        assert c["token_count_is_exact"] is False
+        assert c["token_count"] == len(c["text"].split())
+
+
+def test_chunk_text_fallback_on_encoding_load_failure(monkeypatch):
+    """tiktoken installed but its encoding can't load (e.g. no network
+    egress to fetch the BPE rank file on first use) -- must degrade to
+    the honest fallback, not raise."""
+    import ragleap.chunker as chunker_module
+
+    def _raise(*args, **kwargs):
+        raise RuntimeError("simulated: no network egress to fetch encoding")
+
+    monkeypatch.setattr(chunker_module, "_TIKTOKEN_AVAILABLE", True)
+    monkeypatch.setattr(chunker_module.tiktoken, "get_encoding", _raise, raising=False)
+    chunker_module._encoding_cache.clear()
+
+    chunker = chunker_module.TextChunker(chunk_size=10, chunk_overlap=2)
+    chunks = chunker.chunk_text("a phrase whose encoding load will fail")
+
+    for c in chunks:
+        assert c["token_count_is_exact"] is False
+        assert c["token_count"] == len(c["text"].split())


### PR DESCRIPTION
Real tiktoken-based token_count with honest fallback. See CHANGELOG.