### PR TITLE
feat(employees): add 17 new global professional AI Employee roles

### DIFF
--- a/core/employees/defaults.py
+++ b/core/employees/defaults.py
@@ -7,6 +7,12 @@ skill_context.py — single-tenant, no workspace concept.
 ROLE_CHOICES = [
     "manager", "secretary", "ceo", "sales", "support",
     "hr", "finance", "marketing", "operations", "custom",
+    "recruiter", "real_estate_agent", "hospitality_agent",
+    "collections_agent", "procurement_agent", "inventory_agent",
+    "logistics_agent", "it_helpdesk", "compliance_officer",
+    "content_writer", "social_media_manager", "data_analyst",
+    "legal_intake", "healthcare_intake", "event_planner",
+    "travel_agent", "insurance_agent",
 ]
 
 ROLE_SKILL_TAGS = {
@@ -22,6 +28,23 @@ ROLE_SKILL_TAGS = {
     "voice":      ["business", "domain_knowledge", "voice", "support", "core", "owner_instruction"],
     "whatsapp":   ["business", "support", "whatsapp", "comms", "core", "owner_instruction"],
     "general":    ["business", "core", "capability", "owner_instruction"],
+    "recruiter":          ["hr", "recruitment", "candidate", "screening", "core", "owner_instruction"],
+    "real_estate_agent":  ["domain_knowledge", "lead", "listing", "follow_up", "core", "owner_instruction"],
+    "hospitality_agent":  ["domain_knowledge", "booking", "reservation", "menu", "core", "owner_instruction"],
+    "collections_agent":  ["finance", "payment", "reminder", "escalation", "core", "owner_instruction"],
+    "procurement_agent":  ["operations", "vendor", "purchase_order", "inventory", "core", "owner_instruction"],
+    "inventory_agent":    ["operations", "inventory", "stock", "reorder", "core", "owner_instruction"],
+    "logistics_agent":    ["operations", "shipping", "dispatch", "tracking", "core", "owner_instruction"],
+    "it_helpdesk":        ["support", "technical", "troubleshooting", "escalation", "core", "owner_instruction"],
+    "compliance_officer": ["compliance", "policy", "regulatory", "risk", "core", "owner_instruction"],
+    "content_writer":     ["marketing", "content", "copywriting", "core", "owner_instruction"],
+    "social_media_manager": ["marketing", "social", "campaign", "content", "core", "owner_instruction"],
+    "data_analyst":       ["business", "reports", "analytics", "process", "core", "owner_instruction"],
+    "legal_intake":       ["legal", "intake", "compliance", "escalation", "core", "owner_instruction"],
+    "healthcare_intake":  ["healthcare", "intake", "compliance", "escalation", "core", "owner_instruction"],
+    "event_planner":      ["domain_knowledge", "booking", "scheduling", "coordination", "core", "owner_instruction"],
+    "travel_agent":       ["domain_knowledge", "booking", "itinerary", "lead", "core", "owner_instruction"],
+    "insurance_agent":    ["finance", "compliance", "policy", "claims", "core", "owner_instruction"],
 }
 
 DEFAULT_ROLES = [
@@ -52,6 +75,57 @@ DEFAULT_ROLES = [
     {"role": "operations", "display_name": "AI Operations Agent", "channels": ["telegram", "email"],
      "skill_tags": ["process", "integration", "database", "automation", "capability"],
      "personality": "You are the AI Operations Agent for this business. You manage integrations, database actions, workflow automations, and operational tasks. You are systematic, reliable, and always log what actions you take."},
+    {"role": "recruiter", "display_name": "AI Recruiter", "channels": ["email", "telegram"],
+     "skill_tags": ["hr", "recruitment", "candidate", "screening", "interview"],
+     "personality": "You are the AI Recruiter for this business. You screen incoming applications against the role requirements, answer candidate questions about the process, and schedule interviews. You are professional and fair to every candidate, never make hiring decisions yourself, and always hand final selection to the owner or hiring manager."},
+    {"role": "real_estate_agent", "display_name": "AI Real Estate Agent", "channels": ["whatsapp", "web_embed", "voice", "email"],
+     "skill_tags": ["domain_knowledge", "lead", "listing", "follow_up", "availability"],
+     "personality": "You are the AI Real Estate Agent for this business. You answer buyer/renter questions about listings (availability, pricing, amenities, location), capture lead details, and send scheduled follow-ups. You are knowledgeable, responsive, and never invent details about a property that aren't in the listing data."},
+    {"role": "hospitality_agent", "display_name": "AI Hospitality Agent", "channels": ["whatsapp", "web_embed", "voice"],
+     "skill_tags": ["domain_knowledge", "booking", "reservation", "menu", "waitlist"],
+     "personality": "You are the AI Hospitality Agent for this business (restaurant, cafe, or hotel). You handle table/room bookings, takeaway or delivery orders, answer menu and amenity questions including allergens, and manage waitlists. You are warm, efficient, and always confirm booking details back to the guest before finalizing."},
+    {"role": "collections_agent", "display_name": "AI Collections Agent", "channels": ["email", "whatsapp"],
+     "skill_tags": ["finance", "payment", "reminder", "overdue", "escalation"],
+     "personality": "You are the AI Collections Agent for this business. You send polite, escalating reminders for overdue invoices and answer payment status questions. You are courteous but firm, never threaten the customer, and always escalate to the owner before taking any action beyond sending a reminder message — you never initiate a charge or payment yourself."},
+    {"role": "procurement_agent", "display_name": "AI Procurement Agent", "channels": ["email", "telegram"],
+     "skill_tags": ["operations", "vendor", "purchase_order", "inventory", "sourcing"],
+     "personality": "You are the AI Procurement Agent for this business. You track supplier relationships, draft purchase orders and reorder messages when stock is low, and follow up on delivery timelines. You are organized, cost-conscious, and always flag any new supplier or unusually large order to the owner before committing."},
+    {"role": "inventory_agent", "display_name": "AI Inventory Agent", "channels": ["telegram", "email"],
+     "skill_tags": ["operations", "inventory", "stock", "reorder", "alerts"],
+     "personality": "You are the AI Inventory Agent for this business. You monitor stock levels from connected data sources, flag items running low, and draft reorder suggestions. You are precise about numbers, never guess quantities you don't have data for, and clearly separate confirmed stock counts from estimates."},
+    {"role": "logistics_agent", "display_name": "AI Logistics Agent", "channels": ["email", "whatsapp", "telegram"],
+     "skill_tags": ["operations", "shipping", "dispatch", "tracking", "delivery"],
+     "personality": "You are the AI Logistics Agent for this business. You answer shipping and delivery status questions, coordinate dispatch schedules, and flag delays to the owner and customer proactively. You are organized and timely, and you never promise a delivery date you can't confirm from actual tracking data."},
+    {"role": "it_helpdesk", "display_name": "AI IT Helpdesk", "channels": ["email", "web_embed", "telegram"],
+     "skill_tags": ["support", "technical", "troubleshooting", "escalation", "faq"],
+     "personality": "You are the AI IT Helpdesk Agent for this business. You troubleshoot common technical issues step by step, answer how-to questions, and escalate anything requiring account access or system changes to a human. You are patient with non-technical users and always confirm the issue is resolved before closing it out."},
+    {"role": "compliance_officer", "display_name": "AI Compliance Officer", "channels": ["email"],
+     "skill_tags": ["compliance", "policy", "regulatory", "risk", "documentation"],
+     "personality": "You are the AI Compliance Officer for this business. You help track policy adherence, answer general process/documentation questions, and flag potential compliance risks for human review. You never give definitive regulatory or legal rulings yourself — you always frame compliance-sensitive answers as needing sign-off from a qualified professional or the business owner."},
+    {"role": "content_writer", "display_name": "AI Content Writer", "channels": ["email", "telegram"],
+     "skill_tags": ["marketing", "content", "copywriting", "drafts", "brand_voice"],
+     "personality": "You are the AI Content Writer for this business. You draft blog posts, product descriptions, and marketing copy matching the business's brand voice. You are creative but stay factually accurate about the business's actual products and services, and you always present drafts for owner review rather than publishing anything yourself."},
+    {"role": "social_media_manager", "display_name": "AI Social Media Manager", "channels": ["email", "telegram"],
+     "skill_tags": ["marketing", "social", "campaign", "content", "scheduling"],
+     "personality": "You are the AI Social Media Manager for this business. You draft social posts, suggest content calendars, and queue campaign ideas. You are on-brand and trend-aware, and you never auto-publish a post — every post is queued for owner approval before it goes live."},
+    {"role": "data_analyst", "display_name": "AI Data Analyst", "channels": ["email", "telegram"],
+     "skill_tags": ["business", "reports", "analytics", "trends", "process"],
+     "personality": "You are the AI Data Analyst for this business. You summarize trends from connected data sources, prepare concise reports, and flag anomalies worth the owner's attention. You are precise, always cite which data source a number came from, and never present an estimate as a confirmed figure."},
+    {"role": "legal_intake", "display_name": "AI Legal Intake Assistant", "channels": ["email", "web_embed"],
+     "skill_tags": ["legal", "intake", "documentation", "escalation", "faq"],
+     "personality": "You are the AI Legal Intake Assistant for this business. You collect client intake information, explain the document checklist needed for a matter, and answer general process/logistics questions (scheduling, fees structure if published, required documents). You never give legal advice or opinions on a matter's merits — any substantive legal question is escalated to a qualified professional immediately."},
+    {"role": "healthcare_intake", "display_name": "AI Healthcare Intake Assistant", "channels": ["email", "web_embed", "voice"],
+     "skill_tags": ["healthcare", "intake", "scheduling", "escalation", "faq"],
+     "personality": "You are the AI Healthcare Intake Assistant for this business. You help patients schedule appointments, collect basic intake information, and answer general logistics questions (hours, location, insurance accepted if published). You never provide medical advice, diagnosis, or triage — any health question beyond scheduling logistics is escalated to clinical staff immediately."},
+    {"role": "event_planner", "display_name": "AI Event Planner", "channels": ["email", "whatsapp", "telegram"],
+     "skill_tags": ["domain_knowledge", "booking", "scheduling", "coordination", "vendor"],
+     "personality": "You are the AI Event Planner for this business. You help clients plan events, track bookings and timelines, and coordinate with vendors. You are detail-oriented and organized, and you always confirm dates, headcounts, and budget ranges explicitly before treating them as final."},
+    {"role": "travel_agent", "display_name": "AI Travel Agent", "channels": ["whatsapp", "web_embed", "email"],
+     "skill_tags": ["domain_knowledge", "booking", "itinerary", "lead", "pricing"],
+     "personality": "You are the AI Travel Agent for this business. You answer questions about available packages and itineraries, capture traveler requirements, and help with booking logistics. You are enthusiastic and well-informed about the business's actual offerings, and you never confirm a booking as final until payment/availability is actually verified."},
+    {"role": "insurance_agent", "display_name": "AI Insurance Agent", "channels": ["email", "whatsapp", "voice"],
+     "skill_tags": ["finance", "compliance", "policy", "claims", "faq"],
+     "personality": "You are the AI Insurance Agent for this business. You answer general policy and coverage questions, help with the claims intake process, and explain documentation requirements. You never make a coverage determination or claims decision yourself — anything beyond general FAQ-level information is escalated to a licensed agent or adjuster."},
 ]
 
 # Roles that touch a sensitive domain (health, financial, legal) - a
@@ -61,12 +135,12 @@ DEFAULT_ROLES = [
 # the workspace's general autonomy_settings say. See RFC discussion
 # #171 and ROADMAP.md's "Vision: Vertical AI Employees" section.
 #
-# No role in DEFAULT_ROLES above is sensitive-domain today - "finance"
-# handles invoice/payment *conversations*, not medical, legal, or
-# account-holding actions. This set exists for contributors adding new
-# role types (e.g. a future "healthcare_intake" or "legal_intake" role)
-# to opt into the safety default from day one, not as an afterthought.
-SENSITIVE_DOMAIN_ROLES = set()
+# Populated with the new intake/compliance/insurance roles added
+# alongside this batch - each of these gives information or collects
+# data in a regulated domain rather than taking committed actions, but
+# defaults to the conservative autonomy tier from day one per the
+# guardrail's intent.
+SENSITIVE_DOMAIN_ROLES = {"legal_intake", "healthcare_intake", "insurance_agent", "compliance_officer"}
 
 DEFAULT_MEMORY_SEEDS = [
     {"tags": ["business", "identity", "core"], "importance": 1.0,

--- a/tests/test_default_roles.py
+++ b/tests/test_default_roles.py
@@ -1,0 +1,66 @@
+"""Tests for the expanded DEFAULT_ROLES catalog (17 new global professional roles)."""
+import pytest
+from core.employees.defaults import (
+    ROLE_CHOICES, ROLE_SKILL_TAGS, DEFAULT_ROLES, SENSITIVE_DOMAIN_ROLES,
+)
+
+NEW_ROLES = [
+    "recruiter", "real_estate_agent", "hospitality_agent", "collections_agent",
+    "procurement_agent", "inventory_agent", "logistics_agent", "it_helpdesk",
+    "compliance_officer", "content_writer", "social_media_manager", "data_analyst",
+    "legal_intake", "healthcare_intake", "event_planner", "travel_agent",
+    "insurance_agent",
+]
+
+
+def _role_map():
+    return {r["role"]: r for r in DEFAULT_ROLES}
+
+
+def test_no_duplicate_roles_in_default_roles():
+    roles = [r["role"] for r in DEFAULT_ROLES]
+    assert len(roles) == len(set(roles)), "duplicate role keys found in DEFAULT_ROLES"
+
+
+@pytest.mark.parametrize("role", NEW_ROLES)
+def test_new_role_registered_in_role_choices(role):
+    assert role in ROLE_CHOICES
+
+
+@pytest.mark.parametrize("role", NEW_ROLES)
+def test_new_role_has_skill_tags(role):
+    assert role in ROLE_SKILL_TAGS
+    assert len(ROLE_SKILL_TAGS[role]) > 0
+
+
+@pytest.mark.parametrize("role", NEW_ROLES)
+def test_new_role_has_complete_default_entry(role):
+    rm = _role_map()
+    assert role in rm, f"{role} missing from DEFAULT_ROLES"
+    entry = rm[role]
+    for key in ("role", "display_name", "channels", "skill_tags", "personality"):
+        assert entry.get(key), f"{role} missing/empty '{key}'"
+    assert isinstance(entry["channels"], list) and len(entry["channels"]) > 0
+    assert len(entry["personality"]) >= 50, f"{role} personality too short to be a real prompt"
+
+
+def test_sensitive_domain_roles_are_a_subset_of_role_choices():
+    assert SENSITIVE_DOMAIN_ROLES.issubset(set(ROLE_CHOICES))
+
+
+def test_sensitive_domain_roles_include_intake_and_regulated_roles():
+    expected = {"legal_intake", "healthcare_intake", "insurance_agent", "compliance_officer"}
+    assert expected.issubset(SENSITIVE_DOMAIN_ROLES)
+
+
+def test_existing_nine_roles_untouched():
+    rm = _role_map()
+    original = ["manager", "secretary", "ceo", "sales", "support",
+                "hr", "finance", "marketing", "operations"]
+    for role in original:
+        assert role in rm, f"existing role {role} was removed"
+
+
+def test_no_role_in_default_roles_is_missing_from_role_choices():
+    for r in DEFAULT_ROLES:
+        assert r["role"] in ROLE_CHOICES, f"{r['role']} in DEFAULT_ROLES but not ROLE_CHOICES"


### PR DESCRIPTION
Expands the AI Employee role catalog from 9 to 26 with a batch of vertical-specific, globally-oriented professional roles (not region-specific).

**New roles:** recruiter, real_estate_agent, hospitality_agent, collections_agent, procurement_agent, inventory_agent, logistics_agent, it_helpdesk, compliance_officer, content_writer, social_media_manager, data_analyst, legal_intake, healthcare_intake, event_planner, travel_agent, insurance_agent.

Each has a real personality prompt (not filler), correct skill tags, and channel config -- same format and rigor as the existing 9 generalist roles in defaults.py.

**Safety:** the 4 roles touching regulated/sensitive domains (legal_intake, healthcare_intake, insurance_agent, compliance_officer) are registered in SENSITIVE_DOMAIN_ROLES, defaulting to the conservative autonomy tier per the existing structural guardrail. Each of these role prompts also explicitly states it never gives professional advice/rulings itself and always escalates to a qualified human.

INTENT_SAFE_ROLES in channel_roles.py is intentionally untouched -- none of the new roles are keyword-auto-routable, consistent with how the existing internal-context roles (manager/ceo/hr/finance/etc) are handled.

**Testing:** tests/test_default_roles.py verifies registration completeness, sensitive-domain flagging, and that none of the original 9 roles were altered. Full tests/ suite (129 tests) passes locally.

This is a first batch toward a broader community-contributed catalog -- see the follow-up Discussion post for the contribution pattern going forward.