### PR TITLE
feat(ragleap-app-chart): add generic services: schema + range-loop He…

### DIFF
--- a/packages/ragleap-app-chart/helm/ragleap-app-chart/Chart.yaml
+++ b/packages/ragleap-app-chart/helm/ragleap-app-chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ragleap-app-chart
+description: Generic, reusable Helm chart for deploying arbitrary services to Kubernetes — not RagLeap-specific
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/packages/ragleap-app-chart/helm/ragleap-app-chart/templates/_helpers.tpl
+++ b/packages/ragleap-app-chart/helm/ragleap-app-chart/templates/_helpers.tpl
@@ -1,0 +1,37 @@
+{{/*
+Resource name for a given service entry.
+*/}}
+{{- define "ragleap-app-chart.serviceName" -}}
+{{- printf "%s-%s" .Release.Name .service.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels for a given service entry.
+*/}}
+{{- define "ragleap-app-chart.serviceLabels" -}}
+app: {{ .service.name }}
+release: {{ .Release.Name }}
+managed-by: ragleap-app-chart
+{{- end -}}
+
+{{/*
+Resolve resources block: per-service override, else chart-level default.
+*/}}
+{{- define "ragleap-app-chart.resources" -}}
+{{- if .service.resources -}}
+{{ toYaml .service.resources }}
+{{- else -}}
+{{ toYaml .Values.defaultResources }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve securityContext block: per-service override, else chart-level default.
+*/}}
+{{- define "ragleap-app-chart.securityContext" -}}
+{{- if .service.securityContext -}}
+{{ toYaml .service.securityContext }}
+{{- else -}}
+{{ toYaml .Values.defaultSecurityContext }}
+{{- end -}}
+{{- end -}}

--- a/packages/ragleap-app-chart/helm/ragleap-app-chart/templates/deployment.yaml
+++ b/packages/ragleap-app-chart/helm/ragleap-app-chart/templates/deployment.yaml
@@ -1,0 +1,44 @@
+{{- range $svc := .Values.services }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ragleap-app-chart.serviceName" (dict "Release" $.Release "service" $svc) }}
+  labels:
+    {{- include "ragleap-app-chart.serviceLabels" (dict "Release" $.Release "service" $svc) | nindent 4 }}
+spec:
+  replicas: {{ $svc.replicaCount | default 1 }}
+  selector:
+    matchLabels:
+      app: {{ $svc.name }}
+      release: {{ $.Release.Name }}
+  template:
+    metadata:
+      labels:
+        {{- include "ragleap-app-chart.serviceLabels" (dict "Release" $.Release "service" $svc) | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ $svc.name }}
+          image: {{ $svc.image }}
+          ports:
+            - containerPort: {{ $svc.port }}
+          {{- if $svc.env }}
+          env:
+            {{- toYaml $svc.env | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- include "ragleap-app-chart.resources" (dict "Values" $.Values "service" $svc) | nindent 12 }}
+          securityContext:
+            {{- include "ragleap-app-chart.securityContext" (dict "Values" $.Values "service" $svc) | nindent 12 }}
+          {{- if $svc.persistent }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          {{- end }}
+      {{- if $svc.persistent }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "ragleap-app-chart.serviceName" (dict "Release" $.Release "service" $svc) }}
+      {{- end }}
+---
+{{- end }}

--- a/packages/ragleap-app-chart/helm/ragleap-app-chart/templates/ingress.yaml
+++ b/packages/ragleap-app-chart/helm/ragleap-app-chart/templates/ingress.yaml
@@ -1,0 +1,28 @@
+{{- range $svc := .Values.services }}
+{{- if $svc.expose }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "ragleap-app-chart.serviceName" (dict "Release" $.Release "service" $svc) }}
+  annotations:
+    cert-manager.io/cluster-issuer: {{ $.Values.ingress.clusterIssuer }}
+spec:
+  ingressClassName: {{ $.Values.ingress.ingressClassName }}
+  tls:
+    - hosts:
+        - {{ $svc.hostname }}
+      secretName: {{ $svc.name }}-tls
+  rules:
+    - host: {{ $svc.hostname }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "ragleap-app-chart.serviceName" (dict "Release" $.Release "service" $svc) }}
+                port:
+                  number: {{ $svc.port }}
+---
+{{- end }}
+{{- end }}

--- a/packages/ragleap-app-chart/helm/ragleap-app-chart/templates/networkpolicy.yaml
+++ b/packages/ragleap-app-chart/helm/ragleap-app-chart/templates/networkpolicy.yaml
@@ -1,0 +1,41 @@
+{{/*
+Deny-by-default: every service gets its own NetworkPolicy. Ingress is
+only allowed from services that explicitly list this one in their
+dependsOn — matches ragleap-ops's proven deny-by-default design.
+An empty dependsOn (or no other service depending on you) means a real
+deny-all policy, not "no policy" — same as the proposal doc intended.
+*/}}
+{{- range $svc := .Values.services }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "ragleap-app-chart.serviceName" (dict "Release" $.Release "service" $svc) }}-deny-by-default
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $svc.name }}
+      release: {{ $.Release.Name }}
+  policyTypes:
+    - Ingress
+  ingress:
+    {{- $allowedFrom := list }}
+    {{- range $other := $.Values.services }}
+      {{- if $other.dependsOn }}
+        {{- range $dep := $other.dependsOn }}
+          {{- if eq $dep $svc.name }}
+            {{- $allowedFrom = append $allowedFrom $other.name }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+    {{- if $allowedFrom }}
+    - from:
+        {{- range $allowedFrom }}
+        - podSelector:
+            matchLabels:
+              app: {{ . }}
+              release: {{ $.Release.Name }}
+        {{- end }}
+    {{- end }}
+---
+{{- end }}

--- a/packages/ragleap-app-chart/helm/ragleap-app-chart/templates/pvc.yaml
+++ b/packages/ragleap-app-chart/helm/ragleap-app-chart/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- range $svc := .Values.services }}
+{{- if $svc.persistent }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ragleap-app-chart.serviceName" (dict "Release" $.Release "service" $svc) }}
+  labels:
+    {{- include "ragleap-app-chart.serviceLabels" (dict "Release" $.Release "service" $svc) | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ $svc.storage | default "1Gi" }}
+---
+{{- end }}
+{{- end }}

--- a/packages/ragleap-app-chart/helm/ragleap-app-chart/templates/service.yaml
+++ b/packages/ragleap-app-chart/helm/ragleap-app-chart/templates/service.yaml
@@ -1,0 +1,16 @@
+{{- range $svc := .Values.services }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ragleap-app-chart.serviceName" (dict "Release" $.Release "service" $svc) }}
+  labels:
+    {{- include "ragleap-app-chart.serviceLabels" (dict "Release" $.Release "service" $svc) | nindent 4 }}
+spec:
+  selector:
+    app: {{ $svc.name }}
+    release: {{ $.Release.Name }}
+  ports:
+    - port: {{ $svc.port }}
+      targetPort: {{ $svc.port }}
+---
+{{- end }}

--- a/packages/ragleap-app-chart/helm/ragleap-app-chart/values.yaml
+++ b/packages/ragleap-app-chart/helm/ragleap-app-chart/values.yaml
@@ -1,0 +1,71 @@
+# ragleap-app-chart — generic services list
+#
+# Each entry under `services:` renders its own Deployment, Service, and
+# (conditionally) PVC, NetworkPolicy, and Ingress. Nothing here is
+# RagLeap-specific — point this at your own app.
+
+services:
+  - name: web
+    image: myorg/myapp:latest
+    port: 3000
+    replicaCount: 2
+    persistent: false
+
+    # No dependsOn means this service gets a deny-all NetworkPolicy by
+    # default — nothing can reach it unless you list it in another
+    # service's dependsOn. Matches ragleap-ops's deny-by-default design.
+    dependsOn:
+      - postgres
+
+    # Ingress is opt-in per service. Omit `expose` (or set false) for
+    # internal-only services.
+    expose: true
+    hostname: myapp.example.com
+
+    env:
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: app-secrets
+            key: db-url
+
+    # Optional — if omitted, chart-level defaults below apply.
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+  - name: postgres
+    image: postgres:16
+    port: 5432
+    replicaCount: 1          # stateful services should not be scaled via this field
+    persistent: true
+    storage: 10Gi
+    dependsOn: []             # no outbound deps — still gets its own deny-all ingress policy
+    expose: false
+
+# Applied to any service that omits its own `resources` block.
+defaultResources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 250m
+    memory: 256Mi
+
+# SecurityContext defaults applied to every container unless a service
+# sets its own `securityContext` override. Secure-by-default per the
+# proposal doc's design principles.
+defaultSecurityContext:
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false   # many images need write access; override per-service to true where possible
+
+# cert-manager ClusterIssuer name used for any service with expose: true.
+# Same pattern as ragleap-ops's Ingress+TLS.
+ingress:
+  clusterIssuer: letsencrypt-prod
+  ingressClassName: nginx


### PR DESCRIPTION
…lm templates

Deployment, Service, PVC, NetworkPolicy (deny-by-default, ingress derived from dependsOn), and Ingress, all templated via range loops over an arbitrary services: list — proven against two structurally different example services (stateless+exposed 'web', stateful+internal 'postgres') via helm lint and helm template.

Verified: helm lint clean; rendered output confirmed correct for per-service resource/securityContext override vs default fallback, persistent-vs-non-persistent volume mounting, dependsOn-derived NetworkPolicy ingress rules, and expose-gated Ingress generation.

NOT YET verified: no live kind cluster deploy performed this session -- held back due to sustained ~80% CPU steal time on the VPS (hypervisor-level contention, not fixable from inside the VM). Chart correctness proven at the template-rendering level only. Live-cluster verification remains the next real step before this can be called genuinely done, matching the same standard every other feature in this repo has been held to.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
