### PR TITLE
feat(integrations): add Airtable connector (Phase A)

### DIFF
--- a/core/integrations/airtable_connector.py
+++ b/core/integrations/airtable_connector.py
@@ -1,0 +1,115 @@
+"""
+Airtable connector for RagLeap Core integrations.
+
+Uses the Airtable Web API directly over HTTP (requests) -- same
+lightweight approach as SlackConnector/NotionConnector, no pyairtable
+dependency.
+
+Field usage:
+    api_key         -> Airtable Personal Access Token
+    api_endpoint    -> "<base_id>/<table_name_or_id>" (both required,
+                       slash-separated -- e.g. "appXXXXXXXX/Tasks")
+    query_template  -> optional Airtable formula (filterByFormula);
+                       leave blank to fetch all records
+"""
+import logging
+from typing import Dict, List, Tuple
+
+import requests
+
+from core.integrations.base import BaseDatabaseConnector
+
+logger = logging.getLogger(__name__)
+
+AIRTABLE_API_BASE = "https://api.airtable.com/v0"
+
+
+class AirtableConnector(BaseDatabaseConnector):
+    """Connector for Airtable bases using the Airtable Web API (Personal Access Token)."""
+
+    def _headers(self) -> Dict[str, str]:
+        token = (self.data_source.api_key or '').strip()
+        if not token:
+            raise ValueError("Airtable connector requires api_key (Personal Access Token)")
+        return {"Authorization": f"Bearer {token}"}
+
+    def _parse_endpoint(self):
+        endpoint = (self.data_source.api_endpoint or '').strip().strip('/')
+        if not endpoint or '/' not in endpoint:
+            raise ValueError(
+                "Airtable connector requires api_endpoint as '<base_id>/<table_name_or_id>'"
+            )
+        base_id, table = endpoint.split('/', 1)
+        if not base_id or not table:
+            raise ValueError(
+                "Airtable connector requires api_endpoint as '<base_id>/<table_name_or_id>'"
+            )
+        return base_id, table
+
+    def test_connection(self) -> Tuple[bool, str]:
+        try:
+            base_id, table = self._parse_endpoint()
+            resp = requests.get(
+                f"{AIRTABLE_API_BASE}/{base_id}/{table}",
+                headers=self._headers(),
+                params={"maxRecords": 1},
+                timeout=15,
+            )
+            if resp.status_code == 200:
+                return True, f"Airtable connected: base {base_id}, table {table}"
+            try:
+                err = resp.json().get("error", {}).get("message", resp.text)
+            except Exception:
+                err = resp.text
+            return False, f"Airtable API error ({resp.status_code}): {err}"
+        except ValueError as e:
+            return False, str(e)
+        except Exception as e:
+            return False, f"Airtable connection failed: {e}"
+
+    def fetch_data(self, user_identifier: str = None) -> List[Dict]:
+        base_id, table = self._parse_endpoint()
+        formula = (self.data_source.query_template or '').strip()
+
+        records = []
+        params = {"pageSize": 100}
+        if formula:
+            params["filterByFormula"] = formula
+
+        offset = None
+        try:
+            while True:
+                if offset:
+                    params["offset"] = offset
+                resp = requests.get(
+                    f"{AIRTABLE_API_BASE}/{base_id}/{table}",
+                    headers=self._headers(),
+                    params=params,
+                    timeout=30,
+                )
+                if resp.status_code != 200:
+                    try:
+                        err = resp.json().get("error", {}).get("message", resp.text)
+                    except Exception:
+                        err = resp.text
+                    raise ValueError(f"Airtable API error ({resp.status_code}): {err}")
+                data = resp.json()
+                for rec in data.get("records", []):
+                    flat = {"id": rec.get("id")}
+                    flat.update(rec.get("fields", {}))
+                    records.append(flat)
+                offset = data.get("offset")
+                if not offset:
+                    break
+            return records
+        except ValueError:
+            raise
+        except Exception as e:
+            logger.error(f"AirtableConnector.fetch_data error: {e}")
+            raise
+
+    def introspect_schema(self) -> Dict:
+        return {'tables': [], 'filtered_count': 0, 'message': 'Set api_endpoint to <base_id>/<table_name> to fetch records'}
+
+    def execute_query(self, query: str) -> List[Dict]:
+        return self.fetch_data()

--- a/core/integrations/factory.py
+++ b/core/integrations/factory.py
@@ -9,6 +9,7 @@ from core.integrations.rest_api import RestAPIConnector
 from core.integrations.csv_connector import CSVConnector
 from core.integrations.slack_connector import SlackConnector
 from core.integrations.notion_connector import NotionConnector
+from core.integrations.airtable_connector import AirtableConnector
 from core.integrations.crm_connectors import (
     SalesforceConnector,
     HubSpotConnector,
@@ -30,6 +31,7 @@ CONNECTOR_MAP = {
     'stripe': StripeConnector,
     'slack': SlackConnector,
     'notion': NotionConnector,
+    'airtable': AirtableConnector,
 }
 
 

--- a/tests/test_airtable_connector.py
+++ b/tests/test_airtable_connector.py
@@ -1,0 +1,98 @@
+"""
+Tests for core/integrations/airtable_connector.py -- the Airtable Web API connector.
+Pure unit tests against a mocked requests.get; no live Airtable base or
+DB needed.
+"""
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from core.integrations.airtable_connector import AirtableConnector
+from core.integrations.base import DataSource
+
+
+def _mock_response(status_code, payload):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = payload
+    return resp
+
+
+def test_missing_token_fails_gracefully():
+    ds = DataSource(id="1", name="test", source_type="airtable", api_key=None, api_endpoint="app123/Tasks")
+    ok, msg = AirtableConnector(ds).test_connection()
+    assert ok is False
+    assert "api_key" in msg
+
+
+def test_missing_endpoint_fails_gracefully():
+    ds = DataSource(id="1", name="test", source_type="airtable", api_key="patFAKE")
+    ok, msg = AirtableConnector(ds).test_connection()
+    assert ok is False
+    assert "api_endpoint" in msg
+
+
+def test_connection_success():
+    ds = DataSource(id="1", name="test", source_type="airtable", api_key="patFAKE", api_endpoint="app123/Tasks")
+    with patch("core.integrations.airtable_connector.requests.get") as mock_get:
+        mock_get.return_value = _mock_response(200, {"records": []})
+        ok, msg = AirtableConnector(ds).test_connection()
+    assert ok is True
+    assert "app123" in msg and "Tasks" in msg
+
+
+def test_airtable_api_error_surfaces_message():
+    ds = DataSource(id="1", name="test", source_type="airtable", api_key="patFAKE", api_endpoint="app123/Tasks")
+    with patch("core.integrations.airtable_connector.requests.get") as mock_get:
+        mock_get.return_value = _mock_response(401, {"error": {"message": "Invalid authentication token"}})
+        ok, msg = AirtableConnector(ds).test_connection()
+    assert ok is False
+    assert "Invalid authentication token" in msg
+
+
+def test_fetch_flattens_fields():
+    ds = DataSource(id="1", name="test", source_type="airtable", api_key="patFAKE", api_endpoint="app123/Tasks")
+    with patch("core.integrations.airtable_connector.requests.get") as mock_get:
+        mock_get.return_value = _mock_response(200, {
+            "records": [{"id": "rec1", "fields": {"Name": "Task A", "Done": False}}]
+        })
+        data = AirtableConnector(ds).fetch_data()
+    assert data == [{"id": "rec1", "Name": "Task A", "Done": False}]
+
+
+def test_fetch_paginates_using_offset():
+    ds = DataSource(id="1", name="test", source_type="airtable", api_key="patFAKE", api_endpoint="app123/Tasks")
+    page1 = _mock_response(200, {
+        "records": [{"id": "rec1", "fields": {"Name": "A"}}],
+        "offset": "itrOFFSET",
+    })
+    page2 = _mock_response(200, {
+        "records": [{"id": "rec2", "fields": {"Name": "B"}}],
+    })
+    with patch("core.integrations.airtable_connector.requests.get") as mock_get:
+        mock_get.side_effect = [page1, page2]
+        data = AirtableConnector(ds).fetch_data()
+    assert data == [{"id": "rec1", "Name": "A"}, {"id": "rec2", "Name": "B"}]
+    assert mock_get.call_count == 2
+
+
+def test_fetch_uses_filter_formula_when_query_template_set():
+    ds = DataSource(
+        id="1", name="test", source_type="airtable", api_key="patFAKE",
+        api_endpoint="app123/Tasks", query_template="{Done}=TRUE()",
+    )
+    with patch("core.integrations.airtable_connector.requests.get") as mock_get:
+        mock_get.return_value = _mock_response(200, {"records": []})
+        AirtableConnector(ds).fetch_data()
+    called_params = mock_get.call_args.kwargs["params"]
+    assert called_params["filterByFormula"] == "{Done}=TRUE()"
+
+
+def test_fetch_bad_endpoint_format_raises():
+    ds = DataSource(id="1", name="test", source_type="airtable", api_key="patFAKE", api_endpoint="app123-no-slash")
+    with pytest.raises(ValueError, match="api_endpoint"):
+        AirtableConnector(ds).fetch_data()


### PR DESCRIPTION
Adds an Airtable connector for RagLeap Core's data-source integrations, closing another of the 8 connectors requested in Discussion #169 / issue #27.

**Pattern:** Follows Slack/Notion -- plain `requests` against the Airtable Web API directly, no `pyairtable` SDK dependency.

**Field usage:**
- `api_key` — Airtable Personal Access Token
- `api_endpoint` — `<base_id>/<table_name_or_id>` (slash-separated, both required)
- `query_template` — optional Airtable formula (`filterByFormula`); blank fetches all records

**Pagination:** Airtable pages results via an `offset` token. `fetch_data()` loops internally and returns the full record set in one call, with each record's `fields` flattened alongside its `id`.

**Testing:** 8 unit tests (`tests/test_airtable_connector.py`) covering missing-token/endpoint handling, malformed endpoint format, successful auth, Airtable-side API errors, field flattening, multi-page pagination (verified via a 2-page mock), and `filterByFormula` usage. Full `tests/` suite (33 tests) verified passing locally. Registered in `factory.py`'s `CONNECTOR_MAP` under `'airtable'`.