### PR TITLE
release: ragleap-graph v0.6.8

### DIFF
--- a/packages/ragleap-graph/CHANGELOG.md
+++ b/packages/ragleap-graph/CHANGELOG.md
@@ -5,6 +5,15 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.6.8]
+### Fixed
+- CO_OCCURS_WITH relationship-MERGE race, noticed but deliberately left open in the v0.6.7 fix (that release closed the four NODE-level races for Document/Entity/PairWeight/RelationWeight; this closes the equivalent race at the relationship level). `MERGE (ea)-[r:CO_OCCURS_WITH]-(eb)` matched only on the two Entity endpoints and relationship type - not atomic against concurrent writers, same class of bug as the v0.6.7 node-level races.
+- Fix: a `composite_key` property (same `_composite_key()` helper as the four node types) is now MERGE'd on the CO_OCCURS_WITH relationship, backed by a relationship-level uniqueness constraint (`FOR ()-[r:CO_OCCURS_WITH]-() REQUIRE r.composite_key IS UNIQUE`), created idempotently alongside the existing four node constraints. CO_OCCURS_WITH is undirected and entity-pair order wasn't canonicalized anywhere in the existing code, so the composite_key is computed from a sorted (a, b) pair - without this, the same logical entity pair extracted in different orders across different documents would compute two different keys and MERGE could still create a duplicate relationship.
+- Added `backfill_co_occurs_with_composite_key(namespace=None, batch_size=500)` - the same one-time, idempotent migration pattern as `backfill_composite_key()` (v0.6.7), for CO_OCCURS_WITH relationships written before this version. Deduplicates on relationship identity (`WITH DISTINCT r`) before reading endpoint names via `startNode(r)`/`endNode(r)`, since Neo4j's undirected-match semantics can otherwise surface the same relationship via more than one traversal direction.
+### Verified
+- Live concurrency test (8 concurrent `upsert_document()` calls, 8 different document_ids, all mentioning the same two entities) against real Neo4j: exactly 1 CO_OCCURS_WITH relationship resulted, with composite_key correctly set - confirming the fix under real contention, not just code review. This is a different race shape than v0.6.7's Document-race test (same document_id, concurrent calls), since CO_OCCURS_WITH deliberately aggregates across DIFFERENT documents by design.
+- Full suite: 79 passed, 12 skipped - zero regressions.
+
 ## [0.6.7]
 ### Fixed
 - Real, confirmed concurrency bug (issue #183): concurrent upsert_document() calls with identical document_id/user_id/namespace could create duplicate Document/Entity/PairWeight/RelationWeight nodes. MERGE on multiple plain properties is not atomic against concurrent writers without a uniqueness constraint, and Neo4j Community Edition only supports single-property uniqueness constraints (no composite constraints, unlike Enterprise Edition). Reproduced live before fixing: 8 duplicate Document nodes from 6 "successful" concurrent upserts of the same document.

--- a/packages/ragleap-graph/pyproject.toml
+++ b/packages/ragleap-graph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-graph"
-version = "0.6.7"
+version = "0.6.8"
 description = "Knowledge-graph-augmented retrieval for RAG systems: Neo4j-backed entity extraction (regex or LLM-based), co-occurrence graphs, entity deduplication, and GraphRetriever for hybrid vector+graph retrieval via the optional ragleap-rag integration. Framework-agnostic, optional multi-tenant namespacing, no hardcoded models or vocabulary."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-graph/src/ragleap_graph/__init__.py
+++ b/packages/ragleap-graph/src/ragleap_graph/__init__.py
@@ -77,7 +77,7 @@ from ragleap_graph.retrieval import GraphRetriever, GraphRetrievalConfig
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.6.7"
+__version__ = "0.6.8"
 
 # Hard ceiling on traversal depth — prevents both runaway queries and,
 # since max_depth is string-interpolated into Cypher (see note above),
@@ -196,6 +196,18 @@ class GraphIndex:
                     _constraint_session.run(
                         "CREATE CONSTRAINT relationweight_composite_key IF NOT EXISTS "
                         "FOR (rw:RelationWeight) REQUIRE rw.composite_key IS UNIQUE"
+                    )
+                    # Relationship-level composite_key constraint, closing the
+                    # same non-atomic-MERGE race for CO_OCCURS_WITH that the
+                    # four node-level constraints above closed in v0.6.7 --
+                    # noticed but deliberately left open at the time. Canonical
+                    # (sorted) entity-pair order is used when computing this
+                    # key so the same logical pair always produces the same
+                    # key regardless of which order extraction returned the
+                    # two entity names in.
+                    _constraint_session.run(
+                        "CREATE CONSTRAINT co_occurs_with_composite_key IF NOT EXISTS "
+                        "FOR ()-[r:CO_OCCURS_WITH]-() REQUIRE r.composite_key IS UNIQUE"
                     )
             except Exception as constraint_exc:
                 logger.warning(
@@ -573,6 +585,8 @@ class GraphIndex:
                     )
 
                 for (a, b) in old_pairs | current_pairs:
+                    a_canon, b_canon = sorted((a, b))
+                    co_occurs_composite_key = _composite_key(ns, uid, a_canon, b_canon)
                     session.run(
                         """
                         MATCH (pw:PairWeight {namespace: $namespace, entity_a: $a, entity_b: $b, user_id: $user_id})
@@ -580,11 +594,12 @@ class GraphIndex:
                         MATCH (ea:Entity {name: $a, namespace: $namespace, user_id: $user_id})
                         MATCH (eb:Entity {name: $b, namespace: $namespace, user_id: $user_id})
                         FOREACH (_ IN CASE WHEN total > 0 THEN [1] ELSE [] END |
-                            MERGE (ea)-[r:CO_OCCURS_WITH]-(eb)
+                            MERGE (ea)-[r:CO_OCCURS_WITH {composite_key: $co_occurs_composite_key}]-(eb)
+                            ON CREATE SET r.namespace = $namespace, r.user_id = $user_id
                             SET r.weight = total
                         )
                         FOREACH (_ IN CASE WHEN total = 0 THEN [1] ELSE [] END |
-                            MERGE (ea)-[r2:CO_OCCURS_WITH]-(eb)
+                            MERGE (ea)-[r2:CO_OCCURS_WITH {composite_key: $co_occurs_composite_key}]-(eb)
                             DELETE r2
                         )
                         """,
@@ -592,6 +607,7 @@ class GraphIndex:
                         a=a,
                         b=b,
                         user_id=uid,
+                        co_occurs_composite_key=co_occurs_composite_key,
                     )
                     summary["relationships_indexed"] += 1
 
@@ -1402,6 +1418,79 @@ class GraphIndex:
 
         return counts
 
+
+    def backfill_co_occurs_with_composite_key(
+        self, namespace: Optional[str] = None, batch_size: int = 500
+    ) -> int:
+        """
+        One-time migration for CO_OCCURS_WITH relationships written
+        before composite_key was added to them -- closes the same gap
+        backfill_composite_key() closes for the four node labels, just
+        at the relationship level (see that method's docstring for the
+        general background on why this is needed: uniqueness
+        constraints don't apply to null properties, so pre-existing
+        data isn't automatically covered by a new constraint).
+
+        Uses the SAME _composite_key() helper and the SAME canonical
+        (sorted) entity-pair ordering the live MERGE path uses, so a
+        backfilled relationship's key matches exactly what a fresh
+        MERGE for that same logical pair would compute.
+
+        CO_OCCURS_WITH is undirected; the read query explicitly
+        deduplicates on relationship identity (WITH DISTINCT r) before
+        reading endpoint names via startNode(r)/endNode(r), rather
+        than relying on assumptions about undirected-match traversal
+        semantics -- relationship identity itself is unambiguous
+        regardless of how many directions a pattern match considers.
+
+        Idempotent -- only touches relationships still missing
+        composite_key, so re-running after new composite_key-aware
+        data has been written does not overwrite it.
+
+        Pass namespace= to scope the backfill to one namespace, or
+        omit to backfill the whole graph. batch_size controls how
+        many relationships are updated per UNWIND write.
+
+        Returns the count of relationships updated.
+        """
+        if not self.driver:
+            return 0
+
+        ns_filter = "AND r.namespace = $namespace" if namespace is not None else ""
+
+        read_query = (
+            f"MATCH ()-[r:CO_OCCURS_WITH]-() "
+            f"WHERE r.composite_key IS NULL {ns_filter} "
+            f"WITH DISTINCT r "
+            f"RETURN elementId(r) AS eid, r.namespace AS namespace, "
+            f"r.user_id AS user_id, startNode(r).name AS a, endNode(r).name AS b"
+        )
+
+        with self.driver.session() as session:
+            records = list(session.run(read_query, namespace=namespace or ""))
+
+            updates = []
+            for r in records:
+                a_canon, b_canon = sorted((r["a"] or "", r["b"] or ""))
+                updates.append({
+                    "eid": r["eid"],
+                    "composite_key": _composite_key(
+                        r["namespace"] or "", r["user_id"] or "", a_canon, b_canon
+                    ),
+                })
+
+            for i in range(0, len(updates), batch_size):
+                batch = updates[i:i + batch_size]
+                session.run(
+                    """
+                    UNWIND $batch AS row
+                    MATCH ()-[r:CO_OCCURS_WITH]-() WHERE elementId(r) = row.eid
+                    SET r.composite_key = row.composite_key
+                    """,
+                    batch=batch,
+                )
+
+        return len(updates)
 
     def health_check(self) -> bool:
         """Return True if the Neo4j driver is connected and responsive."""

--- a/packages/ragleap-graph/tests/test_ragleap_graph.py
+++ b/packages/ragleap-graph/tests/test_ragleap_graph.py
@@ -981,3 +981,345 @@ def test_concurrent_upsert_same_key_no_duplicates():
                 doc_id=document_id, user_id=user_id, ns=TEST_NAMESPACE,
             )
         graph.close()
+
+
+@pytest.mark.skipif(not HAS_LIVE_NEO4J, reason="No live Neo4j credentials in environment")
+def test_concurrent_co_occurs_with_different_documents_no_duplicate_relationship():
+    """
+    Regression test for the CO_OCCURS_WITH relationship-MERGE race --
+    noticed but deliberately left open in the v0.6.7 fix (that release
+    closed the four NODE-level races for Document/Entity/PairWeight/
+    RelationWeight; this closes the equivalent race at the relationship
+    level for CO_OCCURS_WITH).
+
+    Design: fire 8 concurrent upsert_document() calls, each with a
+    DIFFERENT document_id but the SAME two entities co-occurring in
+    the text, and the SAME user_id/namespace. CO_OCCURS_WITH
+    deliberately aggregates across documents (that's the point of
+    co-occurrence weighting), so this is the realistic race for this
+    specific relationship type -- unlike the Document/Entity race
+    above, which uses the SAME document_id, this test's threads never
+    share a document_id at all; the shared resource under contention
+    is the single CO_OCCURS_WITH relationship between the two entities
+    that every thread's MERGE tries to touch.
+
+    Without the composite_key fix, MERGE (ea)-[r:CO_OCCURS_WITH]-(eb)
+    matches only on the two endpoints and relationship type -- not
+    atomic against concurrent writers, same class of bug the node-level
+    fix closed. The fix adds composite_key (namespace + user_id +
+    sorted entity pair, canonicalized since the relationship is
+    undirected) to the MERGE pattern plus a matching uniqueness
+    constraint.
+
+    A >0 deadlock count observed here is expected under real
+    contention, not a test failure by itself -- same reasoning as the
+    Document-race test above.
+    """
+    config = GraphConfig(uri=NEO4J_URI, user=NEO4J_USER, password=NEO4J_PASSWORD)
+    graph = GraphIndex(config=config)
+
+    user_id = f"pytest-co-occurs-concurrency-user-{uuid.uuid4()}"
+    entity_a = "acme corporation"
+    entity_b = "beta industries"
+    document_ids = [
+        f"pytest-co-occurs-concurrency-doc-{i}-{uuid.uuid4()}" for i in range(8)
+    ]
+    chunks = [
+        {"text": "Acme Corporation announced a new partnership with Beta Industries today."},
+    ]
+
+    try:
+        n_threads = len(document_ids)
+        results = [None] * n_threads
+
+        def do_upsert(index):
+            try:
+                results[index] = graph.upsert_document(
+                    document_id=document_ids[index],
+                    title=f"Concurrency Regression Test Document {index}",
+                    chunks=chunks,
+                    namespace=TEST_NAMESPACE,
+                    user_id=user_id,
+                )
+            except Exception as exc:  # noqa: BLE001
+                results[index] = f"error: {exc!r}"
+
+        threads = [threading.Thread(target=do_upsert, args=(i,)) for i in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        raw_errors = [r for r in results if isinstance(r, str) and r.startswith("error")]
+        other_failures = [
+            r for r in results
+            if isinstance(r, dict) and not r.get("success")
+            and "DeadlockDetected" not in str(r.get("error", ""))
+        ]
+        assert not raw_errors, f"upsert_document() raised uncaught exceptions: {raw_errors}"
+        assert not other_failures, f"upsert_document() failed for a non-deadlock reason: {other_failures}"
+
+        with graph.driver.session() as session:
+            rel_records = list(session.run(
+                "MATCH (ea:Entity {name: $a, user_id: $user_id, namespace: $ns})"
+                "-[r:CO_OCCURS_WITH]-(eb:Entity {name: $b, user_id: $user_id, namespace: $ns}) "
+                "WITH DISTINCT r "
+                "RETURN count(r) AS total, count(r.composite_key) AS with_key",
+                a=entity_a, b=entity_b, user_id=user_id, ns=TEST_NAMESPACE,
+            ))
+            total = rel_records[0]["total"]
+            with_key = rel_records[0]["with_key"]
+
+        assert total == 1, (
+            f"Expected exactly 1 CO_OCCURS_WITH relationship between "
+            f"'{entity_a}' and '{entity_b}' after {n_threads} concurrent "
+            f"upserts from different documents, found {total}."
+        )
+        assert with_key == 1, (
+            f"Expected the relationship to have composite_key set, "
+            f"found {with_key} of {total} with a non-null composite_key."
+        )
+    finally:
+        with graph.driver.session() as session:
+            for doc_id in document_ids:
+                session.run(
+                    "MATCH (d:Document {id: $doc_id, user_id: $user_id}) DETACH DELETE d",
+                    doc_id=doc_id, user_id=user_id,
+                )
+            session.run(
+                "MATCH (e:Entity {user_id: $user_id, namespace: $ns}) DETACH DELETE e",
+                user_id=user_id, ns=TEST_NAMESPACE,
+            )
+            session.run(
+                "MATCH (pw:PairWeight {user_id: $user_id, namespace: $ns}) DETACH DELETE pw",
+                user_id=user_id, ns=TEST_NAMESPACE,
+            )
+        graph.close()
+
+
+@pytest.mark.skipif(not HAS_LIVE_NEO4J, reason="No live Neo4j credentials in environment")
+def test_concurrent_co_occurs_with_different_documents_no_duplicate_relationship():
+    """
+    Regression test for the CO_OCCURS_WITH relationship-MERGE race --
+    noticed but deliberately left open in the v0.6.7 fix (that release
+    closed the four NODE-level races for Document/Entity/PairWeight/
+    RelationWeight; this closes the equivalent race at the relationship
+    level for CO_OCCURS_WITH).
+
+    Design: fire 8 concurrent upsert_document() calls, each with a
+    DIFFERENT document_id but the SAME two entities co-occurring in
+    the text, and the SAME user_id/namespace. CO_OCCURS_WITH
+    deliberately aggregates across documents (that's the point of
+    co-occurrence weighting), so this is the realistic race for this
+    specific relationship type -- unlike the Document/Entity race
+    above, which uses the SAME document_id, this test's threads never
+    share a document_id at all; the shared resource under contention
+    is the single CO_OCCURS_WITH relationship between the two entities
+    that every thread's MERGE tries to touch.
+
+    Without the composite_key fix, MERGE (ea)-[r:CO_OCCURS_WITH]-(eb)
+    matches only on the two endpoints and relationship type -- not
+    atomic against concurrent writers, same class of bug the node-level
+    fix closed. The fix adds composite_key (namespace + user_id +
+    sorted entity pair, canonicalized since the relationship is
+    undirected) to the MERGE pattern plus a matching uniqueness
+    constraint.
+
+    A >0 deadlock count observed here is expected under real
+    contention, not a test failure by itself -- same reasoning as the
+    Document-race test above.
+    """
+    config = GraphConfig(uri=NEO4J_URI, user=NEO4J_USER, password=NEO4J_PASSWORD)
+    graph = GraphIndex(config=config)
+
+    user_id = f"pytest-co-occurs-concurrency-user-{uuid.uuid4()}"
+    entity_a = "acme corporation"
+    entity_b = "beta industries"
+    document_ids = [
+        f"pytest-co-occurs-concurrency-doc-{i}-{uuid.uuid4()}" for i in range(8)
+    ]
+    chunks = [
+        {"text": "Acme Corporation announced a new partnership with Beta Industries today."},
+    ]
+
+    try:
+        n_threads = len(document_ids)
+        results = [None] * n_threads
+
+        def do_upsert(index):
+            try:
+                results[index] = graph.upsert_document(
+                    document_id=document_ids[index],
+                    title=f"Concurrency Regression Test Document {index}",
+                    chunks=chunks,
+                    namespace=TEST_NAMESPACE,
+                    user_id=user_id,
+                )
+            except Exception as exc:  # noqa: BLE001
+                results[index] = f"error: {exc!r}"
+
+        threads = [threading.Thread(target=do_upsert, args=(i,)) for i in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        raw_errors = [r for r in results if isinstance(r, str) and r.startswith("error")]
+        other_failures = [
+            r for r in results
+            if isinstance(r, dict) and not r.get("success")
+            and "DeadlockDetected" not in str(r.get("error", ""))
+        ]
+        assert not raw_errors, f"upsert_document() raised uncaught exceptions: {raw_errors}"
+        assert not other_failures, f"upsert_document() failed for a non-deadlock reason: {other_failures}"
+
+        with graph.driver.session() as session:
+            rel_records = list(session.run(
+                "MATCH (ea:Entity {name: $a, user_id: $user_id, namespace: $ns})"
+                "-[r:CO_OCCURS_WITH]-(eb:Entity {name: $b, user_id: $user_id, namespace: $ns}) "
+                "WITH DISTINCT r "
+                "RETURN count(r) AS total, count(r.composite_key) AS with_key",
+                a=entity_a, b=entity_b, user_id=user_id, ns=TEST_NAMESPACE,
+            ))
+            total = rel_records[0]["total"]
+            with_key = rel_records[0]["with_key"]
+
+        assert total == 1, (
+            f"Expected exactly 1 CO_OCCURS_WITH relationship between "
+            f"'{entity_a}' and '{entity_b}' after {n_threads} concurrent "
+            f"upserts from different documents, found {total}."
+        )
+        assert with_key == 1, (
+            f"Expected the relationship to have composite_key set, "
+            f"found {with_key} of {total} with a non-null composite_key."
+        )
+    finally:
+        with graph.driver.session() as session:
+            for doc_id in document_ids:
+                session.run(
+                    "MATCH (d:Document {id: $doc_id, user_id: $user_id}) DETACH DELETE d",
+                    doc_id=doc_id, user_id=user_id,
+                )
+            session.run(
+                "MATCH (e:Entity {user_id: $user_id, namespace: $ns}) DETACH DELETE e",
+                user_id=user_id, ns=TEST_NAMESPACE,
+            )
+            session.run(
+                "MATCH (pw:PairWeight {user_id: $user_id, namespace: $ns}) DETACH DELETE pw",
+                user_id=user_id, ns=TEST_NAMESPACE,
+            )
+        graph.close()
+
+
+@pytest.mark.skipif(not HAS_LIVE_NEO4J, reason="No live Neo4j credentials in environment")
+def test_concurrent_co_occurs_with_different_documents_no_duplicate_relationship():
+    """
+    Regression test for the CO_OCCURS_WITH relationship-MERGE race --
+    noticed but deliberately left open in the v0.6.7 fix (that release
+    closed the four NODE-level races for Document/Entity/PairWeight/
+    RelationWeight; this closes the equivalent race at the relationship
+    level for CO_OCCURS_WITH).
+
+    Design: fire 8 concurrent upsert_document() calls, each with a
+    DIFFERENT document_id but the SAME two entities co-occurring in
+    the text, and the SAME user_id/namespace. CO_OCCURS_WITH
+    deliberately aggregates across documents (that's the point of
+    co-occurrence weighting), so this is the realistic race for this
+    specific relationship type -- unlike the Document/Entity race
+    above, which uses the SAME document_id, this test's threads never
+    share a document_id at all; the shared resource under contention
+    is the single CO_OCCURS_WITH relationship between the two entities
+    that every thread's MERGE tries to touch.
+
+    Without the composite_key fix, MERGE (ea)-[r:CO_OCCURS_WITH]-(eb)
+    matches only on the two endpoints and relationship type -- not
+    atomic against concurrent writers, same class of bug the node-level
+    fix closed. The fix adds composite_key (namespace + user_id +
+    sorted entity pair, canonicalized since the relationship is
+    undirected) to the MERGE pattern plus a matching uniqueness
+    constraint.
+
+    A >0 deadlock count observed here is expected under real
+    contention, not a test failure by itself -- same reasoning as the
+    Document-race test above.
+    """
+    config = GraphConfig(uri=NEO4J_URI, user=NEO4J_USER, password=NEO4J_PASSWORD)
+    graph = GraphIndex(config=config)
+
+    user_id = f"pytest-co-occurs-concurrency-user-{uuid.uuid4()}"
+    entity_a = "acme corporation"
+    entity_b = "beta industries"
+    document_ids = [
+        f"pytest-co-occurs-concurrency-doc-{i}-{uuid.uuid4()}" for i in range(8)
+    ]
+    chunks = [
+        {"text": "Acme Corporation announced a new partnership with Beta Industries today."},
+    ]
+
+    try:
+        n_threads = len(document_ids)
+        results = [None] * n_threads
+
+        def do_upsert(index):
+            try:
+                results[index] = graph.upsert_document(
+                    document_id=document_ids[index],
+                    title=f"Concurrency Regression Test Document {index}",
+                    chunks=chunks,
+                    namespace=TEST_NAMESPACE,
+                    user_id=user_id,
+                )
+            except Exception as exc:  # noqa: BLE001
+                results[index] = f"error: {exc!r}"
+
+        threads = [threading.Thread(target=do_upsert, args=(i,)) for i in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        raw_errors = [r for r in results if isinstance(r, str) and r.startswith("error")]
+        other_failures = [
+            r for r in results
+            if isinstance(r, dict) and not r.get("success")
+            and "DeadlockDetected" not in str(r.get("error", ""))
+        ]
+        assert not raw_errors, f"upsert_document() raised uncaught exceptions: {raw_errors}"
+        assert not other_failures, f"upsert_document() failed for a non-deadlock reason: {other_failures}"
+
+        with graph.driver.session() as session:
+            rel_records = list(session.run(
+                "MATCH (ea:Entity {name: $a, user_id: $user_id, namespace: $ns})"
+                "-[r:CO_OCCURS_WITH]-(eb:Entity {name: $b, user_id: $user_id, namespace: $ns}) "
+                "WITH DISTINCT r "
+                "RETURN count(r) AS total, count(r.composite_key) AS with_key",
+                a=entity_a, b=entity_b, user_id=user_id, ns=TEST_NAMESPACE,
+            ))
+            total = rel_records[0]["total"]
+            with_key = rel_records[0]["with_key"]
+
+        assert total == 1, (
+            f"Expected exactly 1 CO_OCCURS_WITH relationship between "
+            f"'{entity_a}' and '{entity_b}' after {n_threads} concurrent "
+            f"upserts from different documents, found {total}."
+        )
+        assert with_key == 1, (
+            f"Expected the relationship to have composite_key set, "
+            f"found {with_key} of {total} with a non-null composite_key."
+        )
+    finally:
+        with graph.driver.session() as session:
+            for doc_id in document_ids:
+                session.run(
+                    "MATCH (d:Document {id: $doc_id, user_id: $user_id}) DETACH DELETE d",
+                    doc_id=doc_id, user_id=user_id,
+                )
+            session.run(
+                "MATCH (e:Entity {user_id: $user_id, namespace: $ns}) DETACH DELETE e",
+                user_id=user_id, ns=TEST_NAMESPACE,
+            )
+            session.run(
+                "MATCH (pw:PairWeight {user_id: $user_id, namespace: $ns}) DETACH DELETE pw",
+                user_id=user_id, ns=TEST_NAMESPACE,
+            )
+        graph.close()


### PR DESCRIPTION
Closes the CO_OCCURS_WITH relationship-MERGE race deferred from v0.6.7. See CHANGELOG.