### PR TITLE
feat(ragleap-ops): add backup/DR for db and neo4j PVCs

### DIFF
--- a/packages/ragleap-ops/CHANGELOG.md
+++ b/packages/ragleap-ops/CHANGELOG.md
@@ -5,6 +5,20 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Backup/DR: `backup-pvc.yaml`, `db-backup-cronjob.yaml` (daily `pg_dump`, no downtime), `neo4j-backup-cronjob.yaml` (scale-to-zero + `neo4j-admin dump`, since Community Edition has no online backup command).
+
+### Verified
+
+- `pg_dump` live-tested against a real running database, produced a valid dump.
+- neo4j scale-to-zero + dump pattern live-tested end-to-end via a real Job, produced a genuine 257.8MiB/36-file dump successfully.
+- CronJob wrapper (RBAC, scheduling) validated structurally, not exercised via an actual cron trigger this session.
+
+### Known limitations
+
+- Neo4j backup is fail-loud by design: a failed dump leaves neo4j scaled to 0 rather than auto-restoring, to avoid a silently-failing backup going unnoticed. Requires monitoring CronJob/Job status separately.
+
 ### Fixed
 
 - `k8s/neo4j-deployment.yaml`'s liveness probe still had the original, pre-fix timing (`initialDelaySeconds: 20`, no explicit `failureThreshold`) even though the equivalent bug was already found and fixed in the Helm chart's neo4j template earlier this session. The two deployment paths had silently diverged. Found while live-testing backup/DR tooling on a fresh cluster -- neo4j genuinely crash-looped (kubelet killing it ~7 seconds into JVM startup, well before the database could bind its HTTP listener). Fixed to match the Helm chart's already-proven values (`initialDelaySeconds: 60`, `failureThreshold: 6`), then re-verified stable (0 further restarts after the one within the expected startup window).

--- a/packages/ragleap-ops/README.md
+++ b/packages/ragleap-ops/README.md
@@ -178,3 +178,42 @@ and `ingress.enabled`/`ingress.hostname` confirmed to differ correctly
 across all three overlay files via `helm template -f values-<env>.yaml`
 -- dev (1/1, no ingress), staging (1/1, ingress enabled with its own
 hostname), prod (3/2, ingress enabled with its own hostname).
+
+## Backup / Disaster Recovery
+
+Scheduled backups for both `db` (Postgres) and `neo4j` live in
+`k8s/backup-pvc.yaml`, `k8s/db-backup-cronjob.yaml`, and
+`k8s/neo4j-backup-cronjob.yaml`.
+
+**Postgres**: `pg_dump` runs against the live database daily -- no
+downtime, Postgres handles concurrent dumps natively via MVCC.
+
+**Neo4j**: Community Edition has no online/hot backup command (`neo4j-admin
+database backup` is Enterprise-only, confirmed via `--help` against the
+real image -- only `dump` exists in Community). The CronJob scales
+`ragleap-neo4j` to 0 replicas, waits for the pod to fully terminate, then
+runs `neo4j-admin database dump` against the now-unlocked PVC via a Job
+with the same volume mounted.
+
+**Important design decision -- fail loud, no automatic restart:** if the
+dump step fails, neo4j is intentionally left scaled to 0 rather than
+automatically restored. Coupling application uptime to backup success
+was considered and rejected -- a silently-failing backup with automatic
+scale-up could leave a real backup gap unnoticed for a long time while
+the app appears healthy. Monitor CronJob/Job success explicitly
+(`kubectl get cronjobs`, `kubectl get jobs`, or your alerting stack) and
+manually restore service after confirming/investigating a failure:
+
+```bash
+kubectl scale deployment ragleap-neo4j --replicas=1
+```
+
+Verification performed: both `pg_dump` and the scale-to-zero +
+`neo4j-admin dump` pattern were live-tested against real running
+instances on a real kind cluster -- `pg_dump` produced a valid dump
+against the live database; the neo4j pattern produced a real, complete
+257.8MiB dump (36 files) via the Job mechanism. The scheduled CronJob
+wrapper itself (RBAC, scale-down init container, timing) was validated
+structurally (`python3 -c "import yaml..."` parse + document/kind
+checks) but not exercised end-to-end via an actual cron trigger this
+session.

--- a/packages/ragleap-ops/k8s/backup-pvc.yaml
+++ b/packages/ragleap-ops/k8s/backup-pvc.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ragleap-backup-data
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 10Gi   # UNVERIFIED — holds both db and neo4j dumps, size for real retention needs

--- a/packages/ragleap-ops/k8s/db-backup-cronjob.yaml
+++ b/packages/ragleap-ops/k8s/db-backup-cronjob.yaml
@@ -1,0 +1,38 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ragleap-db-backup
+spec:
+  schedule: "0 3 * * *"   # daily at 03:00 — adjust to your real retention/RPO needs
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: pg-dump
+              image: pgvector/pgvector:pg16
+              command:
+                - sh
+                - -c
+                - |
+                  set -e
+                  TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+                  pg_dump -h ragleap-db -U "$POSTGRES_USER" "$POSTGRES_DB" > /backups/db-${TIMESTAMP}.sql
+                  echo "Backup written: db-${TIMESTAMP}.sql"
+              envFrom:
+                - secretRef:
+                    name: ragleap-db-secret
+              env:
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: ragleap-db-secret
+                      key: POSTGRES_PASSWORD
+              volumeMounts:
+                - name: backup-data
+                  mountPath: /backups
+          volumes:
+            - name: backup-data
+              persistentVolumeClaim:
+                claimName: ragleap-backup-data

--- a/packages/ragleap-ops/k8s/neo4j-backup-cronjob.yaml
+++ b/packages/ragleap-ops/k8s/neo4j-backup-cronjob.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ragleap-neo4j-backup
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ragleap-neo4j-backup-role
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments", "deployments/scale"]
+    resourceNames: ["ragleap-neo4j"]
+    verbs: ["get", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ragleap-neo4j-backup-binding
+subjects:
+  - kind: ServiceAccount
+    name: ragleap-neo4j-backup
+roleRef:
+  kind: Role
+  name: ragleap-neo4j-backup-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ragleap-neo4j-backup
+spec:
+  schedule: "0 3 * * *"   # matches db backup schedule; adjust to your real RPO needs
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          serviceAccountName: ragleap-neo4j-backup
+          restartPolicy: OnFailure
+          initContainers:
+            - name: scale-down
+              image: bitnami/kubectl:1.31
+              command:
+                - sh
+                - -c
+                - |
+                  set -e
+                  kubectl scale deployment ragleap-neo4j --replicas=0
+                  kubectl wait --for=delete pod -l app=ragleap-neo4j --timeout=120s
+          containers:
+            - name: dump
+              image: neo4j:5-community
+              command:
+                - sh
+                - -c
+                - |
+                  set -e
+                  TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+                  mkdir -p /backups/neo4j-${TIMESTAMP}
+                  neo4j-admin database dump neo4j --to-path=/backups/neo4j-${TIMESTAMP}
+                  echo "Backup written: neo4j-${TIMESTAMP}"
+              volumeMounts:
+                - name: neo4j-data
+                  mountPath: /data
+                - name: backup-data
+                  mountPath: /backups
+          volumes:
+            - name: neo4j-data
+              persistentVolumeClaim:
+                claimName: ragleap-neo4j-data
+            - name: backup-data
+              persistentVolumeClaim:
+                claimName: ragleap-backup-data


### PR DESCRIPTION
- backup-pvc.yaml, db-backup-cronjob.yaml (daily pg_dump, no downtime), neo4j-backup-cronjob.yaml (scale-to-zero + neo4j-admin dump, since Community Edition has no online backup command)
- Fail-loud design for neo4j: failed dump leaves it scaled to 0 rather than auto-restoring, to avoid a silent backup gap

pg_dump and the neo4j scale-to-zero+dump pattern both live-tested against real running instances. CronJob scheduling/RBAC validated structurally, not exercised via an actual cron trigger this session.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
