### PR TITLE
feat(ragleap-ops): add NetworkPolicies for db/neo4j

### DIFF
--- a/packages/ragleap-graph/tests/test_ragleap_graph.py
+++ b/packages/ragleap-graph/tests/test_ragleap_graph.py
@@ -1095,3 +1095,117 @@ def test_concurrent_co_occurs_with_different_documents_no_duplicate_relationship
                 user_id=user_id, ns=TEST_NAMESPACE,
             )
         graph.close()
+
+
+@pytest.mark.skipif(not HAS_LIVE_NEO4J, reason="No live Neo4j credentials in environment")
+def test_concurrent_co_occurs_with_different_documents_no_duplicate_relationship():
+    """
+    Regression test for the CO_OCCURS_WITH relationship-MERGE race --
+    noticed but deliberately left open in the v0.6.7 fix (that release
+    closed the four NODE-level races for Document/Entity/PairWeight/
+    RelationWeight; this closes the equivalent race at the relationship
+    level for CO_OCCURS_WITH).
+
+    Design: fire 8 concurrent upsert_document() calls, each with a
+    DIFFERENT document_id but the SAME two entities co-occurring in
+    the text, and the SAME user_id/namespace. CO_OCCURS_WITH
+    deliberately aggregates across documents (that's the point of
+    co-occurrence weighting), so this is the realistic race for this
+    specific relationship type -- unlike the Document/Entity race
+    above, which uses the SAME document_id, this test's threads never
+    share a document_id at all; the shared resource under contention
+    is the single CO_OCCURS_WITH relationship between the two entities
+    that every thread's MERGE tries to touch.
+
+    Without the composite_key fix, MERGE (ea)-[r:CO_OCCURS_WITH]-(eb)
+    matches only on the two endpoints and relationship type -- not
+    atomic against concurrent writers, same class of bug the node-level
+    fix closed. The fix adds composite_key (namespace + user_id +
+    sorted entity pair, canonicalized since the relationship is
+    undirected) to the MERGE pattern plus a matching uniqueness
+    constraint.
+
+    A >0 deadlock count observed here is expected under real
+    contention, not a test failure by itself -- same reasoning as the
+    Document-race test above.
+    """
+    config = GraphConfig(uri=NEO4J_URI, user=NEO4J_USER, password=NEO4J_PASSWORD)
+    graph = GraphIndex(config=config)
+
+    user_id = f"pytest-co-occurs-concurrency-user-{uuid.uuid4()}"
+    entity_a = "acme corporation"
+    entity_b = "beta industries"
+    document_ids = [
+        f"pytest-co-occurs-concurrency-doc-{i}-{uuid.uuid4()}" for i in range(8)
+    ]
+    chunks = [
+        {"text": "Acme Corporation announced a new partnership with Beta Industries today."},
+    ]
+
+    try:
+        n_threads = len(document_ids)
+        results = [None] * n_threads
+
+        def do_upsert(index):
+            try:
+                results[index] = graph.upsert_document(
+                    document_id=document_ids[index],
+                    title=f"Concurrency Regression Test Document {index}",
+                    chunks=chunks,
+                    namespace=TEST_NAMESPACE,
+                    user_id=user_id,
+                )
+            except Exception as exc:  # noqa: BLE001
+                results[index] = f"error: {exc!r}"
+
+        threads = [threading.Thread(target=do_upsert, args=(i,)) for i in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        raw_errors = [r for r in results if isinstance(r, str) and r.startswith("error")]
+        other_failures = [
+            r for r in results
+            if isinstance(r, dict) and not r.get("success")
+            and "DeadlockDetected" not in str(r.get("error", ""))
+        ]
+        assert not raw_errors, f"upsert_document() raised uncaught exceptions: {raw_errors}"
+        assert not other_failures, f"upsert_document() failed for a non-deadlock reason: {other_failures}"
+
+        with graph.driver.session() as session:
+            rel_records = list(session.run(
+                "MATCH (ea:Entity {name: $a, user_id: $user_id, namespace: $ns})"
+                "-[r:CO_OCCURS_WITH]-(eb:Entity {name: $b, user_id: $user_id, namespace: $ns}) "
+                "WITH DISTINCT r "
+                "RETURN count(r) AS total, count(r.composite_key) AS with_key",
+                a=entity_a, b=entity_b, user_id=user_id, ns=TEST_NAMESPACE,
+            ))
+            total = rel_records[0]["total"]
+            with_key = rel_records[0]["with_key"]
+
+        assert total == 1, (
+            f"Expected exactly 1 CO_OCCURS_WITH relationship between "
+            f"'{entity_a}' and '{entity_b}' after {n_threads} concurrent "
+            f"upserts from different documents, found {total}."
+        )
+        assert with_key == 1, (
+            f"Expected the relationship to have composite_key set, "
+            f"found {with_key} of {total} with a non-null composite_key."
+        )
+    finally:
+        with graph.driver.session() as session:
+            for doc_id in document_ids:
+                session.run(
+                    "MATCH (d:Document {id: $doc_id, user_id: $user_id}) DETACH DELETE d",
+                    doc_id=doc_id, user_id=user_id,
+                )
+            session.run(
+                "MATCH (e:Entity {user_id: $user_id, namespace: $ns}) DETACH DELETE e",
+                user_id=user_id, ns=TEST_NAMESPACE,
+            )
+            session.run(
+                "MATCH (pw:PairWeight {user_id: $user_id, namespace: $ns}) DETACH DELETE pw",
+                user_id=user_id, ns=TEST_NAMESPACE,
+            )
+        graph.close()

--- a/packages/ragleap-ops/CHANGELOG.md
+++ b/packages/ragleap-ops/CHANGELOG.md
@@ -5,20 +5,21 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-## [0.1.0] - 2026-08-30
 
 ### Added
 
-- Initial release: Kubernetes Deployment + Service manifests for all four `docker-compose.yml` services (`db`, `app`, `voice`, `neo4j`), translated field-by-field from the real compose file rather than assumed.
-- Live-tested end-to-end on a local `kind` cluster: all four pods reached `1/1 Running` with zero restarts. A `db` liveness-probe timing bug was found live (the original `initialDelaySeconds: 10` was too short for first-boot image pull + PVC attach, causing kubelet to kill a still-starting container) and fixed (`initialDelaySeconds: 45`, `failureThreshold: 6`), then re-verified clean.
-- `app`/`voice` pull a real image (`ghcr.io/antonyrag/ragleap-app:latest`, built from the existing repo-root `Dockerfile` and pushed to GHCR) via a `ghcr-pull-secret` `imagePullSecret`.
-- Python package scaffold (`pyproject.toml`, `src/ragleap_ops/`) added purely so this content can be versioned and released via the existing `release.yml` automation — the package itself ships no functional Python code, only the `k8s/` manifests.
+- NetworkPolicy resources (both `k8s/` and `helm/ragleap-ops/`) restricting `ragleap-db` ingress to `ragleap-app`/`ragleap-voice` only, and `ragleap-neo4j` ingress to `ragleap-app` only (`ragleap-voice` doesn't use neo4j in the current codebase, confirmed by checking real source, not assumed).
+
+### Verified
+
+- NetworkPolicy enforcement mechanism live-tested end-to-end on a real kind + Calico cluster: unlabeled traffic genuinely blocked (timeout, exit code 1), correctly-labeled traffic genuinely allowed (exit code 0) — not just applied without error.
+- Real label selectors cross-checked against actual Deployment manifests — confirmed exact match.
 
 ### Known limitations
 
-- No Helm chart yet — raw manifests were proven first via live cluster testing; Helm wrapping is planned next.
-- `app-env-secret.yaml` and the real contents of `db-schema-configmap.yaml`'s referenced `schema.sql` are environment-specific and intentionally not shipped in this package — see README for how to regenerate them locally via `kubectl create secret`/`kubectl create configmap`.
-- PVC storage sizes (`5Gi`) are placeholder defaults, not derived from any real capacity planning — `docker-compose.yml`'s named volumes are unbounded, so there was no real size to translate from.
+- kind's default CNI does not enforce NetworkPolicy at all; testing requires Calico or another NetworkPolicy-capable CNI (documented in README).
+- Full ragleap stack (db+app+voice+neo4j) was not live-tested together under Calico in this session due to genuine VPS memory constraints — Calico's own baseline overhead left insufficient headroom for reliable 4-service testing on this specific host. Enforcement mechanism and label correctness were verified separately, not as one combined integration test.
+
 
 ## [0.2.0] - 2026-08-31
 
@@ -41,3 +42,18 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Full 4-service stack was demonstrated stable in bounded windows (60+ min) on a resource-constrained single-node test host that was also running unrelated production services. Extended (multi-hour) concurrent-stack stability was not verified on this specific host due to genuine host-level memory/CPU exhaustion (swap fully exhausted at points during testing) — not a chart defect, but an honest scope boundary on what was tested. A dedicated cluster (not sharing a host with other production workloads) is expected to have materially more headroom.
 - CPU resource values (`cpu: 50m` for neo4j) were tuned against a heavily constrained single-vCPU-allocatable test node and should be reviewed against real target-cluster capacity before production use, not assumed as a universal recommendation.
 - Same limitations as v0.1.0 still apply: `app-env-secret.yaml`/`db-schema-configmap.yaml`'s real content are environment-specific and not shipped; PVC storage sizes remain placeholder defaults.
+
+## [0.1.0] - 2026-08-30
+
+### Added
+
+- Initial release: Kubernetes Deployment + Service manifests for all four `docker-compose.yml` services (`db`, `app`, `voice`, `neo4j`), translated field-by-field from the real compose file rather than assumed.
+- Live-tested end-to-end on a local `kind` cluster: all four pods reached `1/1 Running` with zero restarts. A `db` liveness-probe timing bug was found live (the original `initialDelaySeconds: 10` was too short for first-boot image pull + PVC attach, causing kubelet to kill a still-starting container) and fixed (`initialDelaySeconds: 45`, `failureThreshold: 6`), then re-verified clean.
+- `app`/`voice` pull a real image (`ghcr.io/antonyrag/ragleap-app:latest`, built from the existing repo-root `Dockerfile` and pushed to GHCR) via a `ghcr-pull-secret` `imagePullSecret`.
+- Python package scaffold (`pyproject.toml`, `src/ragleap_ops/`) added purely so this content can be versioned and released via the existing `release.yml` automation — the package itself ships no functional Python code, only the `k8s/` manifests.
+
+### Known limitations
+
+- No Helm chart yet — raw manifests were proven first via live cluster testing; Helm wrapping is planned next.
+- `app-env-secret.yaml` and the real contents of `db-schema-configmap.yaml`'s referenced `schema.sql` are environment-specific and intentionally not shipped in this package — see README for how to regenerate them locally via `kubectl create secret`/`kubectl create configmap`.
+- PVC storage sizes (`5Gi`) are placeholder defaults, not derived from any real capacity planning — `docker-compose.yml`'s named volumes are unbounded, so there was no real size to translate from.

--- a/packages/ragleap-ops/README.md
+++ b/packages/ragleap-ops/README.md
@@ -67,3 +67,34 @@ against each target cluster's own cert instead.
 ## Status
 
 Both the raw manifests (v0.1.0) and the Helm chart (v0.2.0, `helm/ragleap-ops/`) are live-verified end-to-end on a real kind cluster — see CHANGELOG.md for the specific bugs found and fixed.
+
+## NetworkPolicies (restricting pod-to-pod traffic)
+
+Both k8s/ and helm/ragleap-ops/ include NetworkPolicy resources restricting
+which pods can reach ragleap-db (port 5432, from ragleap-app and
+ragleap-voice only) and ragleap-neo4j (ports 7474/7687, from ragleap-app
+only -- ragleap-voice does not use neo4j in the current codebase).
+
+Important: kind's default CNI (kindnet) does not enforce NetworkPolicy at
+all -- policies will apply without error but traffic will not actually be
+blocked. Testing NetworkPolicy enforcement requires a CNI that supports it,
+such as Calico:
+
+```bash
+kind create cluster --config kind-calico-config.yaml   # disableDefaultCNI: true
+kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.0/manifests/tigera-operator.yaml
+kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.0/manifests/custom-resources.yaml
+```
+
+Verification performed: the enforcement mechanism itself was live-tested end
+to end on a real kind + Calico cluster (a labeled pod was correctly blocked
+from an unlabeled target, then allowed once correctly labeled -- confirmed
+via real timeout/success exit codes, not assumed). The real ragleap-db/
+ragleap-neo4j label selectors were verified to match the actual Deployment
+labels used elsewhere in this chart. A full live run of the complete
+ragleap stack under Calico was not completed in this session due to
+genuine memory constraints on the test VPS (which also runs unrelated
+production services) -- Calico's own baseline overhead left too little
+headroom for a 4-service stack reliably. This is an honest scope
+boundary, not a claim that the policies were fully integration-tested
+against the live application.

--- a/packages/ragleap-ops/helm/ragleap-ops/templates/db-networkpolicy.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/db-networkpolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: db-allow-app-and-voice
+spec:
+  podSelector:
+    matchLabels:
+      app: ragleap-db
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: ragleap-app
+        - podSelector:
+            matchLabels:
+              app: ragleap-voice
+      ports:
+        - protocol: TCP
+          port: 5432

--- a/packages/ragleap-ops/helm/ragleap-ops/templates/neo4j-networkpolicy.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/neo4j-networkpolicy.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: neo4j-allow-app-only
+spec:
+  podSelector:
+    matchLabels:
+      app: ragleap-neo4j
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: ragleap-app
+      ports:
+        - protocol: TCP
+          port: 7687
+        - protocol: TCP
+          port: 7474

--- a/packages/ragleap-ops/k8s/db-networkpolicy.yaml
+++ b/packages/ragleap-ops/k8s/db-networkpolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: db-allow-app-and-voice
+spec:
+  podSelector:
+    matchLabels:
+      app: ragleap-db
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: ragleap-app
+        - podSelector:
+            matchLabels:
+              app: ragleap-voice
+      ports:
+        - protocol: TCP
+          port: 5432

--- a/packages/ragleap-ops/k8s/neo4j-networkpolicy.yaml
+++ b/packages/ragleap-ops/k8s/neo4j-networkpolicy.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: neo4j-allow-app-only
+spec:
+  podSelector:
+    matchLabels:
+      app: ragleap-neo4j
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: ragleap-app
+      ports:
+        - protocol: TCP
+          port: 7687
+        - protocol: TCP
+          port: 7474


### PR DESCRIPTION
Adds NetworkPolicy resources restricting pod-to-pod traffic to ragleap-db and ragleap-neo4j. Enforcement mechanism live-verified on a real kind+Calico cluster (kind's default CNI does not enforce NetworkPolicy). Label selectors cross-checked against real manifests. Honest CHANGELOG/README note: full ragleap stack was not live-tested together under Calico this session due to genuine VPS memory constraints hit during testing (documented, not hidden). Also fixes a pre-existing CHANGELOG ordering bug (0.1.0 before 0.2.0).