### PR TITLE
feat(ragleap-ops): k8s manifests for db/app/voice/neo4j, live-tested on kind

### DIFF
--- a/packages/ragleap-ops/.gitignore
+++ b/packages/ragleap-ops/.gitignore
@@ -1,0 +1,1 @@
+k8s/app-env-secret.yaml

--- a/packages/ragleap-ops/k8s/app-deployment.yaml
+++ b/packages/ragleap-ops/k8s/app-deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ragleap-app
+  labels:
+    app: ragleap-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ragleap-app
+  template:
+    metadata:
+      labels:
+        app: ragleap-app
+    spec:
+      imagePullSecrets:
+        - name: ghcr-pull-secret
+      initContainers:
+        - name: wait-for-db
+          image: postgres:16-alpine
+          command: ["sh", "-c", "until pg_isready -h ragleap-db -p 5432 -U ragleap; do sleep 2; done"]
+      containers:
+        - name: app
+          image: ghcr.io/antonyrag/ragleap-app:latest
+          ports:
+            - containerPort: 8000
+          envFrom:
+            - secretRef:
+                name: ragleap-app-env
+          env:
+            - name: DATABASE_URL
+              value: "postgresql://ragleap:ragleap@ragleap-db:5432/ragleap_core"
+          readinessProbe:
+            tcpSocket:
+              port: 8000
+            initialDelaySeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: 8000
+            initialDelaySeconds: 15

--- a/packages/ragleap-ops/k8s/app-service.yaml
+++ b/packages/ragleap-ops/k8s/app-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ragleap-app
+spec:
+  selector:
+    app: ragleap-app
+  ports:
+    - port: 8000
+      targetPort: 8000

--- a/packages/ragleap-ops/k8s/db-deployment.yaml
+++ b/packages/ragleap-ops/k8s/db-deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ragleap-db
+  labels:
+    app: ragleap-db
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: ragleap-db
+  template:
+    metadata:
+      labels:
+        app: ragleap-db
+    spec:
+      containers:
+        - name: db
+          image: pgvector/pgvector:pg16
+          envFrom:
+            - secretRef:
+                name: ragleap-db-secret
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: db-data
+              mountPath: /var/lib/postgresql/data
+            - name: db-schema
+              mountPath: /docker-entrypoint-initdb.d/01-schema.sql
+              subPath: schema.sql
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "ragleap"]
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "ragleap"]
+            initialDelaySeconds: 45
+            periodSeconds: 10
+            failureThreshold: 6
+      volumes:
+        - name: db-data
+          persistentVolumeClaim:
+            claimName: ragleap-db-data
+        - name: db-schema
+          configMap:
+            name: ragleap-db-schema

--- a/packages/ragleap-ops/k8s/db-pvc.yaml
+++ b/packages/ragleap-ops/k8s/db-pvc.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ragleap-db-data
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 5Gi   # UNVERIFIED — compose used an unbounded named volume, pick a real size

--- a/packages/ragleap-ops/k8s/db-schema-configmap.yaml
+++ b/packages/ragleap-ops/k8s/db-schema-configmap.yaml
@@ -1,0 +1,235 @@
+apiVersion: v1
+data:
+  schema.sql: |
+    -- RagLeap Core database schema
+    -- Requires the pgvector extension (bundled in the pgvector/pgvector Docker image)
+
+    CREATE EXTENSION IF NOT EXISTS vector;
+
+    CREATE TABLE IF NOT EXISTS documents (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        filename TEXT NOT NULL,
+        uploaded_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+    CREATE TABLE IF NOT EXISTS chunks (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        document_id UUID NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+        document_name TEXT NOT NULL,
+        chunk_index INTEGER NOT NULL,
+        text TEXT NOT NULL,
+        token_count INTEGER,
+        embedding vector(3072),
+        detected_language TEXT,
+        language_confidence REAL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+    -- pgvector's HNSW index has a hard 2000-dimension limit for standard `vector`,
+    -- but Gemini's gemini-embedding-001 produces 3072-dim vectors. We cast to
+    -- halfvec(3072) (half-precision, pgvector >= 0.7.0) to build the index within
+    -- that limit, matching the same workaround used in RagLeap's production schema.
+    CREATE INDEX IF NOT EXISTS chunks_embedding_idx
+        ON chunks USING hnsw ((embedding::halfvec(3072)) halfvec_cosine_ops);
+
+    -- Full-text search support for hybrid (dense + sparse) retrieval.
+    -- Generated column stays in sync automatically on insert/update.
+    ALTER TABLE chunks ADD COLUMN IF NOT EXISTS text_search_vector tsvector
+        GENERATED ALWAYS AS (to_tsvector('english', text)) STORED;
+
+    CREATE INDEX IF NOT EXISTS chunks_text_search_idx
+        ON chunks USING GIN (text_search_vector);
+
+    -- Integrations: external data sources (databases, CRMs, SaaS APIs) that can
+    -- sync per-user context into RAG responses. Single-tenant — no workspace scoping.
+    CREATE TABLE IF NOT EXISTS data_sources (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        name TEXT NOT NULL UNIQUE,
+        source_type TEXT NOT NULL,
+
+        -- Connection details (encrypted at the application layer via Fernet
+        -- before being written here — never store plaintext credentials)
+        connection_string TEXT,
+        api_endpoint TEXT,
+        api_key TEXT,
+        api_headers JSONB DEFAULT '{}',
+
+        -- Query configuration
+        query_template TEXT,
+        field_mappings JSONB DEFAULT '{}',
+        user_identifier_field TEXT NOT NULL DEFAULT 'user_id',
+        documents_table_name TEXT NOT NULL DEFAULT 'documents',
+
+        -- Sync configuration
+        sync_interval_minutes INTEGER NOT NULL DEFAULT 360,
+        last_sync_at TIMESTAMPTZ,
+        last_sync_status TEXT NOT NULL DEFAULT 'pending',
+        last_sync_error TEXT,
+        last_sync_record_count INTEGER NOT NULL DEFAULT 0,
+
+        is_active BOOLEAN NOT NULL DEFAULT true,
+
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+    -- Customer/user context synced from external data sources, used to
+    -- personalize RAG responses.
+    CREATE TABLE IF NOT EXISTS synced_context_data (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        data_source_id UUID NOT NULL REFERENCES data_sources(id) ON DELETE CASCADE,
+        user_identifier TEXT NOT NULL,
+        context_data JSONB NOT NULL DEFAULT '{}',
+        synced_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        last_updated TIMESTAMPTZ NOT NULL DEFAULT now(),
+        source_updated_at TIMESTAMPTZ,
+        UNIQUE (data_source_id, user_identifier)
+    );
+
+    CREATE INDEX IF NOT EXISTS synced_context_data_lookup_idx
+        ON synced_context_data (data_source_id, user_identifier);
+
+
+    CREATE TABLE IF NOT EXISTS business_profile (
+        id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        business_name         TEXT NOT NULL DEFAULT '',
+        industry              TEXT NOT NULL DEFAULT '',
+        description           TEXT NOT NULL DEFAULT '',
+        products_services     TEXT NOT NULL DEFAULT '',
+        target_customers      TEXT NOT NULL DEFAULT '',
+        working_hours         TEXT NOT NULL DEFAULT '',
+        location              TEXT NOT NULL DEFAULT '',
+        tone_preference       TEXT NOT NULL DEFAULT 'friendly',
+        primary_language      TEXT NOT NULL DEFAULT 'en',
+        additional_languages  JSONB NOT NULL DEFAULT '[]',
+        owner_instructions    TEXT NOT NULL DEFAULT '',
+        auto_learned_profile  TEXT NOT NULL DEFAULT '',
+        skill_version         INTEGER NOT NULL DEFAULT 0,
+        is_profile_complete   BOOLEAN NOT NULL DEFAULT false,
+        last_learned_at       TIMESTAMPTZ,
+        created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+    CREATE TABLE IF NOT EXISTS employee_roles (
+        id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        role             TEXT NOT NULL UNIQUE,
+        display_name     TEXT NOT NULL DEFAULT '',
+        is_active        BOOLEAN NOT NULL DEFAULT true,
+        channels         JSONB NOT NULL DEFAULT '[]',
+        skill_tags       JSONB NOT NULL DEFAULT '[]',
+        personality      TEXT NOT NULL DEFAULT '',
+        skills_summary   TEXT NOT NULL DEFAULT '',
+        last_learned_at  TIMESTAMPTZ,
+        created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+    CREATE TABLE IF NOT EXISTS employee_memory (
+        id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        text_content       TEXT NOT NULL,
+        summary            TEXT NOT NULL DEFAULT '',
+        tags               JSONB NOT NULL DEFAULT '[]',
+        importance         REAL NOT NULL DEFAULT 0.7,
+        source             TEXT NOT NULL DEFAULT 'interaction',
+        permanent          BOOLEAN NOT NULL DEFAULT false,
+        review_after_days  INTEGER NOT NULL DEFAULT 180,
+        content_hash       TEXT NOT NULL,
+        embedding          vector(3072),
+        token_count        INTEGER NOT NULL DEFAULT 0,
+        created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+    CREATE INDEX IF NOT EXISTS employee_memory_embedding_idx
+        ON employee_memory USING hnsw ((embedding::halfvec(3072)) halfvec_cosine_ops);
+    CREATE INDEX IF NOT EXISTS employee_memory_tags_idx
+        ON employee_memory USING GIN (tags);
+    CREATE INDEX IF NOT EXISTS employee_memory_hash_idx
+        ON employee_memory (content_hash, source);
+
+    -- n8n workflow automation. Single-tenant — no workspace scoping.
+    -- Fires a webhook after the AI replies on a matching channel; caller
+    -- (channel adapter) supplies channel/message/ai_reply, this module never
+    -- raises — a broken workflow config should never break the main chat flow.
+    CREATE TABLE IF NOT EXISTS n8n_workflows (
+        id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        name        TEXT NOT NULL,
+        description TEXT NOT NULL DEFAULT '',
+        webhook_url TEXT NOT NULL,
+        channels    JSONB NOT NULL DEFAULT '[]',
+        is_active   BOOLEAN NOT NULL DEFAULT false,
+        created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+    CREATE INDEX IF NOT EXISTS n8n_workflows_active_idx
+        ON n8n_workflows (is_active);
+
+    -- Autonomous Loop settings — single-tenant port of production's
+    -- api/autonomy_engine.py. One row (singleton, no workspace FK).
+    CREATE TABLE IF NOT EXISTS autonomy_settings (
+        id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        mode              TEXT NOT NULL DEFAULT 'off',
+        channels          JSONB NOT NULL DEFAULT '[]',
+        actions           JSONB NOT NULL DEFAULT '[]',
+        approval_channel  TEXT NOT NULL DEFAULT 'telegram',
+        approval_target   TEXT NOT NULL DEFAULT '',
+        updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+    -- Pending actions awaiting owner approval in "semi" mode.
+    CREATE TABLE IF NOT EXISTS autonomy_pending (
+        action_id     TEXT PRIMARY KEY,
+        action_type   TEXT NOT NULL,
+        channel       TEXT NOT NULL,
+        target        TEXT NOT NULL,
+        content       TEXT NOT NULL,
+        subject       TEXT NOT NULL DEFAULT '',
+        created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+    -- Bounded audit log of every autonomous action (executed, rejected, or errored).
+    CREATE TABLE IF NOT EXISTS autonomy_log (
+        id           BIGSERIAL PRIMARY KEY,
+        action_type  TEXT NOT NULL,
+        channel      TEXT NOT NULL,
+        target       TEXT NOT NULL,
+        content      TEXT NOT NULL,
+        result       TEXT NOT NULL,
+        approved     BOOLEAN NOT NULL DEFAULT true,
+        created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+    CREATE INDEX IF NOT EXISTS autonomy_log_created_idx
+        ON autonomy_log (created_at DESC);
+
+    -- Tracks the most recent role-based reply per (channel, chat_id), so
+    -- an owner can send a quick feedback command (thumbs up/down,
+    -- "helpful"/"not helpful") that gets attributed to the correct
+    -- memory entries via core.employees.learning.record_role_memory_outcome().
+    -- Without this table there is no real success/failure signal available
+    -- in the channels -- see core/employees/feedback.py.
+    CREATE TABLE IF NOT EXISTS role_reply_log (
+        channel          TEXT NOT NULL,
+        chat_id          TEXT NOT NULL,
+        role_memory_ids  JSONB NOT NULL DEFAULT '[]',
+        created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+        PRIMARY KEY (channel, chat_id)
+    );
+
+    -- Owner-configured default AI Employee role per channel (e.g. telegram ->
+    -- manager, whatsapp -> support). Falls back to 'support' when unset. See
+    -- core/employees/channel_roles.py for the routing logic that uses this.
+    CREATE TABLE IF NOT EXISTS channel_role_config (
+        channel     TEXT PRIMARY KEY,
+        role        TEXT NOT NULL DEFAULT 'support',
+        updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+    -- CSV connector content storage — no persistent disk volume exists in
+    -- docker-compose.yml, so CSV content lives in Postgres like everything
+    -- else in Core, rather than on the container filesystem.
+    ALTER TABLE data_sources ADD COLUMN IF NOT EXISTS csv_content TEXT;
+    ALTER TABLE data_sources ADD COLUMN IF NOT EXISTS csv_filename TEXT;
+kind: ConfigMap
+metadata:
+  name: ragleap-db-schema

--- a/packages/ragleap-ops/k8s/db-secret.yaml
+++ b/packages/ragleap-ops/k8s/db-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ragleap-db-secret
+type: Opaque
+stringData:
+  POSTGRES_USER: ragleap
+  POSTGRES_PASSWORD: ragleap
+  POSTGRES_DB: ragleap_core

--- a/packages/ragleap-ops/k8s/db-service.yaml
+++ b/packages/ragleap-ops/k8s/db-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ragleap-db
+spec:
+  selector:
+    app: ragleap-db
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/packages/ragleap-ops/k8s/neo4j-deployment.yaml
+++ b/packages/ragleap-ops/k8s/neo4j-deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ragleap-neo4j
+  labels:
+    app: ragleap-neo4j
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: ragleap-neo4j
+  template:
+    metadata:
+      labels:
+        app: ragleap-neo4j
+    spec:
+      containers:
+        - name: neo4j
+          image: neo4j:5-community
+          envFrom:
+            - secretRef:
+                name: ragleap-neo4j-secret
+          env:
+            - name: NEO4J_PLUGINS
+              value: "[]"
+          ports:
+            - containerPort: 7474
+            - containerPort: 7687
+          volumeMounts:
+            - name: neo4j-data
+              mountPath: /data
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 7474
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 7474
+            initialDelaySeconds: 20
+            periodSeconds: 10
+      volumes:
+        - name: neo4j-data
+          persistentVolumeClaim:
+            claimName: ragleap-neo4j-data

--- a/packages/ragleap-ops/k8s/neo4j-pvc.yaml
+++ b/packages/ragleap-ops/k8s/neo4j-pvc.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ragleap-neo4j-data
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 5Gi   # UNVERIFIED — compose volume was unbounded, pick a real size

--- a/packages/ragleap-ops/k8s/neo4j-secret.yaml
+++ b/packages/ragleap-ops/k8s/neo4j-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ragleap-neo4j-secret
+type: Opaque
+stringData:
+  NEO4J_AUTH: neo4j/ragleapgraph

--- a/packages/ragleap-ops/k8s/neo4j-service.yaml
+++ b/packages/ragleap-ops/k8s/neo4j-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ragleap-neo4j
+spec:
+  selector:
+    app: ragleap-neo4j
+  ports:
+    - name: http
+      port: 7474
+      targetPort: 7474
+    - name: bolt
+      port: 7687
+      targetPort: 7687

--- a/packages/ragleap-ops/k8s/voice-deployment.yaml
+++ b/packages/ragleap-ops/k8s/voice-deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ragleap-voice
+  labels:
+    app: ragleap-voice
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ragleap-voice
+  template:
+    metadata:
+      labels:
+        app: ragleap-voice
+    spec:
+      imagePullSecrets:
+        - name: ghcr-pull-secret
+      initContainers:
+        - name: wait-for-db
+          image: postgres:16-alpine
+          command: ["sh", "-c", "until pg_isready -h ragleap-db -p 5432 -U ragleap; do sleep 2; done"]
+      containers:
+        - name: voice
+          image: ghcr.io/antonyrag/ragleap-app:latest
+          command: ["python3", "-m", "channels.voice.server"]
+          ports:
+            - containerPort: 8765
+          envFrom:
+            - secretRef:
+                name: ragleap-app-env
+          env:
+            - name: DATABASE_URL
+              value: "postgresql://ragleap:ragleap@ragleap-db:5432/ragleap_core"

--- a/packages/ragleap-ops/k8s/voice-service.yaml
+++ b/packages/ragleap-ops/k8s/voice-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ragleap-voice
+spec:
+  selector:
+    app: ragleap-voice
+  ports:
+    - port: 8765
+      targetPort: 8765


### PR DESCRIPTION
Adds Kubernetes Deployment + Service manifests for all four docker-compose services (db, app, voice, neo4j), translated from real docker-compose.yml values.

Live-tested end-to-end on a local kind cluster: all 4 pods reached 1/1 Running with 0 restarts after fixing a db liveness-probe timing bug (initial delay was too short for first-boot image pull + PVC attach — found via live testing, not assumed).

app/voice now pull a real image (ghcr.io/antonyrag/ragleap-app:latest, built+pushed from the existing Dockerfile) via an imagePullSecret, since the private GHCR visibility toggle wasn't accessible via API.

Not yet included: Helm chart (raw manifests proven first), CHANGELOG entry, packages.ragleap.com doc page, wiki update. app-env-secret.yaml is gitignored — regenerate locally via kubectl create secret --from-env-file, real secret values should never be committed.