### PR TITLE
vectorstores: v0.3.1 - README Redis example + keywords

### DIFF
--- a/packages/ragleap-vectorstores/CHANGELOG.md
+++ b/packages/ragleap-vectorstores/CHANGELOG.md
@@ -5,6 +5,18 @@ loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-09-05
+### Fixed
+- README's Usage section was missing a RedisBackend example (only
+  Chroma/LanceDB were shown) - same category of gap as the v0.2.1
+  missing-uv-add-lines fix, caught the same way: checking the real
+  rendered PyPI page after publish rather than assuming the README
+  was complete.
+- pyproject.toml's keywords only listed generic terms (rag,
+  vector-search, vector-database, ragleap) - added per-backend terms
+  (chroma, chromadb, lancedb, redis, redisearch) plus embeddings and
+  similarity-search for PyPI/search discoverability.
+
 ## [0.3.0] - 2026-09-05
 ### Added
 - `RedisBackend` - third vector backend, via RediSearch/Redis Stack's

--- a/packages/ragleap-vectorstores/README.md
+++ b/packages/ragleap-vectorstores/README.md
@@ -46,3 +46,11 @@ from ragleap_vectorstores import LanceDBBackend
 
 backend = LanceDBBackend(uri="./lancedb_data")
 ```
+
+```python
+from ragleap_vectorstores import RedisBackend
+
+# Requires a real Redis Stack instance (or plain Redis + the RediSearch
+# module) - plain Redis alone has no vector search.
+backend = RedisBackend(redis_url="redis://localhost:6379/0")
+```

--- a/packages/ragleap-vectorstores/pyproject.toml
+++ b/packages/ragleap-vectorstores/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-vectorstores"
-version = "0.3.0"
+version = "0.3.1"
 description = "Pluggable vector backends beyond ragleap-rag core's 6 (PgVector, FAISS, Pinecone, Weaviate, Qdrant, Milvus) - additional VectorBackend implementations as optional extras, no vendor lock-in, no bloated core dependency footprint."
 readme = "README.md"
 license = "MIT"
@@ -12,7 +12,7 @@ requires-python = ">=3.10"
 authors = [
     { name = "Antony", email = "antony@ragleap.com" }
 ]
-keywords = ["rag", "vector-search", "vector-database", "ragleap"]
+keywords = ["rag", "vector-search", "vector-database", "ragleap", "chroma", "chromadb", "lancedb", "redis", "redisearch", "embeddings", "similarity-search"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",

--- a/packages/ragleap-vectorstores/src/ragleap_vectorstores/__init__.py
+++ b/packages/ragleap-vectorstores/src/ragleap_vectorstores/__init__.py
@@ -8,7 +8,7 @@ the package.
 """
 from ragleap.vectorstores.base import VectorBackend
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 __all__ = ["VectorBackend", "__version__"]
 


### PR DESCRIPTION
Docs/metadata-only patch. Fixes the README's missing RedisBackend usage example and expands pyproject.toml keywords with per-backend terms for discoverability. No code changes; all 40 tests still passing. (Superseded the original vectorstores-v0.3.1-docs-fix branch after a branch-pointer mixup — see conversation for details.)