### PR TITLE
feat(ragleap-observability): add Prometheus + postgres_exporter

### DIFF
--- a/packages/ragleap-observability/README.md
+++ b/packages/ragleap-observability/README.md
@@ -30,3 +30,18 @@ building anomaly detection before a metrics pipeline exists would be
   itself -- not a generic monitoring tool
 - Every claim live-verified against a real cluster or explicitly
   labeled unverified, same discipline as every other package here
+
+## Known open items
+
+- **Neo4j Prometheus support is unverified and conflicting in the wild.**
+  Neo4j's own KB and a working xk6-neo4j example show
+  `metrics.prometheus.enabled=true` configured successfully against
+  Neo4j Community 4.4.x. A separate monitoring vendor's own
+  compatibility notes claim Community Edition is unsupported for their
+  specific collector. `neo4jExporter.enabled` defaults to `false` in
+  `values.yaml` until this is live-verified against the real
+  `neo4j:5-community` image in this repo's own `kind` cluster.
+- `ragleap-db`'s schema does not yet have a read-only monitoring role
+  for `postgres_exporter` to connect as — needs adding in `ragleap-ops`
+  first; this package assumes it exists via
+  `ragleap-db-exporter-secret`.

--- a/packages/ragleap-observability/helm/ragleap-observability/Chart.yaml
+++ b/packages/ragleap-observability/helm/ragleap-observability/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ragleap-observability
+description: Prometheus/Grafana/Loki/AlertManager observability stack for RagLeap Core
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/packages/ragleap-observability/helm/ragleap-observability/templates/postgres-exporter-deployment.yaml
+++ b/packages/ragleap-observability/helm/ragleap-observability/templates/postgres-exporter-deployment.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.postgresExporter.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ragleap-postgres-exporter
+  labels:
+    app: ragleap-postgres-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ragleap-postgres-exporter
+  template:
+    metadata:
+      labels:
+        app: ragleap-postgres-exporter
+    spec:
+      containers:
+        - name: postgres-exporter
+          image: {{ .Values.postgresExporter.image }}
+          ports:
+            - containerPort: {{ .Values.postgresExporter.port }}
+          env:
+            - name: DATA_SOURCE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgresExporter.datasourceSecretName }}
+                  key: connection-string
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+{{- end }}

--- a/packages/ragleap-observability/helm/ragleap-observability/templates/postgres-exporter-service.yaml
+++ b/packages/ragleap-observability/helm/ragleap-observability/templates/postgres-exporter-service.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.postgresExporter.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: ragleap-postgres-exporter
+  labels:
+    app: ragleap-postgres-exporter
+spec:
+  selector:
+    app: ragleap-postgres-exporter
+  ports:
+    - port: {{ .Values.postgresExporter.port }}
+      targetPort: {{ .Values.postgresExporter.port }}
+{{- end }}

--- a/packages/ragleap-observability/helm/ragleap-observability/templates/prometheus-configmap.yaml
+++ b/packages/ragleap-observability/helm/ragleap-observability/templates/prometheus-configmap.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.prometheus.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ragleap-prometheus-config
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: {{ .Values.prometheus.scrapeInterval }}
+    scrape_configs:
+      - job_name: 'ragleap-postgres'
+        static_configs:
+          - targets: ['ragleap-postgres-exporter:{{ .Values.postgresExporter.port }}']
+      {{- if .Values.neo4jExporter.enabled }}
+      - job_name: 'ragleap-neo4j'
+        static_configs:
+          - targets: ['ragleap-neo4j:{{ .Values.neo4jExporter.port }}']
+      {{- end }}
+{{- end }}

--- a/packages/ragleap-observability/helm/ragleap-observability/values.yaml
+++ b/packages/ragleap-observability/helm/ragleap-observability/values.yaml
@@ -1,0 +1,32 @@
+# ragleap-observability — Prometheus + exporters (step 1 of the planned build order)
+#
+# Grafana, Loki, and AlertManager are NOT yet configured here — per the
+# README's build order, alerting/dashboards come after real metrics
+# are proven flowing, not before.
+
+postgresExporter:
+  enabled: true
+  image: quay.io/prometheuscommunity/postgres-exporter:v0.15.0
+  # Connects to ragleap-db using a read-only monitoring role — NOT the
+  # app's own credentials. This role does not exist yet in ragleap-ops's
+  # db schema and needs to be created there first (real dependency,
+  # not yet done — see README "Known open items").
+  datasourceSecretName: ragleap-db-exporter-secret
+  port: 9187
+
+neo4jExporter:
+  # UNVERIFIED — see README "Known open items". Neo4j's own docs and a
+  # working xk6-neo4j example show `metrics.prometheus.enabled=true`
+  # configured successfully against Neo4j Community 4.4.x. A separate
+  # third-party monitoring vendor's compatibility notes claim Community
+  # Edition is unsupported for their specific collector. These sources
+  # conflict. Do not enable this until live-verified against the real
+  # neo4j:5-community image running in this repo's own kind cluster.
+  enabled: false
+  port: 2004
+
+prometheus:
+  enabled: true
+  image: prom/prometheus:v2.55.1
+  retention: 15d
+  scrapeInterval: 30s


### PR DESCRIPTION
Step 1 of the planned build order. helm lint/helm template verified. neo4jExporter stays disabled — Neo4j Community Edition Prometheus support is unverified/conflicting in sources, flagged explicitly in README. No live kind cluster test yet (VPS CPU steal constraint).