### PR TITLE
feat(ragleap-app-chart): add package scaffold (pyproject.toml, src/, …

### DIFF
--- a/packages/ragleap-app-chart/README.md
+++ b/packages/ragleap-app-chart/README.md
@@ -1,0 +1,25 @@
+# ragleap-app-chart
+
+A generic, reusable Helm chart for deploying arbitrary services to
+Kubernetes — built by RagLeap, but not specific to RagLeap.
+
+Unlike `ragleap-ops` (which is hardcoded to RagLeap Core's own 4
+services), this chart takes an arbitrary `services:` list in
+`values.yaml` and renders resources for each service via range loops.
+Point it at your own app; it doesn't know or care what RagLeap is.
+
+## Status
+
+Design only. See `GENERIC-K8S-CHART-PROPOSAL.md` at the repo root for
+the full design rationale. No templates or live testing exist yet —
+this scaffold exists so release automation can version this package
+once real chart content is built.
+
+## Design principles (from the proposal doc)
+
+- Arbitrary service list via `range` loops — not hardcoded names
+- Secure-by-default: NetworkPolicy, SecurityContext, and resource
+  limits apply automatically unless explicitly overridden
+- Proven against a non-RagLeap toy app before calling any feature done
+  — genericity is only real once demonstrated against something that
+  isn't RagLeap itself

--- a/packages/ragleap-app-chart/pyproject.toml
+++ b/packages/ragleap-app-chart/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ragleap-app-chart"
+version = "0.1.0"
+description = "Generic, reusable Helm chart for deploying arbitrary services to Kubernetes — not RagLeap-specific"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [
+    { name = "RagLeap Contributors" }
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]
+dependencies = []
+
+[project.urls]
+Homepage = "https://packages.ragleap.com/docs/ragleap-app-chart.html"
+
+[tool.hatchling.build.targets.wheel]
+packages = ["src/ragleap_app_chart"]

--- a/packages/ragleap-app-chart/src/ragleap_app_chart/__init__.py
+++ b/packages/ragleap-app-chart/src/ragleap_app_chart/__init__.py
@@ -1,0 +1,15 @@
+"""ragleap-app-chart: generic, reusable Helm chart for arbitrary services.
+
+Unlike ragleap-ops (hardcoded to RagLeap Core's own 4 services), this
+chart takes an arbitrary list of services via a `services:` values.yaml
+key and renders Deployment/Service/Ingress/NetworkPolicy resources for
+each via range loops — any developer can point this at their own app,
+not just RagLeap.
+
+It contains almost no importable Python — its purpose is to let the
+existing PyPI/git-tag release automation version and ship the helm/
+chart alongside this src/ tree, matching the release discipline of
+ragleap-ops, ragleap-rag, ragleap-graph, and ragleap-vectorstores.
+"""
+
+__version__ = "0.1.0"

--- a/packages/ragleap-app-chart/tests/test_version.py
+++ b/packages/ragleap-app-chart/tests/test_version.py
@@ -1,0 +1,5 @@
+import ragleap_app_chart
+
+
+def test_version_is_set():
+    assert ragleap_app_chart.__version__ == "0.1.0"


### PR DESCRIPTION
…tests/) so release automation can version this package

Mirrors ragleap-ops's original scaffold commit (73b85c4). Generic, reusable Helm chart for arbitrary services — design only per GENERIC-K8S-CHART-PROPOSAL.md, no chart templates yet.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
