### PR TITLE
ci(release): add publish job for ragleap-app-chart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
       - 'ragleap-graph-v*'
       - 'ragleap-vectorstores-v*'
       - 'ragleap-ops-v*'
+      - 'ragleap-app-chart-v*'
   workflow_dispatch:
     inputs:
       package:
@@ -18,6 +19,7 @@ on:
           - ragleap-graph
           - ragleap-vectorstores
           - ragleap-ops
+          - ragleap-app-chart
       target:
         description: 'Publish target'
         required: true
@@ -169,4 +171,40 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/ragleap-ops/dist/
+          skip-existing: true
+
+  publish-ragleap-app-chart:
+    if: |
+      startsWith(github.ref, 'refs/tags/ragleap-app-chart-v') ||
+      (github.event_name == 'workflow_dispatch' && inputs.package == 'ragleap-app-chart')
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.event_name == 'workflow_dispatch' && inputs.target || 'pypi' }}
+    permissions:
+      id-token: write
+    defaults:
+      run:
+        working-directory: packages/ragleap-app-chart
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+      - name: Install build tooling
+        run: pip install build
+      - name: Build
+        run: |
+          rm -rf dist/
+          python -m build
+      - name: Publish to TestPyPI
+        if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/ragleap-app-chart/dist/
+          repository-url: https://test.pypi.org/legacy/
+      - name: Publish to PyPI
+        if: github.event_name != 'workflow_dispatch' || inputs.target == 'pypi'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/ragleap-app-chart/dist/
           skip-existing: true

--- a/packages/ragleap-observability/README.md
+++ b/packages/ragleap-observability/README.md
@@ -1,0 +1,32 @@
+# ragleap-observability
+
+Metrics, logs, and alerting for RagLeap Core -- Prometheus, Grafana,
+Loki, and AlertManager, wired against the real db/app/voice/neo4j
+services.
+
+## Status
+
+Design/scaffold only. No Helm chart content yet. This is the
+prerequisite for AIOps per the project's own DevOps maturity roadmap --
+building anomaly detection before a metrics pipeline exists would be
+"a dashboard for data that doesn't exist."
+
+## Planned build order
+
+1. Prometheus + exporters (postgres_exporter for db; verify neo4j's
+   Prometheus endpoint exists in Community Edition before assuming --
+   same discipline as the backup-command check in ragleap-ops)
+2. Grafana, provisioned dashboards-as-code, verified against real
+   flowing data
+3. Loki + log shipping (can parallel step 2)
+4. AlertManager -- deliberately last; alerting on data that doesn't
+   exist yet is pointless
+5. SLO/SLI dashboards, only after real data has accumulated for days,
+   not minutes
+
+## Design principles
+
+- RagLeap-specific scoping, same honest choice `ragleap-ops` made for
+  itself -- not a generic monitoring tool
+- Every claim live-verified against a real cluster or explicitly
+  labeled unverified, same discipline as every other package here

--- a/packages/ragleap-observability/pyproject.toml
+++ b/packages/ragleap-observability/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ragleap-observability"
+version = "0.1.0"
+description = "Prometheus/Grafana/Loki/AlertManager observability stack for RagLeap Core, live-tested against a real cluster"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [
+    { name = "RagLeap Contributors" }
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]
+dependencies = []
+
+[project.urls]
+Homepage = "https://packages.ragleap.com/docs/ragleap-observability.html"
+
+[tool.hatchling.build.targets.wheel]
+packages = ["src/ragleap_observability"]

--- a/packages/ragleap-observability/src/ragleap_observability/__init__.py
+++ b/packages/ragleap-observability/src/ragleap_observability/__init__.py
@@ -1,0 +1,19 @@
+"""ragleap-observability: metrics, logs, and alerting for RagLeap Core.
+
+This package ships Helm chart configuration wiring Prometheus (with
+exporters for db/neo4j), Grafana (provisioned dashboards-as-code),
+Loki (log aggregation), and AlertManager (routed to Slack/PagerDuty)
+against RagLeap Core's own 4 services -- same RagLeap-specific scoping
+choice ragleap-ops made for itself, not a generic tool.
+
+This is the prerequisite for AIOps per the DevOps maturity roadmap:
+anomaly detection and auto-remediation need a real metrics pipeline to
+operate on, which doesn't exist until this package ships.
+
+It contains almost no importable Python -- its purpose is to let the
+existing PyPI/git-tag release automation version and ship the helm/
+chart alongside this src/ tree, matching the release discipline of
+ragleap-ops, ragleap-rag, ragleap-graph, and ragleap-vectorstores.
+"""
+
+__version__ = "0.1.0"

--- a/packages/ragleap-observability/tests/test_version.py
+++ b/packages/ragleap-observability/tests/test_version.py
@@ -1,0 +1,5 @@
+import ragleap_observability
+
+
+def test_version_is_set():
+    assert ragleap_observability.__version__ == "0.1.0"


### PR DESCRIPTION
Three additive changes, no existing lines modified: adds ragleap-app-chart-v* to the tag trigger list, adds ragleap-app-chart to the workflow_dispatch package choices, and adds a publish-ragleap-app-chart job mirroring publish-ragleap-ops exactly.