### PR TITLE
feat(ragleap-ops): multi-environment values overlays

### DIFF
--- a/packages/ragleap-ops/CHANGELOG.md
+++ b/packages/ragleap-ops/CHANGELOG.md
@@ -7,6 +7,15 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Environment overlay files (`values-dev.yaml`, `values-staging.yaml`, `values-prod.yaml`) for the Helm chart, layered on top of the base `values.yaml`.
+- `app.replicaCount`/`voice.replicaCount` parameterized (were previously hardcoded to `1` in the templates, which would have silently made environment-based replica scaling impossible). `db`/`neo4j` intentionally remain hardcoded at 1 replica -- both are stateful, single-writer services on `ReadWriteOnce` PVCs.
+
+### Verified
+
+- Rendered output confirmed to differ correctly across all three overlays via `helm template -f values-<env>.yaml`: dev (1/1 replicas, ingress disabled), staging (1/1 replicas, ingress enabled with its own hostname), prod (3/2 replicas, ingress enabled with its own hostname).
+
+### Added
+
 - Optional Helm chart Ingress + cert-manager Certificate (`ingress.enabled`, default `false`) for exposing the app outside the cluster over TLS.
 
 ### Verified

--- a/packages/ragleap-ops/README.md
+++ b/packages/ragleap-ops/README.md
@@ -152,3 +152,29 @@ working. Production Let's Encrypt issuance was not live-tested in this
 session for the reason above -- the issuer configuration shown is the
 standard, documented cert-manager pattern, not independently verified
 against a real public domain here.
+
+## Multi-environment deployment
+
+Environment-specific overrides live in `helm/ragleap-ops/values-{dev,staging,prod}.yaml`,
+layered on top of the base `values.yaml` (never edit the base file for a
+single environment):
+
+```bash
+helm install ragleap-ops ./ragleap-ops -f values-dev.yaml       # local/dev
+helm install ragleap-ops ./ragleap-ops -f values-staging.yaml   # staging
+helm install ragleap-ops ./ragleap-ops -f values-prod.yaml      # production
+```
+
+`db` and `neo4j` intentionally have no `replicaCount` in any environment
+file and stay hardcoded at 1 in the templates -- both are stateful,
+single-writer services backed by `ReadWriteOnce` PVCs. Horizontal scaling
+for either would require a genuinely different storage/clustering
+architecture, not a values.yaml change, so this isn't offered as a
+configurable option that would silently produce a broken multi-writer
+setup if someone bumped the number.
+
+Verified: rendered output for `app.replicaCount`/`voice.replicaCount`
+and `ingress.enabled`/`ingress.hostname` confirmed to differ correctly
+across all three overlay files via `helm template -f values-<env>.yaml`
+-- dev (1/1, no ingress), staging (1/1, ingress enabled with its own
+hostname), prod (3/2, ingress enabled with its own hostname).

--- a/packages/ragleap-ops/helm/ragleap-ops/templates/app-deployment.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/app-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: ragleap-app
 spec:
-  replicas: 1
+  replicas: {{ .Values.app.replicaCount }}
   selector:
     matchLabels:
       app: ragleap-app

--- a/packages/ragleap-ops/helm/ragleap-ops/templates/db-deployment.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/db-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: ragleap-db
 spec:
-  replicas: 1
+  replicas: 1  # intentionally not configurable - stateful, single-writer, ReadWriteOnce PVC
   strategy:
     type: Recreate
   selector:

--- a/packages/ragleap-ops/helm/ragleap-ops/templates/neo4j-deployment.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/neo4j-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: ragleap-neo4j
 spec:
-  replicas: 1
+  replicas: 1  # intentionally not configurable - stateful, single-writer, ReadWriteOnce PVC
   strategy:
     type: Recreate
   selector:

--- a/packages/ragleap-ops/helm/ragleap-ops/templates/voice-deployment.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/voice-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: ragleap-voice
 spec:
-  replicas: 1
+  replicas: {{ .Values.voice.replicaCount }}
   selector:
     matchLabels:
       app: ragleap-voice

--- a/packages/ragleap-ops/helm/ragleap-ops/values-dev.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/values-dev.yaml
@@ -1,0 +1,14 @@
+# Dev environment overrides — apply with:
+#   helm install ragleap-ops ./ragleap-ops -f values-dev.yaml
+#
+# Single replicas, minimal resources, ingress disabled (use port-forward
+# for local access instead). Not suitable for anything but local testing.
+
+app:
+  replicaCount: 1
+
+voice:
+  replicaCount: 1
+
+ingress:
+  enabled: false

--- a/packages/ragleap-ops/helm/ragleap-ops/values-prod.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/values-prod.yaml
@@ -1,0 +1,24 @@
+# Production environment overrides — apply with:
+#   helm install ragleap-ops ./ragleap-ops -f values-prod.yaml
+#
+# Higher app/voice replica counts for real traffic. db/neo4j stay at a
+# single replica regardless of environment — they're stateful,
+# single-writer services with ReadWriteOnce PVCs; horizontal scaling
+# would require a different storage/clustering architecture entirely,
+# not a values.yaml change.
+#
+# IMPORTANT: never commit real production database credentials here.
+# Override db.credentials via --set or, better, use the Sealed Secrets
+# workflow documented above instead of values.yaml for anything secret.
+
+app:
+  replicaCount: 3
+
+voice:
+  replicaCount: 2
+
+ingress:
+  enabled: true
+  hostname: app.example.com   # REPLACE with your real production domain
+  ingressClassName: nginx
+  clusterIssuer: letsencrypt-prod   # REPLACE with your ClusterIssuer name

--- a/packages/ragleap-ops/helm/ragleap-ops/values-staging.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/values-staging.yaml
@@ -1,0 +1,18 @@
+# Staging environment overrides — apply with:
+#   helm install ragleap-ops ./ragleap-ops -f values-staging.yaml
+#
+# Mirrors production shape (Ingress enabled, real hostname/issuer) but at
+# lower replica counts, to catch integration issues before they reach
+# production without paying full production resource cost.
+
+app:
+  replicaCount: 1
+
+voice:
+  replicaCount: 1
+
+ingress:
+  enabled: true
+  hostname: staging.example.com   # REPLACE with your real staging domain
+  ingressClassName: nginx
+  clusterIssuer: letsencrypt-prod   # REPLACE with your ClusterIssuer name

--- a/packages/ragleap-ops/helm/ragleap-ops/values.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/values.yaml
@@ -17,6 +17,7 @@ db:
       failureThreshold: 6
 
 app:
+  replicaCount: 1
   image: ghcr.io/antonyrag/ragleap-app:latest
   imagePullSecret: ghcr-pull-secret
   port: 8000
@@ -27,6 +28,7 @@ app:
       initialDelaySeconds: 15
 
 voice:
+  replicaCount: 1
   image: ghcr.io/antonyrag/ragleap-app:latest
   imagePullSecret: ghcr-pull-secret
   port: 8765


### PR DESCRIPTION
Adds values-dev/staging/prod.yaml overlays for the Helm chart. Also fixes a real gap found while building this: app/voice replicaCount was hardcoded in templates, which would have silently broken per-environment scaling. db/neo4j intentionally stay at 1 replica (stateful, ReadWriteOnce). All three overlays verified via helm template to produce genuinely different rendered output.