### PR TITLE
Fix ragleap-vectorstores README to reflect ChromaBackend

### DIFF
--- a/packages/ragleap-vectorstores/README.md
+++ b/packages/ragleap-vectorstores/README.md
@@ -3,9 +3,15 @@
 Pluggable vector backends beyond [ragleap-rag](https://pypi.org/project/ragleap-rag/)'s
 built-in 6 (PgVector, FAISS, Pinecone, Weaviate, Qdrant, Milvus).
 
-**Status: scaffold only - no backends implemented yet.** This package is
-under active development. See the
+This package is under active development - more backends will be added
+over time. See the
 [roadmap](https://github.com/antonyrag/ragleap-core/wiki/Roadmap) for status.
+
+## Available backends
+
+| Backend | Extra | Notes |
+|---|---|---|
+| Chroma | `chroma` | Embedded/local via chromadb's PersistentClient - no server required. No native sparse/keyword search (`supports_sparse()` is `False`); hybrid search falls back to dense-only. |
 
 ## Design
 
@@ -17,7 +23,13 @@ pulls in no heavy dependencies beyond `ragleap-rag` itself.
 ## Install
 
 ```bash
-pip install ragleap-vectorstores[<backend>]
+pip install ragleap-vectorstores[chroma]
 ```
 
-(No backends published yet.)
+## Usage
+
+```python
+from ragleap_vectorstores import ChromaBackend
+
+backend = ChromaBackend(persist_directory="./chroma_data")
+```


### PR DESCRIPTION
The TestPyPI dry-run publish (workflow_dispatch, run 33239446296) surfaced a real problem: checking the live TestPyPI JSON endpoint afterward showed README.md still said "scaffold only - no backends implemented yet" and "No backends published yet", even though ChromaBackend has been in the package since PR #222. Would have shipped a misleading description to real PyPI otherwise.

Scope: packages/ragleap-vectorstores/README.md only.

## Changes
- Removes the stale scaffold-only status line
- Adds an Available backends table (Chroma, `chroma` extra, notes on `supports_sparse()`=False)
- Fixes install command from the placeholder `[<backend>]` to the real `[chroma]`
- Adds a Usage example - verified it actually runs against the real installed package before writing it here

Once merged, plan is to re-run the TestPyPI dry-run to confirm the corrected description shows up live, then do the real PyPI publish.