### PR TITLE
fix(memory): add role-scoped tag filtering to semantic_search()

### DIFF
--- a/core/employees/memory.py
+++ b/core/employees/memory.py
@@ -106,7 +106,17 @@ def get_owner_instructions() -> str:
     return "=== OWNER INSTRUCTIONS (obey always) ===\n" + "\n".join(lines)
 
 
-def semantic_search(query: str, top_k: int = 8) -> List[Dict]:
+def semantic_search(query: str, top_k: int = 8, tags: Optional[List[str]] = None) -> List[Dict]:
+    """
+    tags (optional): when provided, results are restricted to entries
+    that share at least one tag with this list -- the same role-scoping
+    tag_search() already applies. Without this, semantic similarity search
+    ran across the entire employee_memory table with no role boundary at
+    all, meaning a role could surface another role's stored memories
+    (including sensitive-domain roles) whenever they were semantically
+    similar. Passing None preserves the old unscoped behavior for any
+    caller that genuinely wants a global search.
+    """
     try:
         embed_service = EmbeddingService()
         query_embedding = embed_service.embed_text(query)
@@ -119,14 +129,25 @@ def semantic_search(query: str, top_k: int = 8) -> List[Dict]:
     conn = get_connection()
     try:
         cur = conn.cursor()
-        cur.execute(
-            """
-            SELECT id, text_content, summary, tags, importance, created_at
-            FROM employee_memory WHERE embedding IS NOT NULL
-            ORDER BY embedding::halfvec(3072) <=> %s::halfvec(3072) LIMIT %s
-            """,
-            (literal, top_k),
-        )
+        if tags:
+            cur.execute(
+                """
+                SELECT id, text_content, summary, tags, importance, created_at
+                FROM employee_memory
+                WHERE embedding IS NOT NULL AND tags ?| %s::text[]
+                ORDER BY embedding::halfvec(3072) <=> %s::halfvec(3072) LIMIT %s
+                """,
+                (list(tags), literal, top_k),
+            )
+        else:
+            cur.execute(
+                """
+                SELECT id, text_content, summary, tags, importance, created_at
+                FROM employee_memory WHERE embedding IS NOT NULL
+                ORDER BY embedding::halfvec(3072) <=> %s::halfvec(3072) LIMIT %s
+                """,
+                (literal, top_k),
+            )
         rows = cur.fetchall()
         cur.close()
         return [_row_to_dict(r) for r in rows]

--- a/core/employees/skills.py
+++ b/core/employees/skills.py
@@ -1,13 +1,9 @@
 """Read path: get_role_skills / get_role_personality / get_capability_summary."""
 import logging
-
 from core.employees import memory, roles
 from core.employees.defaults import ROLE_SKILL_TAGS, DEFAULT_ROLES
 from core.employees._db import get_connection
-
 logger = logging.getLogger(__name__)
-
-
 def get_role_skills(role: str = "general", query: str = None, top_k: int = 8) -> str:
     """
     Owner instructions are always pulled first and prepended, then
@@ -15,41 +11,34 @@ def get_role_skills(role: str = "general", query: str = None, top_k: int = 8) ->
     twice in the same prompt.
     """
     owner_block = memory.get_owner_instructions()
-
     def _dedupe(entries):
         return [e for e in entries if "owner_instruction" not in (e.get("tags") or [])]
-
     tags = ROLE_SKILL_TAGS.get(role, ROLE_SKILL_TAGS["general"])
     if query and len(query.strip()) > 5:
         try:
-            entries = _dedupe(memory.semantic_search(query, top_k))
+            entries = _dedupe(memory.semantic_search(query, top_k, tags=tags))
             if entries:
                 return memory.format_context(owner_block, entries)
         except Exception as e:
             logger.debug(f"Semantic search failed, falling back to tag search: {e}")
     entries = _dedupe(memory.tag_search(tags, top_k))
     return memory.format_context(owner_block, entries)
-
-
 def get_role_skills_with_ids(role: str = "general", query: str = None, top_k: int = 8):
     """
     Same retrieval as get_role_skills(), but also returns the
     employee_memory row IDs that were actually used -- so a caller
     can later report back whether they led to a good outcome via
     core.employees.learning.record_role_memory_outcome().
-
     Returns (formatted_context: str, memory_ids: List[str]).
     """
     owner_block = memory.get_owner_instructions()
-
     def _dedupe(entries):
         return [e for e in entries if "owner_instruction" not in (e.get("tags") or [])]
-
     tags = ROLE_SKILL_TAGS.get(role, ROLE_SKILL_TAGS["general"])
     entries = []
     if query and len(query.strip()) > 5:
         try:
-            entries = _dedupe(memory.semantic_search(query, top_k))
+            entries = _dedupe(memory.semantic_search(query, top_k, tags=tags))
         except Exception as e:
             logger.debug(f"Semantic search failed, falling back to tag search: {e}")
     if not entries:
@@ -57,8 +46,6 @@ def get_role_skills_with_ids(role: str = "general", query: str = None, top_k: in
     text = memory.format_context(owner_block, entries)
     ids = [e["id"] for e in entries]
     return text, ids
-
-
 def get_role_personality(role: str = "support") -> str:
     r = roles.get_role(role)
     if r and r.get("personality"):
@@ -67,8 +54,6 @@ def get_role_personality(role: str = "support") -> str:
         if d["role"] == role:
             return d["personality"]
     return ""
-
-
 def get_capability_summary() -> str:
     conn = get_connection()
     try:

--- a/tests/test_memory_role_scoping.py
+++ b/tests/test_memory_role_scoping.py
@@ -1,0 +1,112 @@
+"""
+Tests for role-scoped memory retrieval (core/employees/memory.py +
+core/employees/skills.py). Covers the fix for semantic_search() having
+no tag filter at all -- previously any role's query could surface any
+other role's stored memories via similarity search alone.
+"""
+import json
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from core.employees import memory, skills
+from core.employees.defaults import ROLE_SKILL_TAGS
+from core.employees._db import get_connection
+
+VEC_A = "[" + ",".join(["0.10"] * 3072) + "]"
+VEC_B = "[" + ",".join(["0.11"] * 3072) + "]"
+
+
+@pytest.fixture(autouse=True)
+def clean_memory_table():
+    conn = get_connection()
+    try:
+        cur = conn.cursor()
+        cur.execute("DELETE FROM employee_memory WHERE source = 'test_role_scoping'")
+        conn.commit()
+        cur.close()
+    finally:
+        conn.close()
+    yield
+
+
+def _insert_row(text, tags, embedding_literal):
+    conn = get_connection()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO employee_memory
+                (text_content, summary, tags, importance, source, permanent,
+                 review_after_days, content_hash, embedding, token_count)
+            VALUES (%s, %s, %s::jsonb, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (text, text[:300], json.dumps(tags), 0.7,
+             "test_role_scoping", False, 180, text[:8], embedding_literal, len(text.split())),
+        )
+        conn.commit()
+        cur.close()
+    finally:
+        conn.close()
+
+
+def test_semantic_search_without_tags_returns_across_roles():
+    """Baseline: with tags=None (the old default behavior), search is
+    still unscoped -- this is intentional for any caller that genuinely
+    wants a global search, and confirms we didn't accidentally remove
+    that capability."""
+    _insert_row("Sales pricing info", ["sales", "core"], VEC_A)
+    _insert_row("Healthcare intake info", ["healthcare", "intake"], VEC_B)
+
+    with patch("core.employees.memory.EmbeddingService") as MockService:
+        MockService.return_value.embed_text.return_value = [0.10] * 3072
+        results = memory.semantic_search("pricing", top_k=10)
+
+    tags_seen = {t for r in results for t in r["tags"]}
+    assert "sales" in tags_seen
+    assert "healthcare" in tags_seen
+
+
+def test_semantic_search_with_tags_excludes_other_roles():
+    """The actual fix: passing tags restricts results to entries sharing
+    at least one tag -- a healthcare-tagged memory must not leak into a
+    sales-scoped search."""
+    _insert_row("Sales pricing info", ["sales", "core"], VEC_A)
+    _insert_row("Healthcare intake info", ["healthcare", "intake"], VEC_B)
+
+    with patch("core.employees.memory.EmbeddingService") as MockService:
+        MockService.return_value.embed_text.return_value = [0.10] * 3072
+        results = memory.semantic_search("pricing", top_k=10, tags=["sales", "core"])
+
+    tags_seen = {t for r in results for t in r["tags"]}
+    assert "sales" in tags_seen
+    assert "healthcare" not in tags_seen, "tag-scoped semantic search leaked another role's memory"
+
+
+def test_get_role_skills_passes_role_tags_to_semantic_search():
+    """skills.py's get_role_skills() must actually pass the role's own
+    tags into semantic_search() -- the fix is useless if the only real
+    caller never uses the new parameter."""
+    with patch("core.employees.skills.memory") as mock_memory:
+        mock_memory.get_owner_instructions.return_value = ""
+        mock_memory.semantic_search.return_value = []
+        mock_memory.tag_search.return_value = []
+        mock_memory.format_context.return_value = ""
+        skills.get_role_skills(role="healthcare_intake", query="what are your hours")
+        _, kwargs = mock_memory.semantic_search.call_args
+        assert kwargs.get("tags") == ROLE_SKILL_TAGS["healthcare_intake"]
+
+
+def test_get_role_skills_with_ids_passes_role_tags_to_semantic_search():
+    with patch("core.employees.skills.memory") as mock_memory:
+        mock_memory.get_owner_instructions.return_value = ""
+        mock_memory.semantic_search.return_value = []
+        mock_memory.tag_search.return_value = []
+        mock_memory.format_context.return_value = ""
+        skills.get_role_skills_with_ids(role="legal_intake", query="what documents do I need")
+        _, kwargs = mock_memory.semantic_search.call_args
+        assert kwargs.get("tags") == ROLE_SKILL_TAGS["legal_intake"]


### PR DESCRIPTION
tag_search() already restricted results to entries sharing a tag with the caller's role, but semantic_search() had no such filter at all -- it ran pure vector similarity across the ENTIRE employee_memory table regardless of role. Since skills.py's get_role_skills() tries semantic_search() first whenever there's a real query (the common case), this meant most retrievals had no role boundary whatsoever: a sales role's query could easily surface a healthcare_intake or legal_intake role's stored memory if it was semantically similar enough.

**Fix:** semantic_search() now accepts an optional `tags` param that adds the same `tags ?| %s::text[]` filter tag_search() already uses. Passing None preserves the old fully-unscoped behavior for any caller that genuinely wants a global search. Both call sites in skills.py (get_role_skills, get_role_skills_with_ids) now pass the role's own ROLE_SKILL_TAGS through.

**Testing:** no test coverage existed for either memory.py or skills.py before this. Added tests/test_memory_role_scoping.py -- confirms unscoped search still sees across roles (baseline), confirms tag-scoped search excludes another role's memory, and confirms skills.py's two entry points actually pass the role's tags through (the fix is worthless if the only real caller never uses the new parameter). Full tests/ suite (200 tests) passes.
