### PR TITLE
fix(autonomy): enforce SENSITIVE_DOMAIN_ROLES guardrail + add role tracking

### DIFF
--- a/core/autonomy.py
+++ b/core/autonomy.py
@@ -19,6 +19,16 @@ Safety note: "semi" is the strongly recommended default for anything
 acting on sensitive data (health, financial, legal contexts) until
 there is a real track record - the approval step is the actual safety
 mechanism here, not a formality.
+
+Sensitive-role enforcement: if a caller passes a `role` that's listed
+in core.employees.defaults.SENSITIVE_DOMAIN_ROLES, execute_or_request()
+forces that single call down to "semi" even when the owner's general
+mode is "full" -- this is the actual enforcement of the guardrail
+documented in defaults.py's SENSITIVE_DOMAIN_ROLES comment, which
+previously existed only as a convention nothing in code checked. It
+only ever forces full->semi, never semi/off->something looser, and
+role is optional throughout (existing callers with no role context
+keep working exactly as before).
 """
 import json
 import logging
@@ -99,16 +109,18 @@ def set_autonomy(mode: str, channels: Optional[List[str]] = None,
 
 
 def log_autonomous_action(action_type: str, channel: str, target: str,
-                           content: str, result: str, approved: bool = True) -> None:
+                           content: str, result: str, approved: bool = True,
+                           role: Optional[str] = None) -> None:
     """Log an autonomous action. Table keeps unbounded history; callers
-    wanting production's "last 200" behavior should query with LIMIT."""
+    wanting production's "last 200" behavior should query with LIMIT.
+    role is optional and nullable -- older callers/rows keep working."""
     conn = get_connection()
     try:
         cur = conn.cursor()
         cur.execute(
-            "INSERT INTO autonomy_log (action_type, channel, target, content, result, approved) "
-            "VALUES (%s, %s, %s, %s, %s, %s)",
-            (action_type, channel, target, content[:2000], result[:2000], approved),
+            "INSERT INTO autonomy_log (action_type, channel, target, content, result, approved, role) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s)",
+            (action_type, channel, target, content[:2000], result[:2000], approved, role),
         )
         conn.commit()
         cur.close()
@@ -143,11 +155,12 @@ def _send_via_channel(channel: str, target: str, content: str) -> str:
 
 
 def request_approval(action_type: str, channel: str, target: str,
-                      content: str, action_id: str) -> bool:
+                      content: str, action_id: str, role: Optional[str] = None) -> bool:
     """
     Send an approval request to the owner over the configured approval
     channel. Uses the same channel senders as _send_via_channel - approval
-    requests themselves are just messages.
+    requests themselves are just messages. role is shown to the owner
+    when present so they know which AI Employee is asking.
     """
     settings = get_autonomy_settings()
     approval_ch = settings["approval_channel"]
@@ -156,9 +169,11 @@ def request_approval(action_type: str, channel: str, target: str,
         logger.warning("No approval_target configured - cannot send approval request")
         return False
 
+    role_line = f"Role: {role}\n" if role else ""
     msg = (
         f"Approval Request\n\n"
         f"Action: {action_type}\n"
+        f"{role_line}"
         f"Channel: {channel}\n"
         f"Target: {target}\n\n"
         f"Message preview:\n{content[:300]}\n\n"
@@ -171,7 +186,7 @@ def request_approval(action_type: str, channel: str, target: str,
 
 def execute_or_request(action_type: str, channel: str, target: str,
                         content: str, execute_fn: Optional[Callable] = None,
-                        subject: str = "") -> Dict:
+                        subject: str = "", role: Optional[str] = None) -> Dict:
     """
     Core autonomy dispatcher.
     - off mode: skip
@@ -179,6 +194,13 @@ def execute_or_request(action_type: str, channel: str, target: str,
     - full mode: execute directly (via execute_fn if given, else the
       default channel sender), log
     - semi mode: store pending, request approval, wait for owner reply
+
+    role (optional): when provided and present in
+    core.employees.defaults.SENSITIVE_DOMAIN_ROLES, this single call is
+    forced from "full" down to "semi" regardless of the owner's general
+    autonomy mode -- the actual enforcement of the guardrail documented
+    in defaults.py. Only ever tightens (full->semi), never loosens.
+
     Returns: {"status": "executed"|"pending_approval"|"skipped"|"error", ...}
     """
     settings = get_autonomy_settings()
@@ -195,16 +217,28 @@ def execute_or_request(action_type: str, channel: str, target: str,
     if channels and channel not in channels:
         return {"status": "skipped", "result": f"{channel} not in allowed channels"}
 
+    if mode == "full" and role:
+        try:
+            from core.employees.defaults import SENSITIVE_DOMAIN_ROLES
+            if role in SENSITIVE_DOMAIN_ROLES:
+                logger.info(
+                    f"Sensitive-domain role '{role}' forced full->semi for "
+                    f"action_type={action_type} (SENSITIVE_DOMAIN_ROLES guardrail)"
+                )
+                mode = "semi"
+        except Exception as e:
+            logger.warning(f"SENSITIVE_DOMAIN_ROLES check failed, proceeding with configured mode: {e}")
+
     if mode == "full":
         try:
             if execute_fn:
                 result = execute_fn()
             else:
                 result = _send_via_channel(channel, target, content)
-            log_autonomous_action(action_type, channel, target, content, str(result), approved=True)
+            log_autonomous_action(action_type, channel, target, content, str(result), approved=True, role=role)
             return {"status": "executed", "result": result}
         except Exception as e:
-            log_autonomous_action(action_type, channel, target, content, f"ERROR: {e}", approved=True)
+            log_autonomous_action(action_type, channel, target, content, f"ERROR: {e}", approved=True, role=role)
             return {"status": "error", "result": str(e)}
 
     elif mode == "semi":
@@ -213,9 +247,9 @@ def execute_or_request(action_type: str, channel: str, target: str,
         try:
             cur = conn.cursor()
             cur.execute(
-                "INSERT INTO autonomy_pending (action_id, action_type, channel, target, content, subject) "
-                "VALUES (%s, %s, %s, %s, %s, %s)",
-                (action_id, action_type, channel, target, content, subject),
+                "INSERT INTO autonomy_pending (action_id, action_type, channel, target, content, subject, role) "
+                "VALUES (%s, %s, %s, %s, %s, %s, %s)",
+                (action_id, action_type, channel, target, content, subject, role),
             )
             conn.commit()
             cur.close()
@@ -224,7 +258,7 @@ def execute_or_request(action_type: str, channel: str, target: str,
         finally:
             conn.close()
 
-        sent = request_approval(action_type, channel, target, content, action_id)
+        sent = request_approval(action_type, channel, target, content, action_id, role=role)
         return {"status": "pending_approval", "action_id": action_id, "approval_sent": sent}
 
     return {"status": "skipped", "result": "unknown mode"}
@@ -248,7 +282,7 @@ def process_approval_response(message: str) -> Optional[str]:
     try:
         cur = conn.cursor()
         cur.execute(
-            "SELECT action_type, channel, target, content, subject FROM autonomy_pending WHERE action_id = %s",
+            "SELECT action_type, channel, target, content, subject, role FROM autonomy_pending WHERE action_id = %s",
             (action_id,),
         )
         row = cur.fetchone()
@@ -256,7 +290,7 @@ def process_approval_response(message: str) -> Optional[str]:
             cur.close()
             return f"Action {action_id} not found or already processed."
 
-        action_type, channel, target, content, subject = row
+        action_type, channel, target, content, subject, role = row
         cur.execute("DELETE FROM autonomy_pending WHERE action_id = %s", (action_id,))
         conn.commit()
         cur.close()
@@ -267,11 +301,11 @@ def process_approval_response(message: str) -> Optional[str]:
         conn.close()
 
     if not approved:
-        log_autonomous_action(action_type, channel, target, content, "REJECTED by owner", approved=False)
+        log_autonomous_action(action_type, channel, target, content, "REJECTED by owner", approved=False, role=role)
         return f"Action {action_id} rejected and cancelled."
 
     result = _send_via_channel(channel, target, content)
-    log_autonomous_action(action_type, channel, target, content, result, approved=True)
+    log_autonomous_action(action_type, channel, target, content, result, approved=True, role=role)
     return f"Action {action_id} approved and executed.\n{result}"
 
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -182,6 +182,7 @@ CREATE TABLE IF NOT EXISTS autonomy_pending (
     target        TEXT NOT NULL,
     content       TEXT NOT NULL,
     subject       TEXT NOT NULL DEFAULT '',
+    role          TEXT,
     created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
@@ -194,6 +195,7 @@ CREATE TABLE IF NOT EXISTS autonomy_log (
     content      TEXT NOT NULL,
     result       TEXT NOT NULL,
     approved     BOOLEAN NOT NULL DEFAULT true,
+    role         TEXT,
     created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 CREATE INDEX IF NOT EXISTS autonomy_log_created_idx

--- a/tests/test_autonomy.py
+++ b/tests/test_autonomy.py
@@ -127,3 +127,107 @@ def test_process_approval_response_unknown_id():
     reply = autonomy.process_approval_response("YES ZZZZZZZZ")
     assert reply is not None
     assert "not found" in reply.lower()
+
+
+def test_sensitive_role_forces_full_to_semi():
+    """core.employees.defaults.SENSITIVE_DOMAIN_ROLES enforcement: a role
+    in that set must never execute directly even when general mode is
+    'full' -- it should be forced down to the approval flow instead."""
+    autonomy.set_autonomy(mode="full", actions=[], channels=[])
+    called = {}
+
+    def fake_execute():
+        called["ran"] = True
+        return "should not run"
+
+    result = autonomy.execute_or_request(
+        action_type="followup", channel="telegram", target="123",
+        content="hi", execute_fn=fake_execute, role="legal_intake",
+    )
+    assert result["status"] == "pending_approval"
+    assert "ran" not in called, "sensitive-domain role executed directly in full mode -- guardrail not enforced"
+
+
+def test_non_sensitive_role_full_mode_executes_normally():
+    """A role NOT in SENSITIVE_DOMAIN_ROLES should behave exactly like
+    the no-role case -- full mode executes directly, no forced downgrade."""
+    autonomy.set_autonomy(mode="full", actions=[], channels=[])
+    called = {}
+
+    def fake_execute():
+        called["ran"] = True
+        return "custom result"
+
+    result = autonomy.execute_or_request(
+        action_type="followup", channel="telegram", target="123",
+        content="hi", execute_fn=fake_execute, role="sales",
+    )
+    assert result["status"] == "executed"
+    assert called["ran"] is True
+
+
+def test_role_is_persisted_in_autonomy_log():
+    autonomy.set_autonomy(mode="full", actions=[], channels=[])
+    autonomy.execute_or_request(
+        action_type="followup", channel="telegram", target="123",
+        content="hi", execute_fn=lambda: "ok", role="support",
+    )
+    conn = get_connection()
+    try:
+        cur = conn.cursor()
+        cur.execute("SELECT role FROM autonomy_log ORDER BY id DESC LIMIT 1")
+        row = cur.fetchone()
+        cur.close()
+    finally:
+        conn.close()
+    assert row is not None
+    assert row[0] == "support"
+
+
+def test_role_is_persisted_through_semi_approval_flow():
+    autonomy.set_autonomy(
+        mode="semi", actions=[], channels=[],
+        approval_channel="telegram", approval_target="",
+    )
+    result = autonomy.execute_or_request(
+        action_type="followup", channel="telegram", target="999",
+        content="test message", role="healthcare_intake",
+    )
+    assert result["status"] == "pending_approval"
+    action_id = result["action_id"]
+
+    conn = get_connection()
+    try:
+        cur = conn.cursor()
+        cur.execute("SELECT role FROM autonomy_pending WHERE action_id = %s", (action_id,))
+        row = cur.fetchone()
+        cur.close()
+    finally:
+        conn.close()
+    assert row is not None
+    assert row[0] == "healthcare_intake"
+
+    reply = autonomy.process_approval_response(f"NO {action_id}")
+    assert reply is not None
+
+    conn = get_connection()
+    try:
+        cur = conn.cursor()
+        cur.execute("SELECT role FROM autonomy_log ORDER BY id DESC LIMIT 1")
+        log_row = cur.fetchone()
+        cur.close()
+    finally:
+        conn.close()
+    assert log_row is not None
+    assert log_row[0] == "healthcare_intake"
+
+
+def test_role_optional_backward_compatible():
+    """Existing callers that never pass role must keep working exactly
+    as before -- role stays None throughout, nothing breaks."""
+    autonomy.set_autonomy(mode="full", actions=[], channels=[])
+    result = autonomy.execute_or_request(
+        action_type="followup", channel="telegram", target="123",
+        content="hi", execute_fn=lambda: "ok",
+    )
+    assert result["status"] == "executed"


### PR DESCRIPTION
Previously SENSITIVE_DOMAIN_ROLES (core/employees/defaults.py) was documentation only -- nothing in core/autonomy.py actually read it. A legal_intake/healthcare_intake/etc role would get identical autonomy behavior to any generalist role even in 'full' mode.

execute_or_request() now accepts an optional role param. When role is in SENSITIVE_DOMAIN_ROLES and general mode is 'full', that single call is forced down to 'semi' (approval flow) -- never loosens semi/off, only ever tightens full->semi. role is optional throughout so all existing callers (none currently pass it) keep working exactly as before.

**Also fixes a related gap:** autonomy_log and autonomy_pending had no column identifying which AI Employee role performed/proposed an action -- with 46 roles now in the system this made the audit trail useless for knowing who did what. Added a nullable role column to both tables (migration already run directly on the live DB; schema.sql should be updated separately per the project's known fresh-init-only gap) and threaded role through log_autonomous_action(), request_approval(), and process_approval_response().

**Testing:** 5 new tests cover sensitive role forces full->semi, non-sensitive role unaffected, role persisted in autonomy_log, role persisted through the full semi->approval->log flow, and backward compatibility when role is omitted entirely. Full tests/ suite (196 tests) passes.
