### PR TITLE
feat(ragleap-ops): add optional Ingress + TLS via cert-manager

### DIFF
--- a/packages/ragleap-ops/CHANGELOG.md
+++ b/packages/ragleap-ops/CHANGELOG.md
@@ -5,6 +5,17 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Optional Helm chart Ingress + cert-manager Certificate (`ingress.enabled`, default `false`) for exposing the app outside the cluster over TLS.
+
+### Verified
+
+- Full Ingress + TLS chain live-tested end-to-end on a real kind cluster with a genuine NGINX Ingress Controller and cert-manager, using a self-signed ClusterIssuer. Confirmed via openssl that the correct certificate (matching SNI hostname) was served, not a generic fallback. HTTP routing through the Ingress to the backend independently confirmed.
+
+### Known limitations
+
+- Production Let's Encrypt issuance was not live-tested this session — real ACME HTTP-01 challenges require public DNS and an internet-reachable port 80, which a local kind cluster cannot satisfy. The provided ClusterIssuer example is the standard, documented cert-manager pattern, not independently verified against a real domain.
 
 ### Added
 

--- a/packages/ragleap-ops/README.md
+++ b/packages/ragleap-ops/README.md
@@ -98,3 +98,57 @@ production services) -- Calico's own baseline overhead left too little
 headroom for a 4-service stack reliably. This is an honest scope
 boundary, not a claim that the policies were fully integration-tested
 against the live application.
+
+## Ingress + TLS
+
+The Helm chart includes an optional Ingress + cert-manager Certificate
+(disabled by default via `ingress.enabled: false`). Enabling it requires:
+
+1. An NGINX Ingress Controller installed on your cluster
+2. cert-manager installed, with a real ClusterIssuer configured (Let's
+   Encrypt for production, or a self-signed issuer for local testing)
+3. A real hostname you own, set via `ingress.hostname` in values.yaml
+4. Your ClusterIssuer's name set via `ingress.clusterIssuer`
+
+Example production ClusterIssuer (Let's Encrypt, replace the email):
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: you@example.com
+    privateKeySecretRef:
+      name: letsencrypt-prod-key
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: nginx
+EOF
+```
+
+Then deploy with:
+
+```bash
+helm install ragleap-ops ./ragleap-ops \
+  --set ingress.enabled=true \
+  --set ingress.hostname=your-real-domain.com \
+  --set ingress.clusterIssuer=letsencrypt-prod
+```
+
+Verification performed: the full Ingress + TLS chain was live-tested end to
+end on a real kind cluster with a genuine NGINX Ingress Controller and
+cert-manager, using a self-signed ClusterIssuer (Let's Encrypt itself
+requires public DNS and internet-reachable ports, which a local kind
+cluster cannot satisfy for a real ACME challenge). Confirmed via openssl:
+the correct certificate was served over TLS via SNI, matching the exact
+hostname requested, not a generic fallback certificate. HTTP routing
+through the Ingress to the backend service was independently confirmed
+working. Production Let's Encrypt issuance was not live-tested in this
+session for the reason above -- the issuer configuration shown is the
+standard, documented cert-manager pattern, not independently verified
+against a real public domain here.

--- a/packages/ragleap-ops/helm/ragleap-ops/templates/ingress.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ragleap-app-tls
+spec:
+  secretName: ragleap-app-tls-secret
+  issuerRef:
+    name: {{ .Values.ingress.clusterIssuer }}
+    kind: ClusterIssuer
+  dnsNames:
+    - {{ .Values.ingress.hostname }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ragleap-app-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.clusterIssuer }}
+spec:
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.hostname }}
+      secretName: ragleap-app-tls-secret
+  rules:
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ragleap-app
+                port:
+                  number: {{ .Values.app.port }}
+{{- end }}

--- a/packages/ragleap-ops/helm/ragleap-ops/values.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/values.yaml
@@ -55,3 +55,9 @@ neo4j:
       initialDelaySeconds: 60
       periodSeconds: 10
       failureThreshold: 6
+
+ingress:
+  enabled: false   # set true once hostname and issuer are configured for your real cluster
+  hostname: app.example.com   # REPLACE with your real domain before enabling
+  ingressClassName: nginx
+  clusterIssuer: letsencrypt-prod   # REPLACE with your own ClusterIssuer name; see README for setup


### PR DESCRIPTION
Adds an optional Ingress + cert-manager Certificate to the Helm chart, disabled by default. Full mechanism (Ingress routing + TLS/SNI cert selection + cert-manager auto-issuance) live-verified end-to-end on a real kind cluster with a self-signed issuer. Production Let's Encrypt path documented but not independently live-tested (requires public DNS this test environment doesn't have) - honestly flagged in CHANGELOG/README.