### PR TITLE
docs(readme): split badge, bullet description, fix release link, softer tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,24 @@
 
 # RagLeap Core
 
-**AUTONOMOUS AI AGENTS. NOT JUST RAG.**
+**Autonomous AI Agents — Not Just RAG.**
 
-[![license MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE) [![status 9 AI employees + AI manager + multi-channel + integrations + KG + self-learning](https://img.shields.io/badge/status-9%20AI%20employees%20%2B%20AI%20manager%20%2B%20multi--channel%20%2B%20integrations%20%2B%20KG%20%2B%20self--learning-brightgreen)](https://github.com/antonyrag/ragleap-core)
-[![Core Release](https://img.shields.io/github/v/release/antonyrag/ragleap-core?filter=v*&label=ragleap-core&color=blue)](https://github.com/antonyrag/ragleap-core/releases/latest)
+[![license MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE) [![Core Release](https://img.shields.io/github/v/release/antonyrag/ragleap-core?filter=v*&label=ragleap-core&color=blue)](https://github.com/antonyrag/ragleap-core/releases) [![9 AI Employees](https://img.shields.io/badge/9-AI%20Employees-brightgreen)](https://github.com/antonyrag/ragleap-core) [![Autonomous](https://img.shields.io/badge/Autonomous-brightgreen)](https://github.com/antonyrag/ragleap-core) [![Self--Hosted](https://img.shields.io/badge/Self--Hosted-brightgreen)](https://github.com/antonyrag/ragleap-core)
 [![PyPI ragleap-rag](https://img.shields.io/pypi/v/ragleap-rag?label=ragleap-rag)](https://pypi.org/project/ragleap-rag/) [![Downloads](https://img.shields.io/pepy/dt/ragleap-rag?label=downloads)](https://pypi.org/project/ragleap-rag/)
 [![PyPI ragleap-graph](https://img.shields.io/pypi/v/ragleap-graph?label=ragleap-graph)](https://pypi.org/project/ragleap-graph/) [![Downloads](https://img.shields.io/pepy/dt/ragleap-graph?label=downloads)](https://pypi.org/project/ragleap-graph/)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://github.com/antonyrag/ragleap-core)
 
 </div>
 
-RagLeap Core is the open-source engine behind RagLeap — a self-hosted, agentic system of 9 role-based AI Employees (AI Manager, Personal Secretary, Customer Support, Telecaller, DB Analyst, Broadcast Agent, Personal Assistant, AI COO, AI Engineer) that think, decide, and act on their own: self-learning memory, auto-trigger workflows, full/semi autonomy, and a think-act-decide loop that runs your business from your own documents on your own server, with no vendor lock-in.
+RagLeap Core is the open-source engine behind RagLeap — a self-hosted, agentic system that runs your business from your own documents on your own server, with no vendor lock-in.
+
+**9 role-based AI Employees:** AI Manager, Personal Secretary, Customer Support, Telecaller, DB Analyst, Broadcast Agent, Personal Assistant, AI COO, AI Engineer.
+
+**What it does:**
+- Self-learning, outcome-weighted memory
+- Auto-trigger workflows and escalation
+- Full / semi autonomy modes
+- Think-act-decide loop, not just retrieval
 
 [Quickstart](#quickstart) · [Docs](https://docs.ragleap.com) · [Website](https://ragleap.com) · [Hosted Version](https://ragleap.com) · [Packages](https://packages.ragleap.com/)
 


### PR DESCRIPTION
Follow-up polish after #210/#212/#214, addressing feedback that the header still didn't read as fully professional:

1. **Badge split** — the old status badge crammed 6 concepts into one unreadable badge. Split into 3 focused ones (9 AI Employees / Autonomous / Self-Hosted).
2. **Bulleted description** — replaced the 5-line paragraph with a short intro + bulleted employee list + bulleted feature list.
3. **Real bug fix: badge link target** — the Core Release badge's displayed *value* was already correctly filtered to core's own tags (previous PR), but its *link* still pointed to `/releases/latest`, which is a separate GitHub URL resolving to the repo's overall latest release regardless of the badge filter -- currently a `ragleap-graph` tag. Now links to `/releases` (the list page), which is always valid.
4. **Softer tagline** — "AUTONOMOUS AI AGENTS. NOT JUST RAG." -> "Autonomous AI Agents — Not Just RAG." All-caps reads as defensive/aggressive for enterprise positioning; title case keeps the same message with a calmer tone.