### PR TITLE
Add ragleap-vectorstores to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![license MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE) [![Core Release](https://img.shields.io/github/v/release/antonyrag/ragleap-core?filter=v*&label=ragleap-core&color=blue)](https://github.com/antonyrag/ragleap-core/releases) [![9 AI Employees](https://img.shields.io/badge/9-AI%20Employees-brightgreen)](https://github.com/antonyrag/ragleap-core) [![Autonomous](https://img.shields.io/badge/Autonomous-brightgreen)](https://github.com/antonyrag/ragleap-core) [![Self--Hosted](https://img.shields.io/badge/Self--Hosted-brightgreen)](https://github.com/antonyrag/ragleap-core)
 [![PyPI ragleap-rag](https://img.shields.io/pypi/v/ragleap-rag?label=ragleap-rag)](https://pypi.org/project/ragleap-rag/) [![Downloads](https://img.shields.io/pepy/dt/ragleap-rag?label=downloads)](https://pypi.org/project/ragleap-rag/)
 [![PyPI ragleap-graph](https://img.shields.io/pypi/v/ragleap-graph?label=ragleap-graph)](https://pypi.org/project/ragleap-graph/) [![Downloads](https://img.shields.io/pepy/dt/ragleap-graph?label=downloads)](https://pypi.org/project/ragleap-graph/)
+[![PyPI ragleap-vectorstores](https://img.shields.io/pypi/v/ragleap-vectorstores?label=ragleap-vectorstores)](https://pypi.org/project/ragleap-vectorstores/) [![Downloads](https://img.shields.io/pepy/dt/ragleap-vectorstores?label=downloads)](https://pypi.org/project/ragleap-vectorstores/)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://github.com/antonyrag/ragleap-core)
 
 </div>
@@ -484,8 +485,9 @@ pip install --index-url https://packages.ragleap.com/simple/ ragleap-rag
 
 - **`ragleap-rag`** — the chunking → embedding → retrieval → generation pipeline as a library. Pluggable embeddings (12+ providers), 6 vector backends (FAISS, PgVector, Pinecone, Weaviate, Qdrant, Milvus), cross-encoder reranking, and more.
 - **`ragleap-graph`** — Neo4j-backed knowledge graph retrieval, usable standalone or alongside `ragleap-rag`.
+- **`ragleap-vectorstores`** — pluggable vector backends beyond `ragleap-rag` core's 6. First backend: Chroma, embedded/local via chromadb's `PersistentClient` — no server required. Install with `pip install ragleap-vectorstores[chroma]`.
 
-Both are MIT licensed. Browse the full package index at [packages.ragleap.com](https://packages.ragleap.com).
+All three are MIT licensed. Browse the full package index at [packages.ragleap.com](https://packages.ragleap.com).
 
 ## Supported LLM Providers (BYOK)
 


### PR DESCRIPTION
Adds ragleap-vectorstores to the main README, matching the existing ragleap-rag/ragleap-graph presentation.

Scope: README.md only.

## Changes
- Third PyPI badge line (version + downloads), same pattern as the other two packages
- Third bullet in the pip-installable packages section, describing the real current state (ChromaBackend, install command)
- Fixed 'Both are MIT licensed' -> 'All three are MIT licensed'

Deliberately left the quickstart 'pip install ragleap-rag ragleap-graph' lines untouched - ragleap-vectorstores is positioned as an optional backend-extension package everywhere else (packages.ragleap.com, ragleap.com/library), not part of the basic getting-started flow, so this stays consistent with that.