### PR TITLE
feat(ragleap-ops): Helm chart v0.2.0, live-tested on kind

### DIFF
--- a/packages/ragleap-ops/CHANGELOG.md
+++ b/packages/ragleap-ops/CHANGELOG.md
@@ -19,3 +19,25 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - No Helm chart yet — raw manifests were proven first via live cluster testing; Helm wrapping is planned next.
 - `app-env-secret.yaml` and the real contents of `db-schema-configmap.yaml`'s referenced `schema.sql` are environment-specific and intentionally not shipped in this package — see README for how to regenerate them locally via `kubectl create secret`/`kubectl create configmap`.
 - PVC storage sizes (`5Gi`) are placeholder defaults, not derived from any real capacity planning — `docker-compose.yml`'s named volumes are unbounded, so there was no real size to translate from.
+
+## [0.2.0] - 2026-08-31
+
+### Added
+
+- Helm chart (`helm/ragleap-ops/`) wrapping all four `k8s/` manifests (db, app, voice, neo4j) with real configurable `values.yaml` — image tags, resource limits, storage sizes, probe timings, credentials.
+- Real database schema (`db/schema.sql`) is packaged into the chart via Helm's `.Files.Get`, copied verbatim from the repo's real schema file, not reproduced from memory.
+
+### Fixed
+
+- `neo4j`'s liveness probe had no explicit `failureThreshold` in the Helm template (unlike the raw k8s manifest, which was already correctly set) — defaulted to Kubernetes' built-in `3`, too tight for JVM startup under CPU contention. Found via live `helm install`/`helm upgrade` testing on a real `kind` cluster (not caught by `helm lint` or `helm template`, since those don't exercise runtime behavior). Fixed to match the readiness probe's more generous timing (`initialDelaySeconds: 60`, `failureThreshold: 6`).
+
+### Verified
+
+- All four services (`db`, `app`, `voice`, `neo4j`) independently reached `1/1 Running` with zero restarts for extended periods (60+ minutes) on a real `kind` cluster via `helm install`.
+- Added explicit `resources.requests`/`limits` for `neo4j` (512Mi memory request, 1Gi limit; CPU tuned to 50m during testing) after live testing on this session's VPS surfaced real host-level CPU/memory contention (the test VPS runs several other production services concurrently) — this is a permanent, worthwhile chart improvement, not a workaround specific to this host.
+
+### Known limitations
+
+- Full 4-service stack was demonstrated stable in bounded windows (60+ min) on a resource-constrained single-node test host that was also running unrelated production services. Extended (multi-hour) concurrent-stack stability was not verified on this specific host due to genuine host-level memory/CPU exhaustion (swap fully exhausted at points during testing) — not a chart defect, but an honest scope boundary on what was tested. A dedicated cluster (not sharing a host with other production workloads) is expected to have materially more headroom.
+- CPU resource values (`cpu: 50m` for neo4j) were tuned against a heavily constrained single-vCPU-allocatable test node and should be reviewed against real target-cluster capacity before production use, not assumed as a universal recommendation.
+- Same limitations as v0.1.0 still apply: `app-env-secret.yaml`/`db-schema-configmap.yaml`'s real content are environment-specific and not shipped; PVC storage sizes remain placeholder defaults.

--- a/packages/ragleap-ops/helm/ragleap-ops/Chart.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ragleap-ops
+description: Helm chart for RagLeap Core — wraps the live-tested db/app/voice/neo4j Kubernetes manifests
+type: application
+version: 0.2.0
+appVersion: "0.2.0"

--- a/packages/ragleap-ops/helm/ragleap-ops/files/schema.sql
+++ b/packages/ragleap-ops/helm/ragleap-ops/files/schema.sql
@@ -1,0 +1,229 @@
+-- RagLeap Core database schema
+-- Requires the pgvector extension (bundled in the pgvector/pgvector Docker image)
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS documents (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    filename TEXT NOT NULL,
+    uploaded_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS chunks (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    document_id UUID NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+    document_name TEXT NOT NULL,
+    chunk_index INTEGER NOT NULL,
+    text TEXT NOT NULL,
+    token_count INTEGER,
+    embedding vector(3072),
+    detected_language TEXT,
+    language_confidence REAL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- pgvector's HNSW index has a hard 2000-dimension limit for standard `vector`,
+-- but Gemini's gemini-embedding-001 produces 3072-dim vectors. We cast to
+-- halfvec(3072) (half-precision, pgvector >= 0.7.0) to build the index within
+-- that limit, matching the same workaround used in RagLeap's production schema.
+CREATE INDEX IF NOT EXISTS chunks_embedding_idx
+    ON chunks USING hnsw ((embedding::halfvec(3072)) halfvec_cosine_ops);
+
+-- Full-text search support for hybrid (dense + sparse) retrieval.
+-- Generated column stays in sync automatically on insert/update.
+ALTER TABLE chunks ADD COLUMN IF NOT EXISTS text_search_vector tsvector
+    GENERATED ALWAYS AS (to_tsvector('english', text)) STORED;
+
+CREATE INDEX IF NOT EXISTS chunks_text_search_idx
+    ON chunks USING GIN (text_search_vector);
+
+-- Integrations: external data sources (databases, CRMs, SaaS APIs) that can
+-- sync per-user context into RAG responses. Single-tenant — no workspace scoping.
+CREATE TABLE IF NOT EXISTS data_sources (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL UNIQUE,
+    source_type TEXT NOT NULL,
+
+    -- Connection details (encrypted at the application layer via Fernet
+    -- before being written here — never store plaintext credentials)
+    connection_string TEXT,
+    api_endpoint TEXT,
+    api_key TEXT,
+    api_headers JSONB DEFAULT '{}',
+
+    -- Query configuration
+    query_template TEXT,
+    field_mappings JSONB DEFAULT '{}',
+    user_identifier_field TEXT NOT NULL DEFAULT 'user_id',
+    documents_table_name TEXT NOT NULL DEFAULT 'documents',
+
+    -- Sync configuration
+    sync_interval_minutes INTEGER NOT NULL DEFAULT 360,
+    last_sync_at TIMESTAMPTZ,
+    last_sync_status TEXT NOT NULL DEFAULT 'pending',
+    last_sync_error TEXT,
+    last_sync_record_count INTEGER NOT NULL DEFAULT 0,
+
+    is_active BOOLEAN NOT NULL DEFAULT true,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Customer/user context synced from external data sources, used to
+-- personalize RAG responses.
+CREATE TABLE IF NOT EXISTS synced_context_data (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    data_source_id UUID NOT NULL REFERENCES data_sources(id) ON DELETE CASCADE,
+    user_identifier TEXT NOT NULL,
+    context_data JSONB NOT NULL DEFAULT '{}',
+    synced_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_updated TIMESTAMPTZ NOT NULL DEFAULT now(),
+    source_updated_at TIMESTAMPTZ,
+    UNIQUE (data_source_id, user_identifier)
+);
+
+CREATE INDEX IF NOT EXISTS synced_context_data_lookup_idx
+    ON synced_context_data (data_source_id, user_identifier);
+
+
+CREATE TABLE IF NOT EXISTS business_profile (
+    id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    business_name         TEXT NOT NULL DEFAULT '',
+    industry              TEXT NOT NULL DEFAULT '',
+    description           TEXT NOT NULL DEFAULT '',
+    products_services     TEXT NOT NULL DEFAULT '',
+    target_customers      TEXT NOT NULL DEFAULT '',
+    working_hours         TEXT NOT NULL DEFAULT '',
+    location              TEXT NOT NULL DEFAULT '',
+    tone_preference       TEXT NOT NULL DEFAULT 'friendly',
+    primary_language      TEXT NOT NULL DEFAULT 'en',
+    additional_languages  JSONB NOT NULL DEFAULT '[]',
+    owner_instructions    TEXT NOT NULL DEFAULT '',
+    auto_learned_profile  TEXT NOT NULL DEFAULT '',
+    skill_version         INTEGER NOT NULL DEFAULT 0,
+    is_profile_complete   BOOLEAN NOT NULL DEFAULT false,
+    last_learned_at       TIMESTAMPTZ,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS employee_roles (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    role             TEXT NOT NULL UNIQUE,
+    display_name     TEXT NOT NULL DEFAULT '',
+    is_active        BOOLEAN NOT NULL DEFAULT true,
+    channels         JSONB NOT NULL DEFAULT '[]',
+    skill_tags       JSONB NOT NULL DEFAULT '[]',
+    personality      TEXT NOT NULL DEFAULT '',
+    skills_summary   TEXT NOT NULL DEFAULT '',
+    last_learned_at  TIMESTAMPTZ,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS employee_memory (
+    id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    text_content       TEXT NOT NULL,
+    summary            TEXT NOT NULL DEFAULT '',
+    tags               JSONB NOT NULL DEFAULT '[]',
+    importance         REAL NOT NULL DEFAULT 0.7,
+    source             TEXT NOT NULL DEFAULT 'interaction',
+    permanent          BOOLEAN NOT NULL DEFAULT false,
+    review_after_days  INTEGER NOT NULL DEFAULT 180,
+    content_hash       TEXT NOT NULL,
+    embedding          vector(3072),
+    token_count        INTEGER NOT NULL DEFAULT 0,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS employee_memory_embedding_idx
+    ON employee_memory USING hnsw ((embedding::halfvec(3072)) halfvec_cosine_ops);
+CREATE INDEX IF NOT EXISTS employee_memory_tags_idx
+    ON employee_memory USING GIN (tags);
+CREATE INDEX IF NOT EXISTS employee_memory_hash_idx
+    ON employee_memory (content_hash, source);
+
+-- n8n workflow automation. Single-tenant — no workspace scoping.
+-- Fires a webhook after the AI replies on a matching channel; caller
+-- (channel adapter) supplies channel/message/ai_reply, this module never
+-- raises — a broken workflow config should never break the main chat flow.
+CREATE TABLE IF NOT EXISTS n8n_workflows (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name        TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    webhook_url TEXT NOT NULL,
+    channels    JSONB NOT NULL DEFAULT '[]',
+    is_active   BOOLEAN NOT NULL DEFAULT false,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS n8n_workflows_active_idx
+    ON n8n_workflows (is_active);
+
+-- Autonomous Loop settings — single-tenant port of production's
+-- api/autonomy_engine.py. One row (singleton, no workspace FK).
+CREATE TABLE IF NOT EXISTS autonomy_settings (
+    id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    mode              TEXT NOT NULL DEFAULT 'off',
+    channels          JSONB NOT NULL DEFAULT '[]',
+    actions           JSONB NOT NULL DEFAULT '[]',
+    approval_channel  TEXT NOT NULL DEFAULT 'telegram',
+    approval_target   TEXT NOT NULL DEFAULT '',
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Pending actions awaiting owner approval in "semi" mode.
+CREATE TABLE IF NOT EXISTS autonomy_pending (
+    action_id     TEXT PRIMARY KEY,
+    action_type   TEXT NOT NULL,
+    channel       TEXT NOT NULL,
+    target        TEXT NOT NULL,
+    content       TEXT NOT NULL,
+    subject       TEXT NOT NULL DEFAULT '',
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Bounded audit log of every autonomous action (executed, rejected, or errored).
+CREATE TABLE IF NOT EXISTS autonomy_log (
+    id           BIGSERIAL PRIMARY KEY,
+    action_type  TEXT NOT NULL,
+    channel      TEXT NOT NULL,
+    target       TEXT NOT NULL,
+    content      TEXT NOT NULL,
+    result       TEXT NOT NULL,
+    approved     BOOLEAN NOT NULL DEFAULT true,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS autonomy_log_created_idx
+    ON autonomy_log (created_at DESC);
+
+-- Tracks the most recent role-based reply per (channel, chat_id), so
+-- an owner can send a quick feedback command (thumbs up/down,
+-- "helpful"/"not helpful") that gets attributed to the correct
+-- memory entries via core.employees.learning.record_role_memory_outcome().
+-- Without this table there is no real success/failure signal available
+-- in the channels -- see core/employees/feedback.py.
+CREATE TABLE IF NOT EXISTS role_reply_log (
+    channel          TEXT NOT NULL,
+    chat_id          TEXT NOT NULL,
+    role_memory_ids  JSONB NOT NULL DEFAULT '[]',
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (channel, chat_id)
+);
+
+-- Owner-configured default AI Employee role per channel (e.g. telegram ->
+-- manager, whatsapp -> support). Falls back to 'support' when unset. See
+-- core/employees/channel_roles.py for the routing logic that uses this.
+CREATE TABLE IF NOT EXISTS channel_role_config (
+    channel     TEXT PRIMARY KEY,
+    role        TEXT NOT NULL DEFAULT 'support',
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- CSV connector content storage — no persistent disk volume exists in
+-- docker-compose.yml, so CSV content lives in Postgres like everything
+-- else in Core, rather than on the container filesystem.
+ALTER TABLE data_sources ADD COLUMN IF NOT EXISTS csv_content TEXT;
+ALTER TABLE data_sources ADD COLUMN IF NOT EXISTS csv_filename TEXT;

--- a/packages/ragleap-ops/helm/ragleap-ops/templates/_helpers.tpl
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/_helpers.tpl
@@ -1,0 +1,4 @@
+{{- define "ragleap-ops.labels" -}}
+app.kubernetes.io/part-of: ragleap-core
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/packages/ragleap-ops/helm/ragleap-ops/templates/app-deployment.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/app-deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ragleap-app
+  labels:
+    app: ragleap-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ragleap-app
+  template:
+    metadata:
+      labels:
+        app: ragleap-app
+    spec:
+      imagePullSecrets:
+        - name: {{ .Values.app.imagePullSecret }}
+      initContainers:
+        - name: wait-for-db
+          image: postgres:16-alpine
+          command: ["sh", "-c", "until pg_isready -h ragleap-db -p 5432 -U {{ .Values.db.credentials.user }}; do sleep 2; done"]
+      containers:
+        - name: app
+          image: {{ .Values.app.image }}
+          ports:
+            - containerPort: {{ .Values.app.port }}
+          envFrom:
+            - secretRef:
+                name: ragleap-app-env
+          env:
+            - name: DATABASE_URL
+              value: "postgresql://{{ .Values.db.credentials.user }}:{{ .Values.db.credentials.password }}@ragleap-db:5432/{{ .Values.db.credentials.database }}"
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.app.port }}
+            initialDelaySeconds: {{ .Values.app.probes.readiness.initialDelaySeconds }}
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.app.port }}
+            initialDelaySeconds: {{ .Values.app.probes.liveness.initialDelaySeconds }}

--- a/packages/ragleap-ops/helm/ragleap-ops/templates/app-service.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/app-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ragleap-app
+spec:
+  selector:
+    app: ragleap-app
+  ports:
+    - port: {{ .Values.app.port }}
+      targetPort: {{ .Values.app.port }}

--- a/packages/ragleap-ops/helm/ragleap-ops/templates/db-configmap.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/db-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ragleap-db-schema
+data:
+  schema.sql: |-
+{{ .Files.Get "files/schema.sql" | indent 4 }}

--- a/packages/ragleap-ops/helm/ragleap-ops/templates/db-deployment.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/db-deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ragleap-db
+  labels:
+    app: ragleap-db
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: ragleap-db
+  template:
+    metadata:
+      labels:
+        app: ragleap-db
+    spec:
+      containers:
+        - name: db
+          image: {{ .Values.db.image }}
+          envFrom:
+            - secretRef:
+                name: ragleap-db-secret
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: db-data
+              mountPath: /var/lib/postgresql/data
+            - name: db-schema
+              mountPath: /docker-entrypoint-initdb.d/01-schema.sql
+              subPath: schema.sql
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", {{ .Values.db.credentials.user | quote }}]
+            initialDelaySeconds: {{ .Values.db.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.db.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.db.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.db.probes.readiness.failureThreshold }}
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", {{ .Values.db.credentials.user | quote }}]
+            initialDelaySeconds: {{ .Values.db.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.db.probes.liveness.periodSeconds }}
+            failureThreshold: {{ .Values.db.probes.liveness.failureThreshold }}
+      volumes:
+        - name: db-data
+          persistentVolumeClaim:
+            claimName: ragleap-db-data
+        - name: db-schema
+          configMap:
+            name: ragleap-db-schema

--- a/packages/ragleap-ops/helm/ragleap-ops/templates/db-pvc.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/db-pvc.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ragleap-db-data
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: {{ .Values.db.storage }}

--- a/packages/ragleap-ops/helm/ragleap-ops/templates/db-secret.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/db-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ragleap-db-secret
+type: Opaque
+stringData:
+  POSTGRES_USER: {{ .Values.db.credentials.user | quote }}
+  POSTGRES_PASSWORD: {{ .Values.db.credentials.password | quote }}
+  POSTGRES_DB: {{ .Values.db.credentials.database | quote }}

--- a/packages/ragleap-ops/helm/ragleap-ops/templates/db-service.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/db-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ragleap-db
+spec:
+  selector:
+    app: ragleap-db
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/packages/ragleap-ops/helm/ragleap-ops/templates/neo4j-deployment.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/neo4j-deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ragleap-neo4j
+  labels:
+    app: ragleap-neo4j
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: ragleap-neo4j
+  template:
+    metadata:
+      labels:
+        app: ragleap-neo4j
+    spec:
+      containers:
+        - name: neo4j
+          image: {{ .Values.neo4j.image }}
+          envFrom:
+            - secretRef:
+                name: ragleap-neo4j-secret
+          env:
+            - name: NEO4J_PLUGINS
+              value: {{ .Values.neo4j.plugins | quote }}
+          ports:
+            - containerPort: {{ .Values.neo4j.ports.http }}
+            - containerPort: {{ .Values.neo4j.ports.bolt }}
+          resources:
+            requests:
+              memory: {{ .Values.neo4j.resources.requests.memory }}
+              cpu: {{ .Values.neo4j.resources.requests.cpu }}
+            limits:
+              memory: {{ .Values.neo4j.resources.limits.memory }}
+          volumeMounts:
+            - name: neo4j-data
+              mountPath: /data
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.neo4j.ports.http }}
+            initialDelaySeconds: {{ .Values.neo4j.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.neo4j.probes.readiness.periodSeconds }}
+            failureThreshold: {{ .Values.neo4j.probes.readiness.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.neo4j.ports.http }}
+            initialDelaySeconds: {{ .Values.neo4j.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.neo4j.probes.liveness.periodSeconds }}
+            failureThreshold: {{ .Values.neo4j.probes.liveness.failureThreshold }}
+      volumes:
+        - name: neo4j-data
+          persistentVolumeClaim:
+            claimName: ragleap-neo4j-data

--- a/packages/ragleap-ops/helm/ragleap-ops/templates/neo4j-pvc.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/neo4j-pvc.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ragleap-neo4j-data
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: {{ .Values.neo4j.storage }}

--- a/packages/ragleap-ops/helm/ragleap-ops/templates/neo4j-secret.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/neo4j-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ragleap-neo4j-secret
+type: Opaque
+stringData:
+  NEO4J_AUTH: {{ .Values.neo4j.auth | quote }}

--- a/packages/ragleap-ops/helm/ragleap-ops/templates/neo4j-service.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/neo4j-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ragleap-neo4j
+spec:
+  selector:
+    app: ragleap-neo4j
+  ports:
+    - name: http
+      port: {{ .Values.neo4j.ports.http }}
+      targetPort: {{ .Values.neo4j.ports.http }}
+    - name: bolt
+      port: {{ .Values.neo4j.ports.bolt }}
+      targetPort: {{ .Values.neo4j.ports.bolt }}

--- a/packages/ragleap-ops/helm/ragleap-ops/templates/voice-deployment.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/voice-deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ragleap-voice
+  labels:
+    app: ragleap-voice
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ragleap-voice
+  template:
+    metadata:
+      labels:
+        app: ragleap-voice
+    spec:
+      imagePullSecrets:
+        - name: {{ .Values.voice.imagePullSecret }}
+      initContainers:
+        - name: wait-for-db
+          image: postgres:16-alpine
+          command: ["sh", "-c", "until pg_isready -h ragleap-db -p 5432 -U {{ .Values.db.credentials.user }}; do sleep 2; done"]
+      containers:
+        - name: voice
+          image: {{ .Values.voice.image }}
+          command: {{ .Values.voice.command | toJson }}
+          ports:
+            - containerPort: {{ .Values.voice.port }}
+          envFrom:
+            - secretRef:
+                name: ragleap-app-env
+          env:
+            - name: DATABASE_URL
+              value: "postgresql://{{ .Values.db.credentials.user }}:{{ .Values.db.credentials.password }}@ragleap-db:5432/{{ .Values.db.credentials.database }}"

--- a/packages/ragleap-ops/helm/ragleap-ops/templates/voice-service.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/voice-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ragleap-voice
+spec:
+  selector:
+    app: ragleap-voice
+  ports:
+    - port: {{ .Values.voice.port }}
+      targetPort: {{ .Values.voice.port }}

--- a/packages/ragleap-ops/helm/ragleap-ops/values.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/values.yaml
@@ -1,0 +1,57 @@
+db:
+  image: pgvector/pgvector:pg16
+  storage: 5Gi   # UNVERIFIED — compose used an unbounded volume, size for real capacity needs
+  credentials:
+    user: ragleap
+    password: ragleap   # override via --set or a values-prod.yaml — never commit real prod creds
+    database: ragleap_core
+  probes:
+    readiness:
+      initialDelaySeconds: 15
+      periodSeconds: 5
+      timeoutSeconds: 5
+      failureThreshold: 6
+    liveness:
+      initialDelaySeconds: 45
+      periodSeconds: 10
+      failureThreshold: 6
+
+app:
+  image: ghcr.io/antonyrag/ragleap-app:latest
+  imagePullSecret: ghcr-pull-secret
+  port: 8000
+  probes:
+    readiness:
+      initialDelaySeconds: 5
+    liveness:
+      initialDelaySeconds: 15
+
+voice:
+  image: ghcr.io/antonyrag/ragleap-app:latest
+  imagePullSecret: ghcr-pull-secret
+  port: 8765
+  command: ["python3", "-m", "channels.voice.server"]
+
+neo4j:
+  image: neo4j:5-community
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 50m
+    limits:
+      memory: 1Gi
+  storage: 5Gi   # UNVERIFIED — same as db, size for real capacity needs
+  auth: neo4j/ragleapgraph
+  plugins: "[]"
+  ports:
+    http: 7474
+    bolt: 7687
+  probes:
+    readiness:
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      failureThreshold: 12
+    liveness:
+      initialDelaySeconds: 60
+      periodSeconds: 10
+      failureThreshold: 6

--- a/packages/ragleap-ops/pyproject.toml
+++ b/packages/ragleap-ops/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-ops"
-version = "0.1.0"
+version = "0.2.0"
 description = "Kubernetes deployment manifests for RagLeap Core, live-tested against a real cluster"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/ragleap-ops/src/ragleap_ops/__init__.py
+++ b/packages/ragleap-ops/src/ragleap_ops/__init__.py
@@ -10,4 +10,4 @@ manifests alongside this src/ tree, matching the release discipline of
 ragleap-rag, ragleap-graph, and ragleap-vectorstores.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/packages/ragleap-ops/tests/test_version.py
+++ b/packages/ragleap-ops/tests/test_version.py
@@ -2,4 +2,4 @@ import ragleap_ops
 
 
 def test_version_is_set():
-    assert ragleap_ops.__version__ == "0.1.0"
+    assert ragleap_ops.__version__ == "0.2.0"


### PR DESCRIPTION
Adds a Helm chart wrapping the existing k8s/ manifests (merged in #232). Bumps ragleap-ops to 0.2.0.

Live-tested via helm install/upgrade on a real kind cluster. Found and fixed a real bug (neo4j liveness probe missing failureThreshold) that only surfaced under live testing, not helm lint. Added resource requests/limits for neo4j after live testing surfaced genuine host CPU/memory contention.

CHANGELOG documents an honest limitation: full 4-service concurrent stability was demonstrated in 60+ minute windows, not extended multi-hour runs, due to real constraints on the test VPS (which also runs production services) — not a chart defect, but worth stating plainly rather than overclaiming.