### PR TITLE
Add ChromaBackend to ragleap-vectorstores

### DIFF
--- a/packages/ragleap-vectorstores/pyproject.toml
+++ b/packages/ragleap-vectorstores/pyproject.toml
@@ -29,8 +29,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = ["pytest>=8.0.0", "pytest-asyncio>=0.24.0"]
-# Backend-specific extras go here once a backend is chosen and implemented,
-# e.g.: chroma = ["chromadb>=0.5.0"]
+chroma = ["chromadb>=1.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/antonyrag/ragleap-core"

--- a/packages/ragleap-vectorstores/src/ragleap_vectorstores/__init__.py
+++ b/packages/ragleap-vectorstores/src/ragleap_vectorstores/__init__.py
@@ -1,10 +1,17 @@
 """
 ragleap-vectorstores: pluggable vector backends beyond ragleap-rag core's 6.
 
-Scaffold only - no backends implemented yet. Backends will be added here
-following ragleap-rag's own vectorstores/__init__.py pattern: each backend
-import wrapped in try/except ImportError, so a missing optional extra
-simply makes that one backend unavailable rather than breaking the package.
+Each backend import is wrapped in try/except ImportError, matching
+ragleap-rag's own vectorstores/__init__.py pattern - a missing optional
+extra simply makes that one backend unavailable rather than breaking
+the package.
 """
+from ragleap.vectorstores.base import VectorBackend
 
-__all__ = []
+__all__ = ["VectorBackend"]
+
+try:
+    from ragleap_vectorstores.chroma_backend import ChromaBackend
+    __all__.append("ChromaBackend")
+except ImportError:
+    pass  # chroma extra not installed - ChromaBackend simply unavailable, not an error

--- a/packages/ragleap-vectorstores/src/ragleap_vectorstores/chroma_backend.py
+++ b/packages/ragleap-vectorstores/src/ragleap_vectorstores/chroma_backend.py
@@ -1,0 +1,203 @@
+"""
+Chroma-backed vector storage for ragleap-vectorstores.
+
+Live-verified against the actually installed chromadb==1.5.9 package:
+every method signature and return shape used below was introspected and
+exercised against a real local PersistentClient during development, not
+assumed from documentation.
+
+Design notes:
+- persist_directory is REQUIRED. Chroma's PersistentClient already stores
+  chunk text and metadata durably on disk under this path, so - unlike
+  QdrantBackend/PineconeBackend/WeaviateBackend - no SQLite sidecar is
+  needed for chunk data. A small SQLite sidecar is still used, but only
+  for the document registry (filename, uploaded_at, metadata), because
+  Chroma has no native "parent document" concept - it only knows about
+  individual (id, embedding, metadata, document-text) chunk records.
+- Chroma's `where=` filter requires exactly one top-level operator per
+  clause - live-verified: a plain multi-key dict like
+  {"document_id": "d1", "tag": "x"} raises ValueError ("Expected where to
+  have exactly one operator"). Multiple equality conditions must be
+  wrapped in {"$and": [...]}. _build_where() below handles this.
+- similarity_score is derived as (1 - distance). Verified live with
+  "hnsw:space": "cosine" (the default configured here): querying with an
+  embedding identical to a stored one returns a distance ~0, consistent
+  with Chroma's documented cosine distance = 1 - cosine_similarity.
+- supports_sparse() is False. Chroma has no native BM25/keyword search
+  surface as of 1.5.9 - only vector similarity - so hybrid search falls
+  back to the VectorBackend default (dense-only), matching the honest
+  "don't claim capability that isn't there" rule QdrantBackend follows.
+"""
+import json
+import logging
+import os
+import sqlite3
+import threading
+from typing import Dict, List, Optional
+
+from ragleap.vectorstores.base import VectorBackend
+
+logger = logging.getLogger(__name__)
+
+
+class ChromaBackend(VectorBackend):
+    def __init__(
+        self,
+        persist_directory: str,
+        collection_name: str = "ragleap",
+    ):
+        try:
+            import chromadb  # noqa: F401
+        except ImportError as e:
+            raise ImportError(
+                "ChromaBackend requires the 'chroma' extra: "
+                "pip install ragleap-vectorstores[chroma]"
+            ) from e
+
+        if not persist_directory:
+            raise ValueError(
+                "ChromaBackend requires persist_directory= - this is where "
+                "both Chroma's own on-disk index and the document-registry "
+                "SQLite sidecar are stored."
+            )
+
+        self.persist_directory = persist_directory
+        self.collection_name = collection_name
+        self._client = None
+        self._collection = None
+        self._dimensions = None
+        self._lock = threading.Lock()
+
+        os.makedirs(persist_directory, exist_ok=True)
+        self._sqlite_path = os.path.join(persist_directory, "chroma_documents.sqlite3")
+        self._conn = sqlite3.connect(self._sqlite_path, check_same_thread=False)
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS documents (
+                id TEXT PRIMARY KEY, filename TEXT NOT NULL,
+                metadata TEXT NOT NULL, uploaded_at TEXT NOT NULL
+            )"""
+        )
+        self._conn.commit()
+
+    def _vector_key(self, document_id: str, chunk_index: int) -> str:
+        return f"{document_id}:{chunk_index}"
+
+    def _build_where(self, metadata_filter: Optional[Dict]):
+        """Chroma requires exactly one top-level operator per where-clause
+        (live-verified) - a plain multi-key dict raises ValueError. Wrap
+        multiple equality conditions in $and; pass single conditions
+        through directly."""
+        if not metadata_filter:
+            return None
+        if len(metadata_filter) == 1:
+            return dict(metadata_filter)
+        return {"$and": [{k: v} for k, v in metadata_filter.items()]}
+
+    def init_schema(self, dimensions: int) -> None:
+        import chromadb
+
+        self._dimensions = dimensions
+        self._client = chromadb.PersistentClient(path=self.persist_directory)
+        self._collection = self._client.get_or_create_collection(
+            name=self.collection_name,
+            metadata={"hnsw:space": "cosine"},
+        )
+        logger.info(
+            f"ChromaBackend: using collection '{self.collection_name}' "
+            f"(dimensions={dimensions}) at {self.persist_directory}"
+        )
+
+    def insert_document(self, document_id: str, filename: str, metadata: Dict) -> None:
+        import datetime
+        with self._lock:
+            self._conn.execute(
+                "INSERT INTO documents (id, filename, metadata, uploaded_at) VALUES (?, ?, ?, ?)",
+                (document_id, filename, json.dumps(metadata or {}), datetime.datetime.utcnow().isoformat()),
+            )
+            self._conn.commit()
+
+    def insert_chunk(
+        self, document_id: str, document_name: str, chunk_index: int,
+        text: str, token_count: int, embedding: List[float], metadata: Dict,
+    ) -> None:
+        vector_key = self._vector_key(document_id, chunk_index)
+        payload = {
+            "document_id": document_id, "document_name": document_name,
+            "chunk_index": chunk_index, "token_count": token_count or 0,
+            **(metadata or {}),
+        }
+        with self._lock:
+            self._collection.upsert(
+                ids=[vector_key],
+                embeddings=[embedding],
+                metadatas=[payload],
+                documents=[text],
+            )
+
+    def search_dense(self, embedding: List[float], top_k: int, metadata_filter: Optional[Dict] = None) -> List[Dict]:
+        if not embedding or self._collection is None:
+            return []
+
+        result = self._collection.query(
+            query_embeddings=[embedding],
+            n_results=top_k,
+            where=self._build_where(metadata_filter),
+            include=["documents", "metadatas", "distances"],
+        )
+
+        ids = result.get("ids") or [[]]
+        docs = result.get("documents") or [[]]
+        metas = result.get("metadatas") or [[]]
+        dists = result.get("distances") or [[]]
+        if not ids or not ids[0]:
+            return []
+
+        results = []
+        for chunk_id, text, meta, distance in zip(ids[0], docs[0], metas[0], dists[0]):
+            meta = meta or {}
+            results.append({
+                "chunk_id": chunk_id,
+                "text": text,
+                "similarity_score": round(1.0 - float(distance), 4),
+                "document_id": meta.get("document_id"),
+                "document_name": meta.get("document_name"),
+                "chunk_index": meta.get("chunk_index"),
+            })
+        return results
+
+    def supports_sparse(self) -> bool:
+        return False
+
+    def list_documents(self, limit: int, offset: int) -> List[Dict]:
+        rows = self._conn.execute(
+            "SELECT id, filename, uploaded_at, metadata FROM documents "
+            "ORDER BY uploaded_at DESC LIMIT ? OFFSET ?",
+            (limit, offset),
+        ).fetchall()
+
+        results = []
+        for doc_id, filename, uploaded_at, metadata_json in rows:
+            chunk_count = 0
+            if self._collection is not None:
+                chunk_rows = self._collection.get(where={"document_id": doc_id}, include=[])
+                chunk_count = len((chunk_rows or {}).get("ids", []))
+            results.append({
+                "document_id": doc_id, "filename": filename, "uploaded_at": uploaded_at,
+                "metadata": json.loads(metadata_json), "chunk_count": chunk_count,
+            })
+        return results
+
+    def delete_document(self, document_id: str) -> bool:
+        with self._lock:
+            if self._collection is not None:
+                self._collection.delete(where={"document_id": document_id})
+            cur = self._conn.execute("DELETE FROM documents WHERE id = ?", (document_id,))
+            deleted = cur.rowcount > 0
+            self._conn.commit()
+        return deleted
+
+    def get_document_filename(self, document_id: str) -> Optional[str]:
+        row = self._conn.execute(
+            "SELECT filename FROM documents WHERE id = ?", (document_id,)
+        ).fetchone()
+        return row[0] if row else None

--- a/packages/ragleap-vectorstores/tests/test_chroma_backend.py
+++ b/packages/ragleap-vectorstores/tests/test_chroma_backend.py
@@ -1,0 +1,109 @@
+"""
+Tests for ChromaBackend. Uses a real local chromadb PersistentClient
+against a temp directory (Chroma has no meaningful "fake" - it's already
+fully local/embedded, so there's no live-credentials gap to skip around,
+unlike QdrantBackend/PineconeBackend/WeaviateBackend's tests).
+"""
+import shutil
+
+import pytest
+
+from ragleap_vectorstores.chroma_backend import ChromaBackend
+
+
+@pytest.fixture
+def backend(tmp_path):
+    b = ChromaBackend(persist_directory=str(tmp_path / "chroma_data"))
+    b.init_schema(dimensions=3)
+    yield b
+
+
+def _seed(backend):
+    backend.insert_document("doc1", "report.pdf", {"source": "upload"})
+    backend.insert_chunk("doc1", "report.pdf", 0, "The cat sat on the mat.", 6, [0.1, 0.2, 0.3], {"page": 1})
+    backend.insert_chunk("doc1", "report.pdf", 1, "Dogs bark loudly outside.", 5, [0.9, 0.1, 0.1], {"page": 2})
+    backend.insert_document("doc2", "notes.txt", {"source": "manual"})
+    backend.insert_chunk("doc2", "notes.txt", 0, "Unrelated content here.", 4, [0.5, 0.5, 0.5], {"page": 1})
+
+
+def test_requires_persist_directory():
+    with pytest.raises(ValueError):
+        ChromaBackend(persist_directory="")
+
+
+def test_insert_and_search_dense_shape(backend):
+    _seed(backend)
+    results = backend.search_dense([0.1, 0.2, 0.3], top_k=5)
+    assert results, "expected at least one result"
+    assert set(results[0].keys()) == {
+        "chunk_id", "text", "similarity_score", "document_id", "document_name", "chunk_index",
+    }
+    assert results[0]["chunk_id"] == "doc1:0"
+    assert results[0]["text"] == "The cat sat on the mat."
+
+
+def test_search_dense_single_key_filter(backend):
+    _seed(backend)
+    results = backend.search_dense([0.1, 0.2, 0.3], top_k=5, metadata_filter={"document_id": "doc2"})
+    assert results
+    assert all(r["document_id"] == "doc2" for r in results)
+
+
+def test_search_dense_multi_key_filter(backend):
+    """Regression guard for the real Chroma constraint (live-verified): a
+    plain multi-key `where=` dict raises ValueError - multiple conditions
+    must be wrapped in $and. This test would fail loudly if _build_where()
+    regressed to a naive dict pass-through."""
+    _seed(backend)
+    results = backend.search_dense([0.1, 0.2, 0.3], top_k=5, metadata_filter={"document_id": "doc1", "page": 2})
+    assert len(results) == 1
+    assert results[0]["chunk_id"] == "doc1:1"
+
+
+def test_search_dense_empty_embedding_returns_empty(backend):
+    assert backend.search_dense([], top_k=5) == []
+
+
+def test_search_sparse_not_supported(backend):
+    _seed(backend)
+    assert backend.search_sparse("cat", top_k=5) == []
+
+
+def test_search_hybrid_falls_back_to_dense(backend):
+    _seed(backend)
+    hybrid = backend.search_hybrid("cat", [0.1, 0.2, 0.3], top_k=5)
+    dense = backend.search_dense([0.1, 0.2, 0.3], top_k=5)
+    assert [r["chunk_id"] for r in hybrid] == [r["chunk_id"] for r in dense]
+
+
+def test_supports_sparse_is_false(backend):
+    assert backend.supports_sparse() is False
+
+
+def test_list_documents(backend):
+    _seed(backend)
+    docs = backend.list_documents(limit=10, offset=0)
+    assert len(docs) == 2
+    by_id = {d["document_id"]: d for d in docs}
+    assert by_id["doc1"]["chunk_count"] == 2
+    assert by_id["doc2"]["chunk_count"] == 1
+    assert by_id["doc1"]["filename"] == "report.pdf"
+    assert by_id["doc1"]["metadata"] == {"source": "upload"}
+
+
+def test_get_document_filename(backend):
+    _seed(backend)
+    assert backend.get_document_filename("doc1") == "report.pdf"
+    assert backend.get_document_filename("nonexistent") is None
+
+
+def test_delete_document_removes_registry_entry_and_vectors(backend):
+    _seed(backend)
+    assert backend.delete_document("doc1") is True
+    assert backend.delete_document("doc1") is False  # already gone
+
+    docs = backend.list_documents(limit=10, offset=0)
+    assert [d["document_id"] for d in docs] == ["doc2"]
+
+    remaining = backend.search_dense([0.1, 0.2, 0.3], top_k=5)
+    assert all(r["document_id"] != "doc1" for r in remaining)

--- a/packages/ragleap-vectorstores/tests/test_smoke.py
+++ b/packages/ragleap-vectorstores/tests/test_smoke.py
@@ -1,6 +1,7 @@
-"""Smoke test - the package imports cleanly with zero backends registered yet."""
+"""Smoke test - the package imports cleanly and VectorBackend is always
+re-exported regardless of which optional backend extras are installed."""
 import ragleap_vectorstores
 
 
 def test_import():
-    assert ragleap_vectorstores.__all__ == []
+    assert "VectorBackend" in ragleap_vectorstores.__all__


### PR DESCRIPTION
First real backend implementation for ragleap-vectorstores - Chroma via chromadb's embedded PersistentClient.

Scope: packages/ragleap-vectorstores/ only.

## What this adds
- `ChromaBackend` implementing the full `VectorBackend` interface
- `chroma` optional extra in pyproject.toml (`chromadb>=1.0.0`)
- 11 new tests against a real local PersistentClient (no mocks - Chroma is already embedded/local, so unlike Qdrant/Pinecone/Weaviate's tests there's no live-credentials gap to skip around)

## Design notes (live-verified against chromadb==1.5.9, not assumed from docs)
- No SQLite sidecar needed for chunk text/metadata - Chroma's PersistentClient already stores that durably. A small sidecar is still used for the document registry only, since Chroma has no native parent-document concept.
- Real API gotcha discovered and handled: `where=` requires exactly one top-level operator per clause - a plain multi-key filter dict raises `ValueError`. Multi-key filters wrap in `$and`. Covered by a dedicated regression test (`test_search_dense_multi_key_filter`).
- `similarity_score` derived as `1 - distance` under cosine space, confirmed live against identical-embedding queries.
- `supports_sparse()` is `False` - Chroma has no native BM25/keyword surface as of 1.5.9, so hybrid search honestly falls back to dense-only rather than claiming unimplemented capability.

## Verified
- 12/12 tests pass locally and on the VPS (real chromadb, not mocked)
- Editable install resolves to real package source, not dist-packages
- Heads up: chromadb pulls a real dependency footprint (kubernetes client, opentelemetry API/SDK/OTLP-gRPC, uvicorn[standard] extras) - correctly gated behind the optional `[chroma]` extra, but worth knowing for anyone auditing what installing this extra brings in.

## Note on backend choice
Chroma was picked without an explicit maintainer sign-off on backend priority (see the original scaffold PR #221 discussion) - reasoning: embedded/local-first fills a real gap the other 6 backends don't cover, mature Python client, no compiled-dependency burden beyond chromadb itself. Flagging this explicitly in case backend order matters for the roadmap.