### PR TITLE
feat(integrations): add Snowflake connector (Phase A)

### DIFF
--- a/core/integrations/factory.py
+++ b/core/integrations/factory.py
@@ -4,6 +4,7 @@ Ported from production's DatabaseConnector.get_connector().
 """
 from core.integrations.base import BaseDatabaseConnector, DataSource
 from core.integrations.sql_connectors import MySQLConnector, PostgreSQLConnector
+from core.integrations.snowflake_connector import SnowflakeConnector
 from core.integrations.mongodb import MongoDBConnector
 from core.integrations.rest_api import RestAPIConnector
 from core.integrations.csv_connector import CSVConnector
@@ -23,6 +24,7 @@ from core.integrations.crm_connectors import (
 CONNECTOR_MAP = {
     'mysql': MySQLConnector,
     'postgresql': PostgreSQLConnector,
+    'snowflake': SnowflakeConnector,
     'mongodb': MongoDBConnector,
     'rest_api': RestAPIConnector,
     'csv': CSVConnector,

--- a/core/integrations/snowflake_connector.py
+++ b/core/integrations/snowflake_connector.py
@@ -1,0 +1,142 @@
+"""
+Snowflake connector for RagLeap Core integrations.
+
+Uses the snowflake-connector-python library, lazily imported (optional
+dependency) -- same graceful-ImportError pattern as MySQLConnector/
+PostgreSQLConnector in sql_connectors.py, since Snowflake is a real
+SQL database rather than a REST API.
+
+Field usage:
+    connection_string -> JSON: {"account": "...", "user": "...", "password": "...",
+                                 "warehouse": "...", "database": "...", "schema": "..."}
+                          (account/user/password required; the rest optional)
+    query_template     -> the SQL query to run (same {{user_id}} /
+                          {{user_identifier}} substitution convention
+                          as MySQLConnector/PostgreSQLConnector)
+"""
+import json
+import logging
+from typing import Dict, Any, Tuple, List
+
+from core.integrations.base import BaseDatabaseConnector
+
+logger = logging.getLogger(__name__)
+
+REQUIRED_CONN_KEYS = ['account', 'user', 'password']
+
+
+class SnowflakeConnector(BaseDatabaseConnector):
+    """Snowflake connector using snowflake-connector-python."""
+
+    def _parse_conn(self) -> Dict[str, str]:
+        raw = (self.data_source.connection_string or '').strip()
+        if not raw:
+            raise ValueError(
+                "Snowflake connector requires connection_string as JSON: "
+                '{"account": "...", "user": "...", "password": "...", '
+                '"warehouse": "...", "database": "...", "schema": "..."}'
+            )
+        try:
+            params = json.loads(raw)
+        except Exception:
+            raise ValueError("Snowflake connector's connection_string must be valid JSON")
+        missing = [k for k in REQUIRED_CONN_KEYS if not params.get(k)]
+        if missing:
+            raise ValueError(f"Snowflake connection_string missing required keys: {', '.join(missing)}")
+        return params
+
+    def _connect(self):
+        try:
+            import snowflake.connector
+        except ImportError:
+            raise ImportError(
+                "snowflake-connector-python not installed. Run: pip install snowflake-connector-python"
+            )
+        params = self._parse_conn()
+        return snowflake.connector.connect(
+            account=params['account'],
+            user=params['user'],
+            password=params['password'],
+            warehouse=params.get('warehouse'),
+            database=params.get('database'),
+            schema=params.get('schema'),
+            login_timeout=10,
+        )
+
+    def test_connection(self) -> Tuple[bool, str]:
+        try:
+            conn = self._connect()
+            conn.close()
+            return True, "Snowflake connection successful"
+        except ImportError as e:
+            return False, str(e)
+        except ValueError as e:
+            return False, str(e)
+        except Exception as e:
+            return False, f"Snowflake connection failed: {e}"
+
+    def fetch_data(self, user_identifier: str = None) -> List[Dict]:
+        conn = self._connect()
+        try:
+            query = (self.data_source.query_template or '').strip()
+            if not query:
+                raise ValueError("Snowflake connector requires query_template (SQL query)")
+
+            params = None
+            if user_identifier:
+                query = query.replace('{{user_id}}', '%s').replace('{{user_identifier}}', '%s')
+                params = [user_identifier] * query.count('%s')
+
+            cursor = conn.cursor()
+            try:
+                cursor.execute(query, params)
+                columns = [col[0] for col in cursor.description]
+                rows = cursor.fetchall()
+                return [dict(zip(columns, row)) for row in rows]
+            finally:
+                cursor.close()
+        except ValueError:
+            raise
+        except Exception as e:
+            logger.error(f"SnowflakeConnector.fetch_data error: {e}")
+            raise
+        finally:
+            conn.close()
+
+    def introspect_schema(self) -> Dict[str, Any]:
+        try:
+            conn = self._connect()
+        except Exception as e:
+            return {'tables': [], 'filtered_count': 0, 'error': str(e)}
+        try:
+            cursor = conn.cursor()
+            try:
+                cursor.execute("SHOW TABLES")
+                all_tables = [row[1] for row in cursor.fetchall()]
+                allowed = []
+                filtered_count = 0
+                for table in all_tables:
+                    if self._is_table_blacklisted(table):
+                        filtered_count += 1
+                        continue
+                    allowed.append({'name': table, 'columns': []})
+                return {
+                    'tables': allowed,
+                    'total_tables': len(all_tables),
+                    'filtered_count': filtered_count,
+                    'db_type': 'snowflake',
+                }
+            finally:
+                cursor.close()
+        except Exception as e:
+            return {'tables': [], 'filtered_count': 0, 'error': str(e)}
+        finally:
+            conn.close()
+
+    def execute_query(self, query: str) -> List[Dict]:
+        original = self.data_source.query_template
+        self.data_source.query_template = query
+        try:
+            return self.fetch_data()
+        finally:
+            self.data_source.query_template = original

--- a/tests/test_snowflake_connector.py
+++ b/tests/test_snowflake_connector.py
@@ -1,0 +1,117 @@
+"""
+Tests for core/integrations/snowflake_connector.py -- the Snowflake connector.
+snowflake-connector-python is a heavy optional dependency that isn't
+installed in CI (matching the pymysql/psycopg2 pattern in
+sql_connectors.py -- these are lazily imported, not required deps).
+We inject a fake `snowflake.connector` module into sys.modules so the
+connector's lazy `import snowflake.connector` succeeds against a
+MagicMock, and drive behavior by configuring that mock per test.
+"""
+import os
+import sys
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Inject fake snowflake.connector module before importing the connector,
+# so its lazy `import snowflake.connector` resolves to our mock.
+_fake_connector_module = MagicMock()
+_fake_snowflake_pkg = MagicMock()
+_fake_snowflake_pkg.connector = _fake_connector_module
+sys.modules['snowflake'] = _fake_snowflake_pkg
+sys.modules['snowflake.connector'] = _fake_connector_module
+
+from core.integrations.snowflake_connector import SnowflakeConnector
+from core.integrations.base import DataSource
+
+VALID_CONN = json.dumps({
+    "account": "abc123", "user": "bot", "password": "secret",
+    "warehouse": "wh1", "database": "db1", "schema": "public",
+})
+
+
+@pytest.fixture(autouse=True)
+def reset_connect_mock():
+    _fake_connector_module.connect.reset_mock(return_value=True, side_effect=True)
+    yield
+
+
+def test_missing_connection_string_fails_gracefully():
+    ds = DataSource(id="1", name="test", source_type="snowflake", connection_string=None)
+    ok, msg = SnowflakeConnector(ds).test_connection()
+    assert ok is False
+    assert "connection_string" in msg
+
+
+def test_invalid_json_fails_gracefully():
+    ds = DataSource(id="1", name="test", source_type="snowflake", connection_string="not json")
+    ok, msg = SnowflakeConnector(ds).test_connection()
+    assert ok is False
+    assert "JSON" in msg
+
+
+def test_missing_required_keys_fails_gracefully():
+    ds = DataSource(id="1", name="test", source_type="snowflake", connection_string='{"account": "abc"}')
+    ok, msg = SnowflakeConnector(ds).test_connection()
+    assert ok is False
+    assert "missing required keys" in msg
+
+
+def test_connection_success():
+    ds = DataSource(id="1", name="test", source_type="snowflake", connection_string=VALID_CONN)
+    mock_conn = MagicMock()
+    _fake_connector_module.connect.return_value = mock_conn
+    ok, msg = SnowflakeConnector(ds).test_connection()
+    assert ok is True
+    assert "successful" in msg
+    mock_conn.close.assert_called_once()
+
+
+def test_fetch_data_requires_query_template():
+    ds = DataSource(id="1", name="test", source_type="snowflake", connection_string=VALID_CONN, query_template=None)
+    _fake_connector_module.connect.return_value = MagicMock()
+    with pytest.raises(ValueError, match="query_template"):
+        SnowflakeConnector(ds).fetch_data()
+
+
+def test_fetch_data_maps_columns():
+    ds = DataSource(
+        id="1", name="test", source_type="snowflake", connection_string=VALID_CONN,
+        query_template="SELECT * FROM t",
+    )
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_cursor.description = [("ID",), ("NAME",)]
+    mock_cursor.fetchall.return_value = [(1, "Alice"), (2, "Bob")]
+    mock_conn.cursor.return_value = mock_cursor
+    _fake_connector_module.connect.return_value = mock_conn
+    data = SnowflakeConnector(ds).fetch_data()
+    assert data == [{"ID": 1, "NAME": "Alice"}, {"ID": 2, "NAME": "Bob"}]
+
+
+def test_fetch_data_substitutes_user_identifier():
+    ds = DataSource(
+        id="1", name="test", source_type="snowflake", connection_string=VALID_CONN,
+        query_template="SELECT * FROM t WHERE id = {{user_id}}",
+    )
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_cursor.description = [("ID",)]
+    mock_cursor.fetchall.return_value = [(1,)]
+    mock_conn.cursor.return_value = mock_cursor
+    _fake_connector_module.connect.return_value = mock_conn
+    SnowflakeConnector(ds).fetch_data(user_identifier="42")
+    called_query, called_params = mock_cursor.execute.call_args.args
+    assert "%s" in called_query
+    assert called_params == ["42"]
+
+
+def test_connection_failure_surfaces_message():
+    ds = DataSource(id="1", name="test", source_type="snowflake", connection_string=VALID_CONN)
+    _fake_connector_module.connect.side_effect = Exception("account locked")
+    ok, msg = SnowflakeConnector(ds).test_connection()
+    assert ok is False
+    assert "account locked" in msg


### PR DESCRIPTION
Adds a Snowflake connector for RagLeap Core's data-source integrations, closing another of the 8 connectors requested in Discussion #169 / issue #27.

**Pattern:** Snowflake is a real SQL database, not a REST API, so this follows `MySQLConnector`/`PostgreSQLConnector`'s pattern instead of the REST-connector pattern used for Slack/Notion/Airtable/Razorpay/WooCommerce — a lazily imported optional dependency (`snowflake-connector-python`) with a graceful `ImportError` message, matching `pymysql`/`psycopg2`'s convention in `sql_connectors.py`.

**Field usage:**
- `connection_string` — JSON: `{account, user, password, warehouse, database, schema}` (account/user/password required, rest optional)
- `query_template` — the SQL query to run, same `{{user_id}}`/`{{user_identifier}}` substitution convention as MySQL/PostgreSQL

**Testing note:** `snowflake-connector-python` is a heavy optional dependency not installed in CI. Tests inject a fake `snowflake.connector` module into `sys.modules` before import, so the connector's lazy `import snowflake.connector` resolves against a `MagicMock` instead of requiring the real package — this is the technique any future SQL-driver-style connector (BigQuery, etc.) should reuse.

**Testing:** 8 unit tests (`tests/test_snowflake_connector.py`) covering missing/invalid `connection_string`, missing required keys, successful auth, missing `query_template`, column mapping from `cursor.description`, `user_identifier` substitution, and connection failures. Full `tests/` suite (57 tests) verified passing locally. Registered in `factory.py`'s `CONNECTOR_MAP` under `'snowflake'`.