### PR TITLE
feat(integrations): add BigQuery connector (Phase A)

### DIFF
--- a/core/integrations/bigquery_connector.py
+++ b/core/integrations/bigquery_connector.py
@@ -1,0 +1,137 @@
+"""
+BigQuery connector for RagLeap Core integrations.
+
+Uses the google-cloud-bigquery library, lazily imported (optional
+dependency) -- same graceful-ImportError pattern as SnowflakeConnector/
+MySQLConnector/PostgreSQLConnector, since BigQuery is a real SQL
+warehouse rather than a REST API.
+
+Field usage:
+    connection_string -> the full GCP service account JSON key (as a string)
+    api_endpoint       -> optional GCP project ID override (if omitted,
+                          uses the project_id embedded in the service
+                          account JSON)
+    query_template     -> the SQL query to run. Use {{user_id}} or
+                          {{user_identifier}} as a placeholder -- it's
+                          converted to a proper BigQuery named query
+                          parameter (@user_identifier) rather than raw
+                          string substitution, to avoid SQL injection.
+"""
+import json
+import logging
+from typing import Dict, Any, Tuple, List
+
+from core.integrations.base import BaseDatabaseConnector
+
+logger = logging.getLogger(__name__)
+
+
+class BigQueryConnector(BaseDatabaseConnector):
+    """BigQuery connector using google-cloud-bigquery (service account JSON auth)."""
+
+    def _parse_credentials(self) -> Dict[str, Any]:
+        raw = (self.data_source.connection_string or '').strip()
+        if not raw:
+            raise ValueError(
+                "BigQuery connector requires connection_string as the full "
+                "GCP service account JSON key"
+            )
+        try:
+            creds_dict = json.loads(raw)
+        except Exception:
+            raise ValueError("BigQuery connector's connection_string must be valid JSON")
+        if not creds_dict.get('project_id') and not (self.data_source.api_endpoint or '').strip():
+            raise ValueError(
+                "BigQuery connector requires a project_id -- either in the "
+                "service account JSON or via api_endpoint"
+            )
+        return creds_dict
+
+    def _client(self):
+        try:
+            from google.cloud import bigquery
+            from google.oauth2 import service_account
+        except ImportError:
+            raise ImportError(
+                "google-cloud-bigquery not installed. Run: pip install google-cloud-bigquery"
+            )
+        creds_dict = self._parse_credentials()
+        credentials = service_account.Credentials.from_service_account_info(creds_dict)
+        project_id = (self.data_source.api_endpoint or '').strip() or creds_dict.get('project_id')
+        return bigquery.Client(credentials=credentials, project=project_id)
+
+    def test_connection(self) -> Tuple[bool, str]:
+        try:
+            client = self._client()
+            list(client.list_datasets(max_results=1))
+            return True, "BigQuery connection successful"
+        except ImportError as e:
+            return False, str(e)
+        except ValueError as e:
+            return False, str(e)
+        except Exception as e:
+            return False, f"BigQuery connection failed: {e}"
+
+    def fetch_data(self, user_identifier: str = None) -> List[Dict]:
+        try:
+            from google.cloud import bigquery
+        except ImportError:
+            raise ImportError(
+                "google-cloud-bigquery not installed. Run: pip install google-cloud-bigquery"
+            )
+        client = self._client()
+
+        query = (self.data_source.query_template or '').strip()
+        if not query:
+            raise ValueError("BigQuery connector requires query_template (SQL query)")
+
+        job_config = None
+        if user_identifier:
+            query = query.replace('{{user_id}}', '@user_identifier').replace(
+                '{{user_identifier}}', '@user_identifier'
+            )
+            job_config = bigquery.QueryJobConfig(
+                query_parameters=[bigquery.ScalarQueryParameter("user_identifier", "STRING", user_identifier)]
+            )
+
+        try:
+            query_job = client.query(query, job_config=job_config)
+            rows = query_job.result()
+            return [dict(row.items()) for row in rows]
+        except Exception as e:
+            logger.error(f"BigQueryConnector.fetch_data error: {e}")
+            raise
+
+    def introspect_schema(self) -> Dict[str, Any]:
+        try:
+            client = self._client()
+        except Exception as e:
+            return {'tables': [], 'filtered_count': 0, 'error': str(e)}
+        try:
+            allowed = []
+            filtered_count = 0
+            total = 0
+            for dataset in client.list_datasets():
+                for table in client.list_tables(dataset.dataset_id):
+                    total += 1
+                    table_name = f"{dataset.dataset_id}.{table.table_id}"
+                    if self._is_table_blacklisted(table.table_id):
+                        filtered_count += 1
+                        continue
+                    allowed.append({'name': table_name, 'columns': []})
+            return {
+                'tables': allowed,
+                'total_tables': total,
+                'filtered_count': filtered_count,
+                'db_type': 'bigquery',
+            }
+        except Exception as e:
+            return {'tables': [], 'filtered_count': 0, 'error': str(e)}
+
+    def execute_query(self, query: str) -> List[Dict]:
+        original = self.data_source.query_template
+        self.data_source.query_template = query
+        try:
+            return self.fetch_data()
+        finally:
+            self.data_source.query_template = original

--- a/core/integrations/factory.py
+++ b/core/integrations/factory.py
@@ -5,6 +5,7 @@ Ported from production's DatabaseConnector.get_connector().
 from core.integrations.base import BaseDatabaseConnector, DataSource
 from core.integrations.sql_connectors import MySQLConnector, PostgreSQLConnector
 from core.integrations.snowflake_connector import SnowflakeConnector
+from core.integrations.bigquery_connector import BigQueryConnector
 from core.integrations.mongodb import MongoDBConnector
 from core.integrations.rest_api import RestAPIConnector
 from core.integrations.csv_connector import CSVConnector
@@ -25,6 +26,7 @@ CONNECTOR_MAP = {
     'mysql': MySQLConnector,
     'postgresql': PostgreSQLConnector,
     'snowflake': SnowflakeConnector,
+    'bigquery': BigQueryConnector,
     'mongodb': MongoDBConnector,
     'rest_api': RestAPIConnector,
     'csv': CSVConnector,

--- a/tests/test_bigquery_connector.py
+++ b/tests/test_bigquery_connector.py
@@ -1,0 +1,128 @@
+"""
+Tests for core/integrations/bigquery_connector.py -- the BigQuery connector.
+google-cloud-bigquery is a heavy optional dependency not installed in
+CI (same convention as snowflake-connector-python for
+SnowflakeConnector). We inject fake google.cloud.bigquery and
+google.oauth2.service_account modules into sys.modules so the
+connector's lazy imports succeed against MagicMocks.
+"""
+import os
+import sys
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+_fake_bigquery_module = MagicMock()
+_fake_cloud_pkg = MagicMock()
+_fake_cloud_pkg.bigquery = _fake_bigquery_module
+_fake_google_pkg = MagicMock()
+_fake_google_pkg.cloud = _fake_cloud_pkg
+sys.modules['google'] = _fake_google_pkg
+sys.modules['google.cloud'] = _fake_cloud_pkg
+sys.modules['google.cloud.bigquery'] = _fake_bigquery_module
+
+_fake_service_account_module = MagicMock()
+_fake_oauth2_pkg = MagicMock()
+_fake_oauth2_pkg.service_account = _fake_service_account_module
+_fake_google_pkg.oauth2 = _fake_oauth2_pkg
+sys.modules['google.oauth2'] = _fake_oauth2_pkg
+sys.modules['google.oauth2.service_account'] = _fake_service_account_module
+
+from core.integrations.bigquery_connector import BigQueryConnector
+from core.integrations.base import DataSource
+
+VALID_CREDS = json.dumps({
+    "type": "service_account", "project_id": "my-project",
+    "client_email": "bot@my-project.iam.gserviceaccount.com",
+})
+
+
+@pytest.fixture(autouse=True)
+def reset_mocks():
+    _fake_bigquery_module.reset_mock()
+    _fake_service_account_module.reset_mock()
+    yield
+
+
+def test_missing_connection_string_fails_gracefully():
+    ds = DataSource(id="1", name="test", source_type="bigquery", connection_string=None)
+    ok, msg = BigQueryConnector(ds).test_connection()
+    assert ok is False
+    assert "connection_string" in msg
+
+
+def test_invalid_json_fails_gracefully():
+    ds = DataSource(id="1", name="test", source_type="bigquery", connection_string="not json")
+    ok, msg = BigQueryConnector(ds).test_connection()
+    assert ok is False
+    assert "JSON" in msg
+
+
+def test_missing_project_id_without_override_fails_gracefully():
+    ds = DataSource(id="1", name="test", source_type="bigquery", connection_string='{"type": "service_account"}')
+    ok, msg = BigQueryConnector(ds).test_connection()
+    assert ok is False
+    assert "project_id" in msg
+
+
+def test_connection_success():
+    ds = DataSource(id="1", name="test", source_type="bigquery", connection_string=VALID_CREDS)
+    mock_client = MagicMock()
+    mock_client.list_datasets.return_value = []
+    _fake_bigquery_module.Client.return_value = mock_client
+    ok, msg = BigQueryConnector(ds).test_connection()
+    assert ok is True
+    assert "successful" in msg
+
+
+def test_fetch_data_requires_query_template():
+    ds = DataSource(id="1", name="test", source_type="bigquery", connection_string=VALID_CREDS, query_template=None)
+    _fake_bigquery_module.Client.return_value = MagicMock()
+    with pytest.raises(ValueError, match="query_template"):
+        BigQueryConnector(ds).fetch_data()
+
+
+def test_fetch_data_maps_rows():
+    ds = DataSource(
+        id="1", name="test", source_type="bigquery", connection_string=VALID_CREDS,
+        query_template="SELECT * FROM t",
+    )
+    mock_client = MagicMock()
+    mock_row1 = MagicMock()
+    mock_row1.items.return_value = [("id", 1), ("name", "Alice")]
+    mock_row2 = MagicMock()
+    mock_row2.items.return_value = [("id", 2), ("name", "Bob")]
+    mock_query_job = MagicMock()
+    mock_query_job.result.return_value = [mock_row1, mock_row2]
+    mock_client.query.return_value = mock_query_job
+    _fake_bigquery_module.Client.return_value = mock_client
+    data = BigQueryConnector(ds).fetch_data()
+    assert data == [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
+
+
+def test_fetch_data_uses_named_parameter_for_user_identifier():
+    ds = DataSource(
+        id="1", name="test", source_type="bigquery", connection_string=VALID_CREDS,
+        query_template="SELECT * FROM t WHERE id = {{user_id}}",
+    )
+    mock_client = MagicMock()
+    mock_query_job = MagicMock()
+    mock_query_job.result.return_value = []
+    mock_client.query.return_value = mock_query_job
+    _fake_bigquery_module.Client.return_value = mock_client
+    BigQueryConnector(ds).fetch_data(user_identifier="42")
+    called_query = mock_client.query.call_args.args[0]
+    assert "@user_identifier" in called_query
+    assert "{{user_id}}" not in called_query
+    _fake_bigquery_module.ScalarQueryParameter.assert_called_once_with("user_identifier", "STRING", "42")
+
+
+def test_connection_failure_surfaces_message():
+    ds = DataSource(id="1", name="test", source_type="bigquery", connection_string=VALID_CREDS)
+    _fake_bigquery_module.Client.side_effect = Exception("permission denied")
+    ok, msg = BigQueryConnector(ds).test_connection()
+    assert ok is False
+    assert "permission denied" in msg


### PR DESCRIPTION
Adds a BigQuery connector for RagLeap Core's data-source integrations, closing the 7th of the 8 connectors requested in Discussion #169 / issue #27.

**Pattern:** Follows `SnowflakeConnector`'s SQL-driver pattern -- a lazily imported optional dependency (`google-cloud-bigquery`) with a graceful `ImportError` message, rather than the plain-`requests` pattern used for the REST connectors.

**Field usage:**
- `connection_string` — the full GCP service account JSON key
- `api_endpoint` — optional GCP project ID override (falls back to the `project_id` embedded in the service account JSON)
- `query_template` — the SQL query to run

**Parameterization note:** Unlike MySQL/PostgreSQL/Snowflake's simple `%s` string substitution, BigQuery's client library supports real named query parameters. So `{{user_id}}`/`{{user_identifier}}` here convert to a proper `@user_identifier` parameter bound via `QueryJobConfig`, not raw string substitution -- a small safety improvement worth carrying back to the other SQL connectors at some point, though out of scope for this PR.

**Testing:** 8 unit tests (`tests/test_bigquery_connector.py`) covering missing/invalid `connection_string`, missing `project_id` without an `api_endpoint` override, successful auth, missing `query_template`, row mapping, named-parameter substitution, and connection failures. Tests inject fake `google.cloud.bigquery`/`google.oauth2.service_account` modules into `sys.modules`, same technique as `SnowflakeConnector`'s tests. Full `tests/` suite (65 tests) verified passing locally. Registered in `factory.py`'s `CONNECTOR_MAP` under `'bigquery'`.

Only Gmail remains after this — it needs a different design since it's OAuth2, not a static token like every connector so far.