### PR TITLE
Prep ragleap-vectorstores v0.1.0 release

### DIFF
--- a/packages/ragleap-vectorstores/CHANGELOG.md
+++ b/packages/ragleap-vectorstores/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `ragleap-vectorstores` are documented here. Format
 loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+
+## [0.1.0] - 2026-08-29
 ### Added
-- Initial package scaffold - pyproject.toml, package layout, empty
-  `__init__.py`. No backends implemented yet.
+- Initial package scaffold - pyproject.toml, package layout matching
+  ragleap-graph's src/ragleap_vectorstores convention.
+- `ChromaBackend` - first vector backend, implementing the full
+  `VectorBackend` interface via chromadb's embedded PersistentClient
+  (no server required). Available via the `chroma` optional extra
+  (`pip install ragleap-vectorstores[chroma]`).
+- `supports_sparse()` correctly reports `False` for Chroma - no native
+  keyword/BM25 search as of chromadb 1.5.9, so hybrid search honestly
+  falls back to dense-only rather than claiming unimplemented capability.

--- a/packages/ragleap-vectorstores/src/ragleap_vectorstores/__init__.py
+++ b/packages/ragleap-vectorstores/src/ragleap_vectorstores/__init__.py
@@ -8,7 +8,9 @@ the package.
 """
 from ragleap.vectorstores.base import VectorBackend
 
-__all__ = ["VectorBackend"]
+__version__ = "0.1.0"
+
+__all__ = ["VectorBackend", "__version__"]
 
 try:
     from ragleap_vectorstores.chroma_backend import ChromaBackend


### PR DESCRIPTION
Version bump + CHANGELOG entry ahead of the first real ragleap-vectorstores release.

Scope: packages/ragleap-vectorstores/__init__.py and CHANGELOG.md only.

## Changes
- Adds __version__ = "0.1.0" to __init__.py, matching ragleap-rag/ragleap-graph convention
- Moves CHANGELOG Unreleased content into a real [0.1.0] entry, now correctly documenting both the scaffold AND the ChromaBackend addition (PR #222) - the changelog previously still only said scaffold-only despite Chroma already being merged

## Verified
- 12/12 tests pass
- python -m build succeeds; confirmed via zipfile inspection that both __init__.py and chroma_backend.py are actually packaged
- twine check PASSED on wheel + sdist

Once merged, next step is a TestPyPI dry-run via workflow_dispatch, then tagging ragleap-vectorstores-v0.1.0 to publish for real via the new publish-ragleap-vectorstores CI job (#224).