### PR TITLE
Prep ragleap-vectorstores v0.2.0 release

### DIFF
--- a/packages/ragleap-vectorstores/CHANGELOG.md
+++ b/packages/ragleap-vectorstores/CHANGELOG.md
@@ -5,6 +5,19 @@ loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-31
+### Added
+- `LanceDBBackend` - second vector backend, via LanceDB's embedded/local
+  connection mode (a directory path, no server required). Available via
+  the `lancedb` optional extra (`pip install ragleap-vectorstores[lancedb]`).
+- Real upsert semantics via `merge_insert()` - re-inserting the same
+  document_id/chunk_index updates the row in place rather than
+  duplicating it.
+- `supports_sparse()` correctly reports `False` for LanceDB - it does
+  support full-text search via tantivy, but that surface wasn't
+  implemented or tested in this release, so hybrid search honestly
+  falls back to dense-only.
+
 ## [0.1.0] - 2026-08-29
 ### Added
 - Initial package scaffold - pyproject.toml, package layout matching

--- a/packages/ragleap-vectorstores/README.md
+++ b/packages/ragleap-vectorstores/README.md
@@ -12,6 +12,7 @@ over time. See the
 | Backend | Extra | Notes |
 |---|---|---|
 | Chroma | `chroma` | Embedded/local via chromadb's PersistentClient - no server required. No native sparse/keyword search (`supports_sparse()` is `False`); hybrid search falls back to dense-only. |
+| LanceDB | `lancedb` | Embedded/local via a directory path - no server required. Real upsert semantics via `merge_insert()`. No native sparse/keyword search enabled yet (`supports_sparse()` is `False`); hybrid search falls back to dense-only. |
 
 ## Design
 
@@ -24,6 +25,8 @@ pulls in no heavy dependencies beyond `ragleap-rag` itself.
 
 ```bash
 pip install ragleap-vectorstores[chroma]
+# or
+pip install ragleap-vectorstores[lancedb]
 ```
 
 ## Usage
@@ -32,4 +35,10 @@ pip install ragleap-vectorstores[chroma]
 from ragleap_vectorstores import ChromaBackend
 
 backend = ChromaBackend(persist_directory="./chroma_data")
+```
+
+```python
+from ragleap_vectorstores import LanceDBBackend
+
+backend = LanceDBBackend(uri="./lancedb_data")
 ```

--- a/packages/ragleap-vectorstores/pyproject.toml
+++ b/packages/ragleap-vectorstores/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-vectorstores"
-version = "0.1.0"
+version = "0.2.0"
 description = "Pluggable vector backends beyond ragleap-rag core's 6 (PgVector, FAISS, Pinecone, Weaviate, Qdrant, Milvus) - additional VectorBackend implementations as optional extras, no vendor lock-in, no bloated core dependency footprint."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-vectorstores/src/ragleap_vectorstores/__init__.py
+++ b/packages/ragleap-vectorstores/src/ragleap_vectorstores/__init__.py
@@ -8,7 +8,7 @@ the package.
 """
 from ragleap.vectorstores.base import VectorBackend
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __all__ = ["VectorBackend", "__version__"]
 


### PR DESCRIPTION
Version bump + CHANGELOG + README updates ahead of the v0.2.0 release (LanceDBBackend).

Scope: packages/ragleap-vectorstores/pyproject.toml, __init__.py, CHANGELOG.md, README.md only.

## Changes
- Version bump 0.1.0 -> 0.2.0 (pyproject.toml + __init__.py)
- CHANGELOG: new [0.2.0] entry documenting LanceDBBackend
- README: LanceDB row in Available backends table, second install line, second usage example (verified the exact snippet runs against real LanceDB)

## Verified
- 25/25 tests pass (11 Chroma + 13 LanceDB + smoke)
- python3 -m build succeeds; wheel confirmed via zipfile inspection to contain both chroma_backend.py and lancedb_backend.py
- twine check PASSED on wheel + sdist

Once merged, next step is tagging ragleap-vectorstores-v0.2.0 to publish for real via the existing publish-ragleap-vectorstores CI job.