### PR TITLE
Add ragleap-vectorstores package scaffold

### DIFF
--- a/packages/ragleap-vectorstores/CHANGELOG.md
+++ b/packages/ragleap-vectorstores/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to `ragleap-vectorstores` are documented here. Format
+loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+### Added
+- Initial package scaffold - pyproject.toml, package layout, empty
+  `__init__.py`. No backends implemented yet.

--- a/packages/ragleap-vectorstores/README.md
+++ b/packages/ragleap-vectorstores/README.md
@@ -1,0 +1,23 @@
+# ragleap-vectorstores
+
+Pluggable vector backends beyond [ragleap-rag](https://pypi.org/project/ragleap-rag/)'s
+built-in 6 (PgVector, FAISS, Pinecone, Weaviate, Qdrant, Milvus).
+
+**Status: scaffold only - no backends implemented yet.** This package is
+under active development. See the
+[roadmap](https://github.com/antonyrag/ragleap-core/wiki/Roadmap) for status.
+
+## Design
+
+Every backend here implements ragleap-rag's `VectorBackend` interface, so it
+can be passed directly to `RagLeap(vector_backend=...)`. Each backend's real
+client SDK is an optional extra - installing `ragleap-vectorstores` alone
+pulls in no heavy dependencies beyond `ragleap-rag` itself.
+
+## Install
+
+```bash
+pip install ragleap-vectorstores[<backend>]
+```
+
+(No backends published yet.)

--- a/packages/ragleap-vectorstores/pyproject.toml
+++ b/packages/ragleap-vectorstores/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ragleap-vectorstores"
+version = "0.1.0"
+description = "Pluggable vector backends beyond ragleap-rag core's 6 (PgVector, FAISS, Pinecone, Weaviate, Qdrant, Milvus) - additional VectorBackend implementations as optional extras, no vendor lock-in, no bloated core dependency footprint."
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.10"
+authors = [
+    { name = "Antony", email = "antony@ragleap.com" }
+]
+keywords = ["rag", "vector-search", "vector-database", "ragleap"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+    "ragleap-rag>=0.12.4",
+]
+
+[project.optional-dependencies]
+test = ["pytest>=8.0.0", "pytest-asyncio>=0.24.0"]
+# Backend-specific extras go here once a backend is chosen and implemented,
+# e.g.: chroma = ["chromadb>=0.5.0"]
+
+[project.urls]
+Homepage = "https://github.com/antonyrag/ragleap-core"
+Repository = "https://github.com/antonyrag/ragleap-core"
+Documentation = "https://packages.ragleap.com/docs/ragleap-vectorstores.html"
+Issues = "https://github.com/antonyrag/ragleap-core/issues"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ragleap_vectorstores"]

--- a/packages/ragleap-vectorstores/src/ragleap_vectorstores/__init__.py
+++ b/packages/ragleap-vectorstores/src/ragleap_vectorstores/__init__.py
@@ -1,0 +1,10 @@
+"""
+ragleap-vectorstores: pluggable vector backends beyond ragleap-rag core's 6.
+
+Scaffold only - no backends implemented yet. Backends will be added here
+following ragleap-rag's own vectorstores/__init__.py pattern: each backend
+import wrapped in try/except ImportError, so a missing optional extra
+simply makes that one backend unavailable rather than breaking the package.
+"""
+
+__all__ = []

--- a/packages/ragleap-vectorstores/tests/test_smoke.py
+++ b/packages/ragleap-vectorstores/tests/test_smoke.py
@@ -1,0 +1,6 @@
+"""Smoke test - the package imports cleanly with zero backends registered yet."""
+import ragleap_vectorstores
+
+
+def test_import():
+    assert ragleap_vectorstores.__all__ == []


### PR DESCRIPTION
Initial scaffold for the new ragleap-vectorstores package (roadmap Next-tier item #3).

Scope: packages/ragleap-vectorstores/ only - no other package touched.

Contents:
- pyproject.toml (depends on ragleap-rag>=0.12.4 for the VectorBackend ABC)
- src/ragleap_vectorstores/__init__.py (empty, no backends yet)
- README.md, CHANGELOG.md
- tests/test_smoke.py

Verified: pip install -e . succeeds, import resolves to the real package source (not dist-packages), test suite passes 1/1.

Backend choice (Chroma/LanceDB/Redis/OpenSearch/Vespa/MongoDB Atlas) is intentionally not made here - pending maintainer decision per the handover doc.