### PR TITLE
feat(ragleap-ops): add dedicated namespace + PodSecurityStandards (baseline)

### DIFF
--- a/packages/ragleap-ops/k8s/app-deployment.yaml
+++ b/packages/ragleap-ops/k8s/app-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ragleap-app
+  namespace: ragleap-core
   labels:
     app: ragleap-app
 spec:

--- a/packages/ragleap-ops/k8s/app-service.yaml
+++ b/packages/ragleap-ops/k8s/app-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ragleap-app
+  namespace: ragleap-core
 spec:
   selector:
     app: ragleap-app

--- a/packages/ragleap-ops/k8s/backup-pvc.yaml
+++ b/packages/ragleap-ops/k8s/backup-pvc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: ragleap-backup-data
+  namespace: ragleap-core
 spec:
   accessModes: ["ReadWriteOnce"]
   resources:

--- a/packages/ragleap-ops/k8s/db-backup-cronjob.yaml
+++ b/packages/ragleap-ops/k8s/db-backup-cronjob.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: ragleap-db-backup
+  namespace: ragleap-core
 spec:
   schedule: "0 3 * * *"   # daily at 03:00 — adjust to your real retention/RPO needs
   jobTemplate:

--- a/packages/ragleap-ops/k8s/db-deployment.yaml
+++ b/packages/ragleap-ops/k8s/db-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ragleap-db
+  namespace: ragleap-core
   labels:
     app: ragleap-db
 spec:

--- a/packages/ragleap-ops/k8s/db-networkpolicy.yaml
+++ b/packages/ragleap-ops/k8s/db-networkpolicy.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: db-allow-app-and-voice
+  namespace: ragleap-core
 spec:
   podSelector:
     matchLabels:

--- a/packages/ragleap-ops/k8s/db-pvc.yaml
+++ b/packages/ragleap-ops/k8s/db-pvc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: ragleap-db-data
+  namespace: ragleap-core
 spec:
   accessModes: ["ReadWriteOnce"]
   resources:

--- a/packages/ragleap-ops/k8s/db-schema-configmap.yaml
+++ b/packages/ragleap-ops/k8s/db-schema-configmap.yaml
@@ -233,3 +233,4 @@ data:
 kind: ConfigMap
 metadata:
   name: ragleap-db-schema
+  namespace: ragleap-core

--- a/packages/ragleap-ops/k8s/db-secret.yaml
+++ b/packages/ragleap-ops/k8s/db-secret.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: ragleap-db-secret
+  namespace: ragleap-core
 type: Opaque
 stringData:
   POSTGRES_USER: ragleap

--- a/packages/ragleap-ops/k8s/db-service.yaml
+++ b/packages/ragleap-ops/k8s/db-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ragleap-db
+  namespace: ragleap-core
 spec:
   selector:
     app: ragleap-db

--- a/packages/ragleap-ops/k8s/namespace.yaml
+++ b/packages/ragleap-ops/k8s/namespace.yaml
@@ -1,0 +1,22 @@
+# Dedicated namespace for RagLeap Core, isolating it from default and
+# enabling PodSecurityStandards enforcement without affecting anything
+# else that might share a cluster.
+#
+# Using 'baseline', not 'restricted', deliberately. 'restricted'
+# requires seccompProfile: {type: RuntimeDefault} on every container,
+# which was not added in the prior SecurityContext hardening pass.
+# Enabling 'restricted' without that -- and without live-testing --
+# risks outright admission-controller rejection of every pod, not a
+# cosmetic warning. 'baseline' still meaningfully blocks privileged
+# containers, host namespace access, and dangerous capabilities.
+# Escalating to 'restricted' is a real tracked follow-up once seccomp
+# profiles are added AND live-verified against a real cluster.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ragleap-core
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/warn-version: latest

--- a/packages/ragleap-ops/k8s/neo4j-backup-cronjob.yaml
+++ b/packages/ragleap-ops/k8s/neo4j-backup-cronjob.yaml
@@ -2,11 +2,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ragleap-neo4j-backup
+  namespace: ragleap-core
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: ragleap-neo4j-backup-role
+  namespace: ragleap-core
 rules:
   - apiGroups: ["apps"]
     resources: ["deployments", "deployments/scale"]
@@ -20,6 +22,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: ragleap-neo4j-backup-binding
+  namespace: ragleap-core
 subjects:
   - kind: ServiceAccount
     name: ragleap-neo4j-backup
@@ -32,6 +35,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: ragleap-neo4j-backup
+  namespace: ragleap-core
 spec:
   schedule: "0 3 * * *"   # matches db backup schedule; adjust to your real RPO needs
   jobTemplate:

--- a/packages/ragleap-ops/k8s/neo4j-deployment.yaml
+++ b/packages/ragleap-ops/k8s/neo4j-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ragleap-neo4j
+  namespace: ragleap-core
   labels:
     app: ragleap-neo4j
 spec:

--- a/packages/ragleap-ops/k8s/neo4j-networkpolicy.yaml
+++ b/packages/ragleap-ops/k8s/neo4j-networkpolicy.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: neo4j-allow-app-only
+  namespace: ragleap-core
 spec:
   podSelector:
     matchLabels:

--- a/packages/ragleap-ops/k8s/neo4j-pvc.yaml
+++ b/packages/ragleap-ops/k8s/neo4j-pvc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: ragleap-neo4j-data
+  namespace: ragleap-core
 spec:
   accessModes: ["ReadWriteOnce"]
   resources:

--- a/packages/ragleap-ops/k8s/neo4j-secret.yaml
+++ b/packages/ragleap-ops/k8s/neo4j-secret.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: ragleap-neo4j-secret
+  namespace: ragleap-core
 type: Opaque
 stringData:
   NEO4J_AUTH: neo4j/ragleapgraph

--- a/packages/ragleap-ops/k8s/neo4j-service.yaml
+++ b/packages/ragleap-ops/k8s/neo4j-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ragleap-neo4j
+  namespace: ragleap-core
 spec:
   selector:
     app: ragleap-neo4j

--- a/packages/ragleap-ops/k8s/serviceaccounts.yaml
+++ b/packages/ragleap-ops/k8s/serviceaccounts.yaml
@@ -8,18 +8,22 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ragleap-app
+  namespace: ragleap-core
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ragleap-voice
+  namespace: ragleap-core
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ragleap-db
+  namespace: ragleap-core
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ragleap-neo4j
+  namespace: ragleap-core

--- a/packages/ragleap-ops/k8s/voice-deployment.yaml
+++ b/packages/ragleap-ops/k8s/voice-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ragleap-voice
+  namespace: ragleap-core
   labels:
     app: ragleap-voice
 spec:

--- a/packages/ragleap-ops/k8s/voice-service.yaml
+++ b/packages/ragleap-ops/k8s/voice-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ragleap-voice
+  namespace: ragleap-core
 spec:
   selector:
     app: ragleap-voice


### PR DESCRIPTION
Adds ragleap-core namespace with baseline PSS enforcement (not restricted -- would need seccomp profiles first, unverified without a live cluster). Namespaces all 26 resources across 20 files. YAML-validated, spot-checked in full on the most complex files. No live cluster apply yet (VPS CPU steal constraint).