### PR TITLE
vectorstores: v0.3.2 - README table fix + MODULE LIST parsing regression fix

### DIFF
--- a/packages/ragleap-vectorstores/CHANGELOG.md
+++ b/packages/ragleap-vectorstores/CHANGELOG.md
@@ -5,6 +5,27 @@ loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-09-06
+### Fixed
+- README's "Available backends" table was missing a Redis row entirely
+  (only Chroma and LanceDB were listed) - this table is separate from
+  the Usage section's code examples, which were already fixed in
+  v0.3.1. Caught by checking the live rendered PyPI page, same as the
+  v0.2.1 and v0.3.1 doc-lag issues. Added the Redis row with the same
+  level of detail as the other two (extra name, server requirement,
+  metadata filtering limitation, sparse-search status).
+- REAL REGRESSION, live-verified: init_schema()'s MODULE LIST parsing
+  assumed a single fixed response shape (dict with bytes keys), but
+  running the full test suite in a different environment reproduced
+  the older flat-list shape again - same exact client construction,
+  same server instance, same redis-py version, different shape on
+  different occasions. Almost certainly RESP2/RESP3 protocol
+  negotiation happening beneath redis-py rather than anything this
+  code controls. Parsing is now defensive against both observed
+  shapes rather than assuming either one generalizes; verified across
+  10 consecutive clean test runs plus two full-suite runs (40/40 both
+  times) before shipping this fix.
+
 ## [0.3.1] - 2026-09-05
 ### Fixed
 - README's Usage section was missing a RedisBackend example (only

--- a/packages/ragleap-vectorstores/README.md
+++ b/packages/ragleap-vectorstores/README.md
@@ -13,6 +13,7 @@ over time. See the
 |---|---|---|
 | Chroma | `chroma` | Embedded/local via chromadb's PersistentClient - no server required. No native sparse/keyword search (`supports_sparse()` is `False`); hybrid search falls back to dense-only. |
 | LanceDB | `lancedb` | Embedded/local via a directory path - no server required. Real upsert semantics via `merge_insert()`. No native sparse/keyword search enabled yet (`supports_sparse()` is `False`); hybrid search falls back to dense-only. |
+| Redis | `redis` | Requires a real running server - Redis Stack, or plain Redis with the RediSearch module loaded (no embedded/local mode). `init_schema()` checks for the module and raises a clear error if it's missing. Metadata filtering only supports `document_id` (RediSearch requires predeclared schema fields). No native sparse/keyword search enabled yet (`supports_sparse()` is `False`); hybrid search falls back to dense-only. |
 
 ## Design
 

--- a/packages/ragleap-vectorstores/pyproject.toml
+++ b/packages/ragleap-vectorstores/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-vectorstores"
-version = "0.3.1"
+version = "0.3.2"
 description = "Pluggable vector backends beyond ragleap-rag core's 6 (PgVector, FAISS, Pinecone, Weaviate, Qdrant, Milvus) - additional VectorBackend implementations as optional extras, no vendor lock-in, no bloated core dependency footprint."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-vectorstores/src/ragleap_vectorstores/__init__.py
+++ b/packages/ragleap-vectorstores/src/ragleap_vectorstores/__init__.py
@@ -8,7 +8,7 @@ the package.
 """
 from ragleap.vectorstores.base import VectorBackend
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 __all__ = ["VectorBackend", "__version__"]
 

--- a/packages/ragleap-vectorstores/src/ragleap_vectorstores/redis_backend.py
+++ b/packages/ragleap-vectorstores/src/ragleap_vectorstores/redis_backend.py
@@ -141,17 +141,29 @@ class RedisBackend(VectorBackend):
         self._dimensions = dimensions
         self._client = redis.from_url(self.redis_url, decode_responses=False)
 
-        # MODULE LIST returns a list of dicts with bytes keys, e.g.
-        # {b"name": b"search", b"ver": 21020, ...} - live-verified via the
-        # exact client construction used here (redis.from_url()). An
-        # earlier check using a bare redis.Redis() object returned a
-        # different (flat list) shape, which is why this is verified
-        # against the real call path this method actually uses, not
-        # assumed to generalize across client constructions.
+        # MODULE LIST's response shape is NOT stable - live-verified twice
+        # against this exact client construction (redis.from_url()) on the
+        # same server instance, with the same redis-py version, returning
+        # two different shapes on different occasions:
+        #   1) a list of dicts with bytes keys: {b"name": b"search", ...}
+        #   2) a list of flat key-value lists: [b"name", b"search", ...]
+        # This is almost certainly RESP2/RESP3 protocol negotiation
+        # happening beneath redis-py (map replies parse as dicts under
+        # RESP3, as flat arrays under RESP2) rather than anything this
+        # code controls - so both shapes are handled explicitly instead
+        # of assuming either one generalizes.
         modules = set()
         for m in self._client.execute_command("MODULE", "LIST"):
-            name = m[b"name"]
-            modules.add(name.decode() if isinstance(name, bytes) else name)
+            if isinstance(m, dict):
+                name = m.get(b"name", m.get("name"))
+            else:
+                name = None
+                for i, field in enumerate(m):
+                    if field in (b"name", "name"):
+                        name = m[i + 1]
+                        break
+            if name is not None:
+                modules.add(name.decode() if isinstance(name, bytes) else name)
         if "search" not in modules:
             raise RuntimeError(
                 f"RedisBackend: no 'search' module loaded on {self.redis_url}. "


### PR DESCRIPTION
Two fixes:

1. **Docs**: README's 'Available backends' table was missing a Redis row entirely (only Chroma/LanceDB were listed).
2. **Real regression fix**: `init_schema()`'s `MODULE LIST` parsing assumed a single fixed response shape. Running the full test suite in a different environment reproduced the older shape again — same client construction, same server, same redis-py version, different shape on different occasions (almost certainly RESP2/RESP3 protocol negotiation beneath redis-py). Parsing now handles both shapes defensively.

Verified: 10 consecutive clean Redis test runs + 2 full-suite runs (40/40 both times) before merging.