### PR TITLE
feat(ragleap-ops): add package scaffold for release automation

### DIFF
--- a/packages/ragleap-ops/README.md
+++ b/packages/ragleap-ops/README.md
@@ -1,0 +1,32 @@
+# ragleap-ops
+
+Kubernetes deployment manifests for RagLeap Core.
+
+Ships Deployment + Service manifests for all four `docker-compose.yml`
+services (`db`, `app`, `voice`, `neo4j`), translated from the real
+compose file and live-tested end-to-end on a `kind` cluster — all four
+pods reached `1/1 Running` with zero restarts after a probe-timing bug
+was found and fixed via live testing.
+
+## Contents
+
+- `k8s/` — raw Deployment, Service, PVC, Secret, and ConfigMap manifests
+- Apply order: Secrets/ConfigMap → PVCs → `db` → everything else
+  (`app`/`voice` depend on `db` via an init container that polls
+  `pg_isready`)
+
+## Regenerating local-only files
+
+Two files are intentionally **not** committed (see `.gitignore`) since
+they'd otherwise bake real secret values into git history:
+
+```bash
+kubectl create secret generic ragleap-app-env \
+  --from-env-file=$HOME/ragleap-core/.env \
+  --dry-run=client -o yaml > k8s/app-env-secret.yaml
+```
+
+## Status
+
+Raw manifests are live-verified. A Helm chart wrapping these is not
+yet built.

--- a/packages/ragleap-ops/pyproject.toml
+++ b/packages/ragleap-ops/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ragleap-ops"
+version = "0.1.0"
+description = "Kubernetes deployment manifests for RagLeap Core, live-tested against a real cluster"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [
+    { name = "RagLeap Contributors" }
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]
+dependencies = []
+
+[project.urls]
+Homepage = "https://packages.ragleap.com/docs/ragleap-ops.html"
+
+[tool.hatchling.build.targets.wheel]
+packages = ["src/ragleap_ops"]

--- a/packages/ragleap-ops/src/ragleap_ops/__init__.py
+++ b/packages/ragleap-ops/src/ragleap_ops/__init__.py
@@ -1,0 +1,13 @@
+"""ragleap-ops: Kubernetes deployment tooling for RagLeap Core.
+
+This package ships k8s/ Deployment and Service manifests for all four
+docker-compose services (db, app, voice, neo4j), translated from the
+real docker-compose.yml and live-tested end-to-end on a kind cluster.
+
+It contains almost no importable Python — its purpose is to let the
+existing PyPI/git-tag release automation version and ship the k8s/
+manifests alongside this src/ tree, matching the release discipline of
+ragleap-rag, ragleap-graph, and ragleap-vectorstores.
+"""
+
+__version__ = "0.1.0"

--- a/packages/ragleap-ops/tests/test_version.py
+++ b/packages/ragleap-ops/tests/test_version.py
@@ -1,0 +1,5 @@
+import ragleap_ops
+
+
+def test_version_is_set():
+    assert ragleap_ops.__version__ == "0.1.0"


### PR DESCRIPTION
Adds pyproject.toml, src/ragleap_ops/, tests/, and README.md so ragleap-ops can be built/versioned via the existing release.yml automation. The k8s/ manifests (merged in #232) already exist; this adds the Python packaging layer around them. Verified: pip install -e . succeeds, pytest passes, import resolves to the correct venv-managed path.