### PR TITLE
feat(ragleap-observability): add package scaffold (pyproject.toml, sr…

### DIFF
--- a/packages/ragleap-observability/README.md
+++ b/packages/ragleap-observability/README.md
@@ -1,0 +1,32 @@
+# ragleap-observability
+
+Metrics, logs, and alerting for RagLeap Core -- Prometheus, Grafana,
+Loki, and AlertManager, wired against the real db/app/voice/neo4j
+services.
+
+## Status
+
+Design/scaffold only. No Helm chart content yet. This is the
+prerequisite for AIOps per the project's own DevOps maturity roadmap --
+building anomaly detection before a metrics pipeline exists would be
+"a dashboard for data that doesn't exist."
+
+## Planned build order
+
+1. Prometheus + exporters (postgres_exporter for db; verify neo4j's
+   Prometheus endpoint exists in Community Edition before assuming --
+   same discipline as the backup-command check in ragleap-ops)
+2. Grafana, provisioned dashboards-as-code, verified against real
+   flowing data
+3. Loki + log shipping (can parallel step 2)
+4. AlertManager -- deliberately last; alerting on data that doesn't
+   exist yet is pointless
+5. SLO/SLI dashboards, only after real data has accumulated for days,
+   not minutes
+
+## Design principles
+
+- RagLeap-specific scoping, same honest choice `ragleap-ops` made for
+  itself -- not a generic monitoring tool
+- Every claim live-verified against a real cluster or explicitly
+  labeled unverified, same discipline as every other package here

--- a/packages/ragleap-observability/pyproject.toml
+++ b/packages/ragleap-observability/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ragleap-observability"
+version = "0.1.0"
+description = "Prometheus/Grafana/Loki/AlertManager observability stack for RagLeap Core, live-tested against a real cluster"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [
+    { name = "RagLeap Contributors" }
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]
+dependencies = []
+
+[project.urls]
+Homepage = "https://packages.ragleap.com/docs/ragleap-observability.html"
+
+[tool.hatchling.build.targets.wheel]
+packages = ["src/ragleap_observability"]

--- a/packages/ragleap-observability/src/ragleap_observability/__init__.py
+++ b/packages/ragleap-observability/src/ragleap_observability/__init__.py
@@ -1,0 +1,19 @@
+"""ragleap-observability: metrics, logs, and alerting for RagLeap Core.
+
+This package ships Helm chart configuration wiring Prometheus (with
+exporters for db/neo4j), Grafana (provisioned dashboards-as-code),
+Loki (log aggregation), and AlertManager (routed to Slack/PagerDuty)
+against RagLeap Core's own 4 services -- same RagLeap-specific scoping
+choice ragleap-ops made for itself, not a generic tool.
+
+This is the prerequisite for AIOps per the DevOps maturity roadmap:
+anomaly detection and auto-remediation need a real metrics pipeline to
+operate on, which doesn't exist until this package ships.
+
+It contains almost no importable Python -- its purpose is to let the
+existing PyPI/git-tag release automation version and ship the helm/
+chart alongside this src/ tree, matching the release discipline of
+ragleap-ops, ragleap-rag, ragleap-graph, and ragleap-vectorstores.
+"""
+
+__version__ = "0.1.0"

--- a/packages/ragleap-observability/tests/test_version.py
+++ b/packages/ragleap-observability/tests/test_version.py
@@ -1,0 +1,5 @@
+import ragleap_observability
+
+
+def test_version_is_set():
+    assert ragleap_observability.__version__ == "0.1.0"


### PR DESCRIPTION
…c/, tests/) so release automation can version this package

Mirrors ragleap-ops's original scaffold commit (73b85c4). Prerequisite for AIOps per the DevOps maturity roadmap. No Helm chart content yet.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
