### PR TITLE
feat(integrations): add WooCommerce connector (Phase A)

### DIFF
--- a/core/integrations/factory.py
+++ b/core/integrations/factory.py
@@ -11,6 +11,7 @@ from core.integrations.slack_connector import SlackConnector
 from core.integrations.notion_connector import NotionConnector
 from core.integrations.airtable_connector import AirtableConnector
 from core.integrations.razorpay_connector import RazorpayConnector
+from core.integrations.woocommerce_connector import WooCommerceConnector
 from core.integrations.crm_connectors import (
     SalesforceConnector,
     HubSpotConnector,
@@ -34,6 +35,7 @@ CONNECTOR_MAP = {
     'notion': NotionConnector,
     'airtable': AirtableConnector,
     'razorpay': RazorpayConnector,
+    'woocommerce': WooCommerceConnector,
 }
 
 

--- a/core/integrations/woocommerce_connector.py
+++ b/core/integrations/woocommerce_connector.py
@@ -1,0 +1,127 @@
+"""
+WooCommerce connector for RagLeap Core integrations.
+
+Uses the WooCommerce REST API (v3) directly over HTTP (requests) --
+same lightweight approach as the other connectors, no woocommerce SDK
+dependency. Auth is HTTP Basic (consumer_key:consumer_secret), per
+WooCommerce's own REST API convention when the store isn't served
+over HTTPS with query-param auth -- Basic Auth works for both.
+
+Field usage:
+    api_endpoint    -> store base URL (e.g. https://mystore.com,
+                       no trailing slash, no /wp-json suffix)
+    api_key         -> Consumer Key (ck_...)
+    connection_string -> Consumer Secret (cs_...)
+    query_template  -> resource type: 'orders' (default), 'products',
+                       'customers', 'coupons', or 'refunds'
+"""
+import logging
+from typing import Dict, List, Tuple
+
+import requests
+from requests.auth import HTTPBasicAuth
+
+from core.integrations.base import BaseDatabaseConnector
+
+logger = logging.getLogger(__name__)
+
+WC_API_VERSION = "wc/v3"
+
+RESOURCE_ENDPOINTS = {
+    'orders': 'orders',
+    'products': 'products',
+    'customers': 'customers',
+    'coupons': 'coupons',
+    'refunds': 'products/refunds',
+}
+
+
+class WooCommerceConnector(BaseDatabaseConnector):
+    """Connector for WooCommerce stores using the REST API v3 (Consumer Key/Secret)."""
+
+    def _base_url(self) -> str:
+        store_url = (self.data_source.api_endpoint or '').strip().rstrip('/')
+        if not store_url:
+            raise ValueError("WooCommerce connector requires api_endpoint (store base URL)")
+        return f"{store_url}/wp-json/{WC_API_VERSION}"
+
+    def _auth(self) -> HTTPBasicAuth:
+        consumer_key = (self.data_source.api_key or '').strip()
+        consumer_secret = (self.data_source.connection_string or '').strip()
+        if not consumer_key or not consumer_secret:
+            raise ValueError(
+                "WooCommerce connector requires api_key (Consumer Key) and "
+                "connection_string (Consumer Secret)"
+            )
+        return HTTPBasicAuth(consumer_key, consumer_secret)
+
+    def test_connection(self) -> Tuple[bool, str]:
+        try:
+            base_url = self._base_url()
+            auth = self._auth()
+            resp = requests.get(f"{base_url}/orders", auth=auth, params={"per_page": 1}, timeout=15)
+            if resp.status_code == 200:
+                return True, "WooCommerce connection successful"
+            try:
+                err = resp.json().get("message", resp.text)
+            except Exception:
+                err = resp.text
+            return False, f"WooCommerce API error ({resp.status_code}): {err}"
+        except ValueError as e:
+            return False, str(e)
+        except Exception as e:
+            return False, f"WooCommerce connection failed: {e}"
+
+    def fetch_data(self, user_identifier: str = None) -> List[Dict]:
+        base_url = self._base_url()
+        auth = self._auth()
+        resource = (self.data_source.query_template or 'orders').strip().lower() or 'orders'
+        path = RESOURCE_ENDPOINTS.get(resource)
+        if not path:
+            raise ValueError(
+                f"Unsupported WooCommerce query_template: {resource}. "
+                f"Use one of: {', '.join(sorted(RESOURCE_ENDPOINTS.keys()))}."
+            )
+
+        items = []
+        page = 1
+        try:
+            while True:
+                resp = requests.get(
+                    f"{base_url}/{path}",
+                    auth=auth,
+                    params={"per_page": 100, "page": page},
+                    timeout=30,
+                )
+                if resp.status_code != 200:
+                    try:
+                        err = resp.json().get("message", resp.text)
+                    except Exception:
+                        err = resp.text
+                    raise ValueError(f"WooCommerce API error ({resp.status_code}): {err}")
+                batch = resp.json()
+                if not isinstance(batch, list) or not batch:
+                    break
+                items.extend(batch)
+                if len(batch) < 100:
+                    break
+                page += 1
+            if user_identifier:
+                items = [
+                    i for i in items
+                    if str(i.get("customer_id", "")) == str(user_identifier)
+                    or str(i.get("id", "")) == str(user_identifier)
+                ]
+            return items
+        except ValueError:
+            raise
+        except Exception as e:
+            logger.error(f"WooCommerceConnector.fetch_data error: {e}")
+            raise
+
+    def introspect_schema(self) -> Dict:
+        tables = [{'name': r, 'label': r.title(), 'columns': []} for r in RESOURCE_ENDPOINTS]
+        return {'tables': tables, 'filtered_count': 0}
+
+    def execute_query(self, query: str) -> List[Dict]:
+        return self.fetch_data()

--- a/tests/test_woocommerce_connector.py
+++ b/tests/test_woocommerce_connector.py
@@ -1,0 +1,107 @@
+"""
+Tests for core/integrations/woocommerce_connector.py -- the WooCommerce REST API v3 connector.
+Pure unit tests against a mocked requests.get; no live WooCommerce
+store or DB needed.
+"""
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from core.integrations.woocommerce_connector import WooCommerceConnector
+from core.integrations.base import DataSource
+
+
+def _mock_response(status_code, payload):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = payload
+    return resp
+
+
+def test_missing_store_url_fails_gracefully():
+    ds = DataSource(id="1", name="test", source_type="woocommerce", api_endpoint=None)
+    ok, msg = WooCommerceConnector(ds).test_connection()
+    assert ok is False
+    assert "api_endpoint" in msg
+
+
+def test_missing_credentials_fails_gracefully():
+    ds = DataSource(id="1", name="test", source_type="woocommerce", api_endpoint="https://store.com", api_key=None)
+    ok, msg = WooCommerceConnector(ds).test_connection()
+    assert ok is False
+    assert "api_key" in msg or "connection_string" in msg
+
+
+def test_connection_success():
+    ds = DataSource(
+        id="1", name="test", source_type="woocommerce", api_endpoint="https://store.com",
+        api_key="ck_fake", connection_string="cs_fake",
+    )
+    with patch("core.integrations.woocommerce_connector.requests.get") as mock_get:
+        mock_get.return_value = _mock_response(200, [])
+        ok, msg = WooCommerceConnector(ds).test_connection()
+    assert ok is True
+    assert "successful" in msg
+
+
+def test_woocommerce_api_error_surfaces_message():
+    ds = DataSource(
+        id="1", name="test", source_type="woocommerce", api_endpoint="https://store.com",
+        api_key="ck_fake", connection_string="cs_fake",
+    )
+    with patch("core.integrations.woocommerce_connector.requests.get") as mock_get:
+        mock_get.return_value = _mock_response(401, {"message": "Consumer key is invalid."})
+        ok, msg = WooCommerceConnector(ds).test_connection()
+    assert ok is False
+    assert "Consumer key is invalid." in msg
+
+
+def test_fetch_orders_default():
+    ds = DataSource(
+        id="1", name="test", source_type="woocommerce", api_endpoint="https://store.com",
+        api_key="ck_fake", connection_string="cs_fake",
+    )
+    with patch("core.integrations.woocommerce_connector.requests.get") as mock_get:
+        mock_get.return_value = _mock_response(200, [{"id": 1, "status": "processing"}])
+        data = WooCommerceConnector(ds).fetch_data()
+    assert data == [{"id": 1, "status": "processing"}]
+
+
+def test_fetch_paginates_using_page_param():
+    ds = DataSource(
+        id="1", name="test", source_type="woocommerce", api_endpoint="https://store.com",
+        api_key="ck_fake", connection_string="cs_fake",
+    )
+    full_page = _mock_response(200, [{"id": i} for i in range(100)])
+    partial_page = _mock_response(200, [{"id": 100}])
+    with patch("core.integrations.woocommerce_connector.requests.get") as mock_get:
+        mock_get.side_effect = [full_page, partial_page]
+        data = WooCommerceConnector(ds).fetch_data()
+    assert len(data) == 101
+    assert mock_get.call_count == 2
+
+
+def test_fetch_products_resource():
+    ds = DataSource(
+        id="1", name="test", source_type="woocommerce", api_endpoint="https://store.com",
+        api_key="ck_fake", connection_string="cs_fake", query_template="products",
+    )
+    with patch("core.integrations.woocommerce_connector.requests.get") as mock_get:
+        mock_get.return_value = _mock_response(200, [{"id": 5, "name": "Widget"}])
+        data = WooCommerceConnector(ds).fetch_data()
+    called_url = mock_get.call_args.args[0]
+    assert called_url.endswith("/products")
+    assert data == [{"id": 5, "name": "Widget"}]
+
+
+def test_unsupported_query_template_raises():
+    ds = DataSource(
+        id="1", name="test", source_type="woocommerce", api_endpoint="https://store.com",
+        api_key="ck_fake", connection_string="cs_fake", query_template="bogus",
+    )
+    with pytest.raises(ValueError, match="Unsupported WooCommerce query_template"):
+        WooCommerceConnector(ds).fetch_data()


### PR DESCRIPTION
Adds a WooCommerce connector for RagLeap Core's data-source integrations, closing another of the 8 connectors requested in Discussion #169 / issue #27.

**Pattern:** Follows the other connectors -- plain `requests` against the WooCommerce REST API v3 directly, no `woocommerce` SDK dependency.

**Field usage:**
- `api_endpoint` — store base URL (e.g. `https://mystore.com`)
- `api_key` — Consumer Key (`ck_...`)
- `connection_string` — Consumer Secret (`cs_...`)
- `query_template` — `'orders'` (default), `'products'`, `'customers'`, `'coupons'`, or `'refunds'`

**Pagination:** WooCommerce pages via `page`/`per_page`. `fetch_data()` loops internally until a short page is returned.

**Testing:** 8 unit tests (`tests/test_woocommerce_connector.py`) covering missing store URL, missing credentials, successful auth, WooCommerce-side API errors, default resource fetch, multi-page pagination, resource-type switching, and an unsupported `query_template`. Full `tests/` suite (49 tests) verified passing locally. Registered in `factory.py`'s `CONNECTOR_MAP` under `'woocommerce'`.