### PR TITLE
ci: skip-existing on PyPI publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/ragleap-rag/dist/
+          skip-existing: true
 
   publish-ragleap-graph:
     if: |
@@ -93,3 +94,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/ragleap-graph/dist/
+          skip-existing: true


### PR DESCRIPTION
Prevents the release workflow from showing a failed deployment when a package version was already published manually before the tag-triggered automation ran (harmless duplicate-upload race, not a real failure).