### PR TITLE
release(ragleap-ops): bump to v0.3.0

### DIFF
--- a/packages/ragleap-ops/CHANGELOG.md
+++ b/packages/ragleap-ops/CHANGELOG.md
@@ -5,6 +5,8 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-09-06
+
 ### Added
 
 - Backup/DR: `backup-pvc.yaml`, `db-backup-cronjob.yaml` (daily `pg_dump`, no downtime), `neo4j-backup-cronjob.yaml` (scale-to-zero + `neo4j-admin dump`, since Community Edition has no online backup command).

--- a/packages/ragleap-ops/helm/ragleap-ops/Chart.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ragleap-ops
 description: Helm chart for RagLeap Core — wraps the live-tested db/app/voice/neo4j Kubernetes manifests
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.3.0
+appVersion: "0.3.0"

--- a/packages/ragleap-ops/pyproject.toml
+++ b/packages/ragleap-ops/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-ops"
-version = "0.2.0"
+version = "0.3.0"
 description = "Kubernetes deployment manifests for RagLeap Core, live-tested against a real cluster"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/ragleap-ops/src/ragleap_ops/__init__.py
+++ b/packages/ragleap-ops/src/ragleap_ops/__init__.py
@@ -10,4 +10,4 @@ manifests alongside this src/ tree, matching the release discipline of
 ragleap-rag, ragleap-graph, and ragleap-vectorstores.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"


### PR DESCRIPTION
Sealed Secrets, NetworkPolicies, Ingress+TLS, multi-env values, and Backup/DR (PR #275) all confirmed merged to main. Version bump + CHANGELOG only — no functional changes in this commit.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
