### PR TITLE
feat(integrations): add Gmail connector (Phase A) — final connector

### DIFF
--- a/core/integrations/factory.py
+++ b/core/integrations/factory.py
@@ -6,6 +6,7 @@ from core.integrations.base import BaseDatabaseConnector, DataSource
 from core.integrations.sql_connectors import MySQLConnector, PostgreSQLConnector
 from core.integrations.snowflake_connector import SnowflakeConnector
 from core.integrations.bigquery_connector import BigQueryConnector
+from core.integrations.gmail_connector import GmailConnector
 from core.integrations.mongodb import MongoDBConnector
 from core.integrations.rest_api import RestAPIConnector
 from core.integrations.csv_connector import CSVConnector
@@ -27,6 +28,7 @@ CONNECTOR_MAP = {
     'postgresql': PostgreSQLConnector,
     'snowflake': SnowflakeConnector,
     'bigquery': BigQueryConnector,
+    'gmail': GmailConnector,
     'mongodb': MongoDBConnector,
     'rest_api': RestAPIConnector,
     'csv': CSVConnector,

--- a/core/integrations/gmail_connector.py
+++ b/core/integrations/gmail_connector.py
@@ -1,0 +1,135 @@
+"""
+Gmail connector for RagLeap Core integrations.
+
+Uses the Gmail API via google-api-python-client + google-auth, lazily
+imported (optional dependency) -- same graceful-ImportError pattern as
+SnowflakeConnector/BigQueryConnector.
+
+Unlike every other connector, Gmail's API requires OAuth2 rather than
+a static key. Per RagLeap's BYOK design (Discussion #169 -- "never an
+OAuth app RagLeap owns"), this connector does NOT perform an OAuth
+consent flow itself. The user brings their own OAuth client
+(registered in their own Google Cloud project) and a refresh_token
+they've already obtained once (e.g. via Google's OAuth Playground or
+a short one-time script) -- the connector only ever exchanges that
+refresh_token for short-lived access tokens.
+
+Field usage:
+    connection_string -> JSON: {"client_id": "...", "client_secret": "...",
+                                 "refresh_token": "..."}
+    query_template     -> optional Gmail search query (same syntax as the
+                          Gmail search box, e.g. "is:unread from:x@y.com");
+                          blank fetches the most recent messages
+"""
+import json
+import logging
+from typing import Dict, Any, Tuple, List
+
+from core.integrations.base import BaseDatabaseConnector
+
+logger = logging.getLogger(__name__)
+
+REQUIRED_CONN_KEYS = ['client_id', 'client_secret', 'refresh_token']
+TOKEN_URI = "https://oauth2.googleapis.com/token"
+
+
+class GmailConnector(BaseDatabaseConnector):
+    """Gmail connector using the Gmail API (OAuth2 refresh token, BYO OAuth client)."""
+
+    def _parse_conn(self) -> Dict[str, str]:
+        raw = (self.data_source.connection_string or '').strip()
+        if not raw:
+            raise ValueError(
+                "Gmail connector requires connection_string as JSON: "
+                '{"client_id": "...", "client_secret": "...", "refresh_token": "..."}'
+            )
+        try:
+            params = json.loads(raw)
+        except Exception:
+            raise ValueError("Gmail connector's connection_string must be valid JSON")
+        missing = [k for k in REQUIRED_CONN_KEYS if not params.get(k)]
+        if missing:
+            raise ValueError(f"Gmail connection_string missing required keys: {', '.join(missing)}")
+        return params
+
+    def _service(self):
+        try:
+            from google.oauth2.credentials import Credentials
+            from googleapiclient.discovery import build
+        except ImportError:
+            raise ImportError(
+                "google-api-python-client / google-auth not installed. "
+                "Run: pip install google-api-python-client google-auth"
+            )
+        params = self._parse_conn()
+        credentials = Credentials(
+            token=None,
+            refresh_token=params['refresh_token'],
+            client_id=params['client_id'],
+            client_secret=params['client_secret'],
+            token_uri=TOKEN_URI,
+        )
+        return build('gmail', 'v1', credentials=credentials, cache_discovery=False)
+
+    def test_connection(self) -> Tuple[bool, str]:
+        try:
+            service = self._service()
+            profile = service.users().getProfile(userId='me').execute()
+            email = profile.get('emailAddress', 'unknown')
+            return True, f"Gmail connected: {email}"
+        except ImportError as e:
+            return False, str(e)
+        except ValueError as e:
+            return False, str(e)
+        except Exception as e:
+            return False, f"Gmail connection failed: {e}"
+
+    def fetch_data(self, user_identifier: str = None) -> List[Dict]:
+        service = self._service()
+        query = (self.data_source.query_template or '').strip()
+        if user_identifier:
+            query = f"{query} {user_identifier}".strip()
+
+        try:
+            list_resp = service.users().messages().list(
+                userId='me', q=query or None, maxResults=50
+            ).execute()
+            message_refs = list_resp.get('messages', [])
+
+            results = []
+            for ref in message_refs:
+                msg = service.users().messages().get(
+                    userId='me', id=ref['id'], format='metadata',
+                    metadataHeaders=['Subject', 'From', 'Date'],
+                ).execute()
+                headers = {h['name']: h['value'] for h in msg.get('payload', {}).get('headers', [])}
+                results.append({
+                    'id': msg.get('id'),
+                    'threadId': msg.get('threadId'),
+                    'snippet': msg.get('snippet', ''),
+                    'subject': headers.get('Subject', ''),
+                    'from': headers.get('From', ''),
+                    'date': headers.get('Date', ''),
+                })
+            return results
+        except Exception as e:
+            logger.error(f"GmailConnector.fetch_data error: {e}")
+            raise
+
+    def introspect_schema(self) -> Dict[str, Any]:
+        return {
+            'tables': [{'name': 'messages', 'label': 'Messages', 'columns': []}],
+            'filtered_count': 0,
+            'message': (
+                'Gmail exposes a single logical "messages" resource, '
+                'filterable via query_template (Gmail search syntax)'
+            ),
+        }
+
+    def execute_query(self, query: str) -> List[Dict]:
+        original = self.data_source.query_template
+        self.data_source.query_template = query
+        try:
+            return self.fetch_data()
+        finally:
+            self.data_source.query_template = original

--- a/tests/test_gmail_connector.py
+++ b/tests/test_gmail_connector.py
@@ -1,0 +1,133 @@
+"""
+Tests for core/integrations/gmail_connector.py -- the Gmail connector.
+google-api-python-client / google-auth are heavy optional dependencies
+not installed in CI (same convention as snowflake-connector-python /
+google-cloud-bigquery). We inject fake googleapiclient.discovery and
+google.oauth2.credentials modules into sys.modules so the connector's
+lazy imports succeed against MagicMocks.
+"""
+import os
+import sys
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+_fake_discovery_module = MagicMock()
+_fake_googleapiclient_pkg = MagicMock()
+_fake_googleapiclient_pkg.discovery = _fake_discovery_module
+sys.modules['googleapiclient'] = _fake_googleapiclient_pkg
+sys.modules['googleapiclient.discovery'] = _fake_discovery_module
+
+_fake_credentials_module = MagicMock()
+_fake_oauth2_pkg = MagicMock()
+_fake_oauth2_pkg.credentials = _fake_credentials_module
+_fake_google_pkg = MagicMock()
+_fake_google_pkg.oauth2 = _fake_oauth2_pkg
+sys.modules['google'] = _fake_google_pkg
+sys.modules['google.oauth2'] = _fake_oauth2_pkg
+sys.modules['google.oauth2.credentials'] = _fake_credentials_module
+
+from core.integrations.gmail_connector import GmailConnector
+from core.integrations.base import DataSource
+
+VALID_CONN = json.dumps({
+    "client_id": "abc.apps.googleusercontent.com",
+    "client_secret": "secret",
+    "refresh_token": "1//refresh-token",
+})
+
+
+@pytest.fixture(autouse=True)
+def reset_mocks():
+    _fake_discovery_module.reset_mock(return_value=True, side_effect=True)
+    _fake_credentials_module.reset_mock(return_value=True, side_effect=True)
+    yield
+
+
+def test_missing_connection_string_fails_gracefully():
+    ds = DataSource(id="1", name="test", source_type="gmail", connection_string=None)
+    ok, msg = GmailConnector(ds).test_connection()
+    assert ok is False
+    assert "connection_string" in msg
+
+
+def test_invalid_json_fails_gracefully():
+    ds = DataSource(id="1", name="test", source_type="gmail", connection_string="not json")
+    ok, msg = GmailConnector(ds).test_connection()
+    assert ok is False
+    assert "JSON" in msg
+
+
+def test_missing_required_keys_fails_gracefully():
+    ds = DataSource(id="1", name="test", source_type="gmail", connection_string='{"client_id": "abc"}')
+    ok, msg = GmailConnector(ds).test_connection()
+    assert ok is False
+    assert "missing required keys" in msg
+
+
+def test_connection_success():
+    ds = DataSource(id="1", name="test", source_type="gmail", connection_string=VALID_CONN)
+    mock_service = MagicMock()
+    mock_service.users().getProfile().execute.return_value = {"emailAddress": "me@example.com"}
+    _fake_discovery_module.build.return_value = mock_service
+    ok, msg = GmailConnector(ds).test_connection()
+    assert ok is True
+    assert "me@example.com" in msg
+
+
+def test_connection_failure_surfaces_message():
+    ds = DataSource(id="1", name="test", source_type="gmail", connection_string=VALID_CONN)
+    _fake_discovery_module.build.side_effect = Exception("invalid_grant")
+    ok, msg = GmailConnector(ds).test_connection()
+    assert ok is False
+    assert "invalid_grant" in msg
+
+
+def test_fetch_data_maps_messages():
+    ds = DataSource(id="1", name="test", source_type="gmail", connection_string=VALID_CONN)
+    mock_service = MagicMock()
+    mock_service.users().messages().list().execute.return_value = {
+        "messages": [{"id": "m1", "threadId": "t1"}]
+    }
+    mock_service.users().messages().get().execute.return_value = {
+        "id": "m1",
+        "threadId": "t1",
+        "snippet": "Hello there",
+        "payload": {"headers": [
+            {"name": "Subject", "value": "Test Subject"},
+            {"name": "From", "value": "alice@example.com"},
+            {"name": "Date", "value": "Mon, 1 Jan 2024 00:00:00 +0000"},
+        ]},
+    }
+    _fake_discovery_module.build.return_value = mock_service
+    data = GmailConnector(ds).fetch_data()
+    assert data == [{
+        "id": "m1", "threadId": "t1", "snippet": "Hello there",
+        "subject": "Test Subject", "from": "alice@example.com",
+        "date": "Mon, 1 Jan 2024 00:00:00 +0000",
+    }]
+
+
+def test_fetch_data_no_messages_returns_empty_list():
+    ds = DataSource(id="1", name="test", source_type="gmail", connection_string=VALID_CONN)
+    mock_service = MagicMock()
+    mock_service.users().messages().list().execute.return_value = {}
+    _fake_discovery_module.build.return_value = mock_service
+    data = GmailConnector(ds).fetch_data()
+    assert data == []
+
+
+def test_fetch_data_appends_user_identifier_to_query():
+    ds = DataSource(
+        id="1", name="test", source_type="gmail", connection_string=VALID_CONN,
+        query_template="is:unread",
+    )
+    mock_service = MagicMock()
+    mock_service.users().messages().list().execute.return_value = {}
+    _fake_discovery_module.build.return_value = mock_service
+    GmailConnector(ds).fetch_data(user_identifier="from:bob@example.com")
+    list_call_kwargs = mock_service.users().messages().list.call_args.kwargs
+    assert list_call_kwargs["q"] == "is:unread from:bob@example.com"


### PR DESCRIPTION
Adds a Gmail connector, completing all 8 connectors from Discussion #169 / issue #27.

**Pattern:** OAuth2, not a static key like every other connector. Per the project's stated BYOK philosophy, this does NOT run an OAuth consent flow -- the user brings their own OAuth client (their own Google Cloud project) and a refresh_token obtained once externally.

**Field usage:**
- `connection_string` — JSON: `{client_id, client_secret, refresh_token}`
- `query_template` — optional Gmail search query syntax (e.g. `is:unread from:x@y.com`)

Uses `google-api-python-client`/`google-auth`, lazily imported, same pattern as Snowflake/BigQuery.

**Testing:** 8 unit tests (`tests/test_gmail_connector.py`), same sys.modules mock-injection technique as Snowflake/BigQuery. Full `tests/` suite (73 tests) verified passing locally. Registered in `factory.py`'s `CONNECTOR_MAP` under `'gmail'`.