### PR TITLE
feat(integrations): add Razorpay connector (Phase A)

### DIFF
--- a/core/integrations/factory.py
+++ b/core/integrations/factory.py
@@ -10,6 +10,7 @@ from core.integrations.csv_connector import CSVConnector
 from core.integrations.slack_connector import SlackConnector
 from core.integrations.notion_connector import NotionConnector
 from core.integrations.airtable_connector import AirtableConnector
+from core.integrations.razorpay_connector import RazorpayConnector
 from core.integrations.crm_connectors import (
     SalesforceConnector,
     HubSpotConnector,
@@ -32,6 +33,7 @@ CONNECTOR_MAP = {
     'slack': SlackConnector,
     'notion': NotionConnector,
     'airtable': AirtableConnector,
+    'razorpay': RazorpayConnector,
 }
 
 

--- a/core/integrations/razorpay_connector.py
+++ b/core/integrations/razorpay_connector.py
@@ -1,0 +1,112 @@
+"""
+Razorpay connector for RagLeap Core integrations.
+
+Uses the Razorpay REST API directly over HTTP (requests) -- same
+lightweight approach as SlackConnector/NotionConnector/AirtableConnector,
+no razorpay SDK dependency. Auth is HTTP Basic (key_id:key_secret),
+per Razorpay's own API convention -- unlike the other connectors,
+this needs both an ID and a secret, so api_endpoint carries the key_id
+and api_key carries the key_secret.
+
+Field usage:
+    api_endpoint    -> Razorpay Key ID (starts with rzp_)
+    api_key         -> Razorpay Key Secret
+    query_template  -> resource type: 'payments' (default), 'orders',
+                       'refunds', 'customers', or 'settlements'
+"""
+import logging
+from typing import Dict, List, Tuple
+
+import requests
+from requests.auth import HTTPBasicAuth
+
+from core.integrations.base import BaseDatabaseConnector
+
+logger = logging.getLogger(__name__)
+
+RAZORPAY_API_BASE = "https://api.razorpay.com/v1"
+
+RESOURCE_ENDPOINTS = {
+    'payments': 'payments',
+    'orders': 'orders',
+    'refunds': 'refunds',
+    'customers': 'customers',
+    'settlements': 'settlements',
+}
+
+
+class RazorpayConnector(BaseDatabaseConnector):
+    """Connector for Razorpay using the REST API (Key ID / Key Secret Basic Auth)."""
+
+    def _auth(self) -> HTTPBasicAuth:
+        key_id = (self.data_source.api_endpoint or '').strip()
+        key_secret = (self.data_source.api_key or '').strip()
+        if not key_id or not key_secret:
+            raise ValueError(
+                "Razorpay connector requires api_endpoint (Key ID) and api_key (Key Secret)"
+            )
+        return HTTPBasicAuth(key_id, key_secret)
+
+    def test_connection(self) -> Tuple[bool, str]:
+        try:
+            auth = self._auth()
+            resp = requests.get(
+                f"{RAZORPAY_API_BASE}/payments",
+                auth=auth,
+                params={"count": 1},
+                timeout=15,
+            )
+            if resp.status_code == 200:
+                return True, "Razorpay connection successful"
+            try:
+                err = resp.json().get("error", {}).get("description", resp.text)
+            except Exception:
+                err = resp.text
+            return False, f"Razorpay API error ({resp.status_code}): {err}"
+        except ValueError as e:
+            return False, str(e)
+        except Exception as e:
+            return False, f"Razorpay connection failed: {e}"
+
+    def fetch_data(self, user_identifier: str = None) -> List[Dict]:
+        auth = self._auth()
+        resource = (self.data_source.query_template or 'payments').strip().lower() or 'payments'
+        path = RESOURCE_ENDPOINTS.get(resource)
+        if not path:
+            raise ValueError(
+                f"Unsupported Razorpay query_template: {resource}. "
+                f"Use one of: {', '.join(sorted(RESOURCE_ENDPOINTS.keys()))}."
+            )
+
+        items = []
+        params = {"count": 100, "skip": 0}
+        try:
+            while True:
+                resp = requests.get(f"{RAZORPAY_API_BASE}/{path}", auth=auth, params=params, timeout=30)
+                if resp.status_code != 200:
+                    try:
+                        err = resp.json().get("error", {}).get("description", resp.text)
+                    except Exception:
+                        err = resp.text
+                    raise ValueError(f"Razorpay API error ({resp.status_code}): {err}")
+                data = resp.json()
+                batch = data.get("items", [])
+                items.extend(batch)
+                if len(batch) < params["count"]:
+                    break
+                params["skip"] += params["count"]
+            if user_identifier:
+                items = [i for i in items if i.get("customer_id") == user_identifier or i.get("id") == user_identifier]
+            return items
+        except ValueError:
+            raise
+        except Exception as e:
+            logger.error(f"RazorpayConnector.fetch_data error: {e}")
+            raise
+
+    def introspect_schema(self) -> Dict:
+        tables = [{'name': r, 'label': r.title(), 'columns': []} for r in RESOURCE_ENDPOINTS]
+        return {'tables': tables, 'filtered_count': 0}
+
+    def execute_query(self, query: str) -> List[Dict]:
+        return self.fetch_data()

--- a/tests/test_razorpay_connector.py
+++ b/tests/test_razorpay_connector.py
@@ -1,0 +1,94 @@
+"""
+Tests for core/integrations/razorpay_connector.py -- the Razorpay REST API connector.
+Pure unit tests against a mocked requests.get; no live Razorpay account
+or DB needed.
+"""
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from core.integrations.razorpay_connector import RazorpayConnector
+from core.integrations.base import DataSource
+
+
+def _mock_response(status_code, payload):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = payload
+    return resp
+
+
+def test_missing_credentials_fails_gracefully():
+    ds = DataSource(id="1", name="test", source_type="razorpay", api_endpoint=None, api_key=None)
+    ok, msg = RazorpayConnector(ds).test_connection()
+    assert ok is False
+    assert "api_endpoint" in msg and "api_key" in msg
+
+
+def test_missing_key_secret_fails_gracefully():
+    ds = DataSource(id="1", name="test", source_type="razorpay", api_endpoint="rzp_test_123", api_key=None)
+    ok, msg = RazorpayConnector(ds).test_connection()
+    assert ok is False
+
+
+def test_connection_success():
+    ds = DataSource(id="1", name="test", source_type="razorpay", api_endpoint="rzp_test_123", api_key="secretFAKE")
+    with patch("core.integrations.razorpay_connector.requests.get") as mock_get:
+        mock_get.return_value = _mock_response(200, {"items": []})
+        ok, msg = RazorpayConnector(ds).test_connection()
+    assert ok is True
+    assert "successful" in msg
+
+
+def test_razorpay_api_error_surfaces_message():
+    ds = DataSource(id="1", name="test", source_type="razorpay", api_endpoint="rzp_test_123", api_key="secretFAKE")
+    with patch("core.integrations.razorpay_connector.requests.get") as mock_get:
+        mock_get.return_value = _mock_response(401, {"error": {"description": "Authentication failed"}})
+        ok, msg = RazorpayConnector(ds).test_connection()
+    assert ok is False
+    assert "Authentication failed" in msg
+
+
+def test_fetch_payments_default():
+    ds = DataSource(id="1", name="test", source_type="razorpay", api_endpoint="rzp_test_123", api_key="secretFAKE")
+    with patch("core.integrations.razorpay_connector.requests.get") as mock_get:
+        mock_get.return_value = _mock_response(200, {"items": [{"id": "pay_1", "amount": 500}]})
+        data = RazorpayConnector(ds).fetch_data()
+    assert data == [{"id": "pay_1", "amount": 500}]
+
+
+def test_fetch_paginates_using_skip():
+    ds = DataSource(id="1", name="test", source_type="razorpay", api_endpoint="rzp_test_123", api_key="secretFAKE")
+    full_page = _mock_response(200, {"items": [{"id": f"pay_{i}"} for i in range(100)]})
+    partial_page = _mock_response(200, {"items": [{"id": "pay_100"}]})
+    with patch("core.integrations.razorpay_connector.requests.get") as mock_get:
+        mock_get.side_effect = [full_page, partial_page]
+        data = RazorpayConnector(ds).fetch_data()
+    assert len(data) == 101
+    assert mock_get.call_count == 2
+
+
+def test_fetch_orders_resource():
+    ds = DataSource(
+        id="1", name="test", source_type="razorpay", api_endpoint="rzp_test_123", api_key="secretFAKE",
+        query_template="orders",
+    )
+    with patch("core.integrations.razorpay_connector.requests.get") as mock_get:
+        mock_get.return_value = _mock_response(200, {"items": [{"id": "order_1"}]})
+        data = RazorpayConnector(ds).fetch_data()
+    called_url = mock_get.call_args.args[0]
+    assert called_url.endswith("/orders")
+    assert data == [{"id": "order_1"}]
+
+
+def test_unsupported_query_template_raises():
+    ds = DataSource(
+        id="1", name="test", source_type="razorpay", api_endpoint="rzp_test_123", api_key="secretFAKE",
+        query_template="bogus",
+    )
+    with pytest.raises(ValueError, match="Unsupported Razorpay query_template"):
+        RazorpayConnector(ds).fetch_data()


### PR DESCRIPTION
Adds a Razorpay connector for RagLeap Core's data-source integrations, closing another of the 8 connectors requested in Discussion #169 / issue #27.

**Pattern:** Follows Slack/Notion/Airtable -- plain `requests` against the Razorpay REST API directly, no `razorpay` SDK dependency.

**Auth note:** Razorpay uses HTTP Basic auth (`key_id:key_secret`) rather than a single bearer token, so this connector repurposes the fields slightly: `api_endpoint` carries the Key ID, `api_key` carries the Key Secret.

**Field usage:**
- `api_endpoint` — Razorpay Key ID
- `api_key` — Razorpay Key Secret
- `query_template` — `'payments'` (default), `'orders'`, `'refunds'`, `'customers'`, or `'settlements'`

**Pagination:** Razorpay pages via `count`/`skip`. `fetch_data()` loops internally until a short page is returned, then returns the full set in one call.

**Testing:** 8 unit tests (`tests/test_razorpay_connector.py`) covering both forms of missing credentials, successful auth, Razorpay-side API errors, default resource fetch, multi-page pagination (verified via a 100+1 record mock), resource-type switching, and an unsupported `query_template`. Full `tests/` suite (41 tests) verified passing locally. Registered in `factory.py`'s `CONNECTOR_MAP` under `'razorpay'`.