### PR TITLE
Add ragleap-vectorstores to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ Add `ragleap-graph` too if you want Neo4j-backed knowledge graph retrieval:
 pip install ragleap-rag ragleap-graph
 ```
 
+Add `ragleap-vectorstores` too if you want pluggable vector backends beyond ragleap-rag's built-in six (Chroma today):
+```bash
+pip install ragleap-rag ragleap-vectorstores[chroma]
+# or, with uv
+uv add ragleap-rag ragleap-vectorstores[chroma]
+```
+
 Or run the full self-hosted app (channels, web chat UI, Docker Compose) — see [Quickstart](#quickstart) below. Browse every package at [packages.ragleap.com](https://packages.ragleap.com). Try it hands-on with the runnable scripts in [examples/](examples/) — `01_ingest_and_query.py` (upload a document, ask a question via the API) and `02_test_channel_directly.py` (test channel answering logic without real bot credentials).
 
 ## If a RAG chatbot answers questions, RagLeap runs your business


### PR DESCRIPTION
Adds ragleap-vectorstores to the main README's quickstart Install section, matching the existing ragleap-graph pattern (pip + uv install block).

Scope: README.md only - just the top-level quickstart section. The badge line and packages-list bullet were already added to main independently by a concurrent session before this branch was rebuilt (see closed PR #231 for that history), so this PR only adds what was still missing.

Verified: install commands match the real published package name and extra (`ragleap-vectorstores[chroma]`).