### PR TITLE
feat(ragleap-ops): add SecurityContext + zero-permission ServiceAccounts to db/app/voice/neo4j

### DIFF
--- a/packages/ragleap-ops/k8s/app-deployment.yaml
+++ b/packages/ragleap-ops/k8s/app-deployment.yaml
@@ -14,15 +14,27 @@ spec:
       labels:
         app: ragleap-app
     spec:
+      serviceAccountName: ragleap-app
+      automountServiceAccountToken: false
       imagePullSecrets:
         - name: ghcr-pull-secret
       initContainers:
         - name: wait-for-db
           image: postgres:16-alpine
           command: ["sh", "-c", "until pg_isready -h ragleap-db -p 5432 -U ragleap; do sleep 2; done"]
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
       containers:
         - name: app
           image: ghcr.io/antonyrag/ragleap-app:latest
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            # readOnlyRootFilesystem intentionally NOT enabled yet --
+            # this container may write outside its declared volume
+            # mounts (e.g. /tmp, /var/run) and this has not been
+            # live-tested. Enabling it blind risks breaking startup.
           ports:
             - containerPort: 8000
           envFrom:

--- a/packages/ragleap-ops/k8s/db-deployment.yaml
+++ b/packages/ragleap-ops/k8s/db-deployment.yaml
@@ -16,9 +16,18 @@ spec:
       labels:
         app: ragleap-db
     spec:
+      serviceAccountName: ragleap-db
+      automountServiceAccountToken: false
       containers:
         - name: db
           image: pgvector/pgvector:pg16
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            # readOnlyRootFilesystem intentionally NOT enabled yet --
+            # this container may write outside its declared volume
+            # mounts (e.g. /tmp, /var/run) and this has not been
+            # live-tested. Enabling it blind risks breaking startup.
           envFrom:
             - secretRef:
                 name: ragleap-db-secret

--- a/packages/ragleap-ops/k8s/neo4j-deployment.yaml
+++ b/packages/ragleap-ops/k8s/neo4j-deployment.yaml
@@ -16,9 +16,18 @@ spec:
       labels:
         app: ragleap-neo4j
     spec:
+      serviceAccountName: ragleap-neo4j
+      automountServiceAccountToken: false
       containers:
         - name: neo4j
           image: neo4j:5-community
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            # readOnlyRootFilesystem intentionally NOT enabled yet --
+            # this container may write outside its declared volume
+            # mounts (e.g. /tmp, /var/run) and this has not been
+            # live-tested. Enabling it blind risks breaking startup.
           envFrom:
             - secretRef:
                 name: ragleap-neo4j-secret

--- a/packages/ragleap-ops/k8s/serviceaccounts.yaml
+++ b/packages/ragleap-ops/k8s/serviceaccounts.yaml
@@ -1,0 +1,25 @@
+# Dedicated, zero-permission ServiceAccounts for each RagLeap Core
+# service. None of db/app/voice/neo4j need Kubernetes API access, so
+# the correct least-privilege posture is no Role/RoleBinding at all --
+# automountServiceAccountToken: false on each Deployment (see
+# app-deployment.yaml etc.) means no token is even mounted, making API
+# access structurally impossible rather than merely discouraged.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ragleap-app
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ragleap-voice
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ragleap-db
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ragleap-neo4j

--- a/packages/ragleap-ops/k8s/voice-deployment.yaml
+++ b/packages/ragleap-ops/k8s/voice-deployment.yaml
@@ -14,15 +14,27 @@ spec:
       labels:
         app: ragleap-voice
     spec:
+      serviceAccountName: ragleap-voice
+      automountServiceAccountToken: false
       imagePullSecrets:
         - name: ghcr-pull-secret
       initContainers:
         - name: wait-for-db
           image: postgres:16-alpine
           command: ["sh", "-c", "until pg_isready -h ragleap-db -p 5432 -U ragleap; do sleep 2; done"]
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
       containers:
         - name: voice
           image: ghcr.io/antonyrag/ragleap-app:latest
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            # readOnlyRootFilesystem intentionally NOT enabled yet --
+            # this container may write outside its declared volume
+            # mounts (e.g. /tmp, /var/run) and this has not been
+            # live-tested. Enabling it blind risks breaking startup.
           command: ["python3", "-m", "channels.voice.server"]
           ports:
             - containerPort: 8765


### PR DESCRIPTION
Closes part of the enterprise security hardening gap. Adds runAsNonRoot/allowPrivilegeEscalation:false to all 4 main containers + both init containers, and dedicated per-service ServiceAccounts with automountServiceAccountToken:false (no API access needed, so no token mounted at all). readOnlyRootFilesystem intentionally left disabled pending live testing. YAML-validated via yaml.safe_load_all; no live cluster apply yet (VPS CPU steal constraint).