### PR TITLE
Fix ragleap-vectorstores README missing uv add lines (v0.2.1)

### DIFF
--- a/packages/ragleap-vectorstores/CHANGELOG.md
+++ b/packages/ragleap-vectorstores/CHANGELOG.md
@@ -5,6 +5,15 @@ loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-08-31
+### Fixed
+- README's Install section was missing `uv add` variants for both
+  extras (only `pip install` was shown) - caught by checking the real
+  rendered PyPI project page after the v0.2.0 publish, not caught
+  beforehand. Every other install example across this project's docs
+  shows both pip and uv; this brings the package's own README (which
+  becomes the permanent PyPI page content once published) in line.
+
 ## [0.2.0] - 2026-08-31
 ### Added
 - `LanceDBBackend` - second vector backend, via LanceDB's embedded/local

--- a/packages/ragleap-vectorstores/README.md
+++ b/packages/ragleap-vectorstores/README.md
@@ -25,8 +25,12 @@ pulls in no heavy dependencies beyond `ragleap-rag` itself.
 
 ```bash
 pip install ragleap-vectorstores[chroma]
-# or
+# or, with uv
+uv add ragleap-vectorstores[chroma]
+
 pip install ragleap-vectorstores[lancedb]
+# or, with uv
+uv add ragleap-vectorstores[lancedb]
 ```
 
 ## Usage

--- a/packages/ragleap-vectorstores/pyproject.toml
+++ b/packages/ragleap-vectorstores/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-vectorstores"
-version = "0.2.0"
+version = "0.2.1"
 description = "Pluggable vector backends beyond ragleap-rag core's 6 (PgVector, FAISS, Pinecone, Weaviate, Qdrant, Milvus) - additional VectorBackend implementations as optional extras, no vendor lock-in, no bloated core dependency footprint."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-vectorstores/src/ragleap_vectorstores/__init__.py
+++ b/packages/ragleap-vectorstores/src/ragleap_vectorstores/__init__.py
@@ -8,7 +8,7 @@ the package.
 """
 from ragleap.vectorstores.base import VectorBackend
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 __all__ = ["VectorBackend", "__version__"]
 


### PR DESCRIPTION
The Install section only showed pip install for both extras - caught by checking the real rendered PyPI project page after the v0.2.0 publish.

Scope: packages/ragleap-vectorstores/ only.

## Changes
- README: adds uv add lines for both chroma and lancedb extras
- Version bump 0.2.0 -> 0.2.1
- CHANGELOG entry

## Verified
- 25/25 tests pass
- python3 -m build succeeds, twine check PASSED on wheel + sdist

Once merged, next step is tagging ragleap-vectorstores-v0.2.1 to publish the fix for real.