### PR TITLE
feat(integrations): add Notion connector (Phase A)

### DIFF
--- a/core/integrations/factory.py
+++ b/core/integrations/factory.py
@@ -8,6 +8,7 @@ from core.integrations.mongodb import MongoDBConnector
 from core.integrations.rest_api import RestAPIConnector
 from core.integrations.csv_connector import CSVConnector
 from core.integrations.slack_connector import SlackConnector
+from core.integrations.notion_connector import NotionConnector
 from core.integrations.crm_connectors import (
     SalesforceConnector,
     HubSpotConnector,
@@ -28,6 +29,7 @@ CONNECTOR_MAP = {
     'google_sheets': GoogleSheetsConnector,
     'stripe': StripeConnector,
     'slack': SlackConnector,
+    'notion': NotionConnector,
 }
 
 

--- a/core/integrations/notion_connector.py
+++ b/core/integrations/notion_connector.py
@@ -1,0 +1,94 @@
+"""
+Notion connector for RagLeap Core integrations.
+
+Uses the Notion API directly over HTTP (requests) — same lightweight
+approach as SlackConnector/RestAPIConnector, no notion-client dependency.
+
+Field usage:
+    api_key         -> Notion Integration Token (Internal Integration Secret)
+    api_endpoint    -> database ID (for query_template='database') or
+                       page ID (for query_template='page'); ignored for 'search'
+    query_template  -> 'database' (default, queries a database), 'page'
+                       (fetch a page's block children), or 'search'
+"""
+import logging
+from typing import Dict, List, Tuple
+
+import requests
+
+from core.integrations.base import BaseDatabaseConnector
+
+logger = logging.getLogger(__name__)
+
+NOTION_API_BASE = "https://api.notion.com/v1"
+NOTION_VERSION = "2022-06-28"
+
+
+class NotionConnector(BaseDatabaseConnector):
+    """Connector for Notion workspaces using the Notion API (Integration token)."""
+
+    def _headers(self) -> Dict[str, str]:
+        token = (self.data_source.api_key or '').strip()
+        if not token:
+            raise ValueError("Notion connector requires api_key (Internal Integration Secret)")
+        return {
+            "Authorization": f"Bearer {token}",
+            "Notion-Version": NOTION_VERSION,
+            "Content-Type": "application/json",
+        }
+
+    def _call(self, method: str, path: str, json_body: Dict = None) -> Dict:
+        resp = requests.request(method, f"{NOTION_API_BASE}{path}", headers=self._headers(), json=json_body, timeout=15)
+        if resp.status_code >= 400:
+            try:
+                err = resp.json().get("message", resp.text)
+            except Exception:
+                err = resp.text
+            raise ValueError(f"Notion API error ({resp.status_code}): {err}")
+        return resp.json()
+
+    def test_connection(self) -> Tuple[bool, str]:
+        try:
+            data = self._call("GET", "/users/me")
+            name = data.get("name") or data.get("bot", {}).get("owner", {}).get("type", "unknown")
+            return True, f"Notion connected: {name}"
+        except ValueError as e:
+            return False, str(e)
+        except Exception as e:
+            return False, f"Notion connection failed: {e}"
+
+    def fetch_data(self, user_identifier: str = None) -> List[Dict]:
+        resource = (self.data_source.query_template or 'database').strip().lower() or 'database'
+        try:
+            if resource == 'database':
+                database_id = (self.data_source.api_endpoint or '').strip()
+                if not database_id:
+                    raise ValueError("Notion 'database' fetch requires api_endpoint (database ID)")
+                data = self._call("POST", f"/databases/{database_id}/query", {})
+                return data.get("results", [])
+            elif resource == 'page':
+                page_id = (self.data_source.api_endpoint or '').strip()
+                if not page_id:
+                    raise ValueError("Notion 'page' fetch requires api_endpoint (page ID)")
+                data = self._call("GET", f"/blocks/{page_id}/children")
+                return data.get("results", [])
+            elif resource == 'search':
+                data = self._call("POST", "/search", {})
+                return data.get("results", [])
+            else:
+                raise ValueError(
+                    f"Unsupported Notion query_template: {resource}. Use 'database', 'page', or 'search'."
+                )
+        except ValueError:
+            raise
+        except Exception as e:
+            logger.error(f"NotionConnector.fetch_data error: {e}")
+            raise
+
+    def introspect_schema(self) -> Dict:
+        resources = ['database', 'page', 'search']
+        tables = [{'name': r, 'label': r.title(), 'columns': []} for r in resources]
+        return {'tables': tables, 'filtered_count': 0}
+
+    def execute_query(self, query: str) -> List[Dict]:
+        return self.fetch_data()

--- a/tests/test_notion_connector.py
+++ b/tests/test_notion_connector.py
@@ -1,0 +1,86 @@
+"""
+Tests for core/integrations/notion_connector.py — the Notion API connector.
+Pure unit tests against a mocked requests.request; no live Notion
+workspace or DB needed.
+"""
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from core.integrations.notion_connector import NotionConnector
+from core.integrations.base import DataSource
+
+
+def _mock_response(status_code, payload):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = payload
+    return resp
+
+
+def test_missing_token_fails_gracefully():
+    ds = DataSource(id="1", name="test", source_type="notion", api_key=None)
+    ok, msg = NotionConnector(ds).test_connection()
+    assert ok is False
+    assert "api_key" in msg
+
+
+def test_connection_success():
+    ds = DataSource(id="1", name="test", source_type="notion", api_key="secret_fake")
+    with patch("core.integrations.notion_connector.requests.request") as mock_req:
+        mock_req.return_value = _mock_response(200, {"name": "RagLeap Bot"})
+        ok, msg = NotionConnector(ds).test_connection()
+    assert ok is True
+    assert "RagLeap Bot" in msg
+
+
+def test_notion_api_error_surfaces_message():
+    ds = DataSource(id="1", name="test", source_type="notion", api_key="secret_fake")
+    with patch("core.integrations.notion_connector.requests.request") as mock_req:
+        mock_req.return_value = _mock_response(401, {"message": "API token is invalid."})
+        ok, msg = NotionConnector(ds).test_connection()
+    assert ok is False
+    assert "API token is invalid." in msg
+
+
+def test_fetch_database_default():
+    ds = DataSource(id="1", name="test", source_type="notion", api_key="secret_fake", api_endpoint="db123")
+    with patch("core.integrations.notion_connector.requests.request") as mock_req:
+        mock_req.return_value = _mock_response(200, {"results": [{"id": "row1"}]})
+        data = NotionConnector(ds).fetch_data()
+    assert data == [{"id": "row1"}]
+
+
+def test_fetch_database_requires_endpoint():
+    ds = DataSource(id="1", name="test", source_type="notion", api_key="secret_fake")
+    with pytest.raises(ValueError, match="api_endpoint"):
+        NotionConnector(ds).fetch_data()
+
+
+def test_fetch_page():
+    ds = DataSource(
+        id="1", name="test", source_type="notion", api_key="secret_fake",
+        query_template="page", api_endpoint="page123",
+    )
+    with patch("core.integrations.notion_connector.requests.request") as mock_req:
+        mock_req.return_value = _mock_response(200, {"results": [{"id": "block1"}]})
+        data = NotionConnector(ds).fetch_data()
+    assert data == [{"id": "block1"}]
+
+
+def test_fetch_search_no_endpoint_needed():
+    ds = DataSource(id="1", name="test", source_type="notion", api_key="secret_fake", query_template="search")
+    with patch("core.integrations.notion_connector.requests.request") as mock_req:
+        mock_req.return_value = _mock_response(200, {"results": [{"id": "page1"}, {"id": "db1"}]})
+        data = NotionConnector(ds).fetch_data()
+    assert len(data) == 2
+
+
+def test_unsupported_query_template_raises():
+    ds = DataSource(id="1", name="test", source_type="notion", api_key="secret_fake", query_template="bogus")
+    with pytest.raises(ValueError, match="Unsupported Notion query_template"):
+        NotionConnector(ds).fetch_data()


### PR DESCRIPTION
Adds a Notion connector for RagLeap Core's data-source integrations, closing another of the 8 connectors requested in Discussion #169 / issue #27.

**Pattern:** Follows `SlackConnector` -- plain `requests` against the Notion API directly, no `notion-client` SDK dependency.

**Field usage:**
- `api_key` — Notion Internal Integration Secret
- `api_endpoint` — database ID (`query_template='database'`) or page ID (`query_template='page'`)
- `query_template` — `'database'` (default, POSTs a database query), `'page'` (fetches a page's block children), or `'search'` (workspace-wide search)

**Testing:** 8 unit tests against a mocked Notion API (`tests/test_notion_connector.py`) covering missing-token handling, successful auth, Notion-side API errors (non-200 responses with a message field), each resource type, and an unsupported `query_template`. Full `tests/` suite (25 tests) verified passing locally. Registered in `factory.py`'s `CONNECTOR_MAP` under `'notion'`.