### PR TITLE
Add ragleap-vectorstores publish job to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     tags:
       - 'ragleap-rag-v*'
       - 'ragleap-graph-v*'
+      - 'ragleap-vectorstores-v*'
   workflow_dispatch:
     inputs:
       package:
@@ -14,6 +15,7 @@ on:
         options:
           - ragleap-rag
           - ragleap-graph
+          - ragleap-vectorstores
       target:
         description: 'Publish target'
         required: true
@@ -94,4 +96,40 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/ragleap-graph/dist/
+          skip-existing: true
+
+  publish-ragleap-vectorstores:
+    if: |
+      startsWith(github.ref, 'refs/tags/ragleap-vectorstores-v') ||
+      (github.event_name == 'workflow_dispatch' && inputs.package == 'ragleap-vectorstores')
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.event_name == 'workflow_dispatch' && inputs.target || 'pypi' }}
+    permissions:
+      id-token: write
+    defaults:
+      run:
+        working-directory: packages/ragleap-vectorstores
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+      - name: Install build tooling
+        run: pip install build
+      - name: Build
+        run: |
+          rm -rf dist/
+          python -m build
+      - name: Publish to TestPyPI
+        if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/ragleap-vectorstores/dist/
+          repository-url: https://test.pypi.org/legacy/
+      - name: Publish to PyPI
+        if: github.event_name != 'workflow_dispatch' || inputs.target == 'pypi'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/ragleap-vectorstores/dist/
           skip-existing: true


### PR DESCRIPTION
Extends .github/workflows/release.yml with a third publish job for ragleap-vectorstores, mirroring the existing ragleap-rag/ragleap-graph jobs exactly (tag trigger, workflow_dispatch option, OIDC Trusted Publishing, skip-existing PyPI publish).

Scope: .github/workflows/release.yml only.

Trusted Publishing pending-publisher already registered on both pypi.org and test.pypi.org (antonyrag/ragleap-core, release.yml, environments pypi/testpypi) - confirmed via the PyPI UI before opening this PR, so the first real publish should work without a manual token.

This is CI-only - no package code changes. Once merged, the next step is a real v0.1.0 tag push to actually publish ragleap-vectorstores.