### PR TITLE
fix(ragleap-ops): fix SecurityContext breaking real db/neo4j startup,…

### DIFF
--- a/packages/ragleap-ops/CHANGELOG.md
+++ b/packages/ragleap-ops/CHANGELOG.md
@@ -5,6 +5,25 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- SecurityContext hardening (added in a prior commit) broke real startup for `db` and `neo4j` on live cluster testing -- caught only now via an actual kind deploy, not template validation. Three real, layered issues found and fixed:
+  1. `runAsNonRoot: true` alone rejected both images outright (`pgvector/pgvector:pg16` and `neo4j:5-community` both default to a root user before their entrypoints drop privileges internally) -- fixed by adding explicit `runAsUser` set to each image's real non-root UID (999 for postgres, 7474 for neo4j, confirmed via `docker run --rm <image> id <user>`, not assumed).
+  2. Even with the correct UID, `initdb`/neo4j startup failed with `chmod: Operation not permitted` against the PVC-backed data directory, which K8s creates owned by root by default.
+  3. Pod-level `fsGroup` alone did not resolve this -- it sets group ownership, not directory owner, and `chmod` on the directory itself requires ownership. Fixed with a dedicated `fix-permissions` init container (root, `chown -R <uid>:<uid> <mount>`, busybox:1.36) that runs once before the main container starts as its restricted UID.
+
+### Verified
+
+- Full backup/DR restore drill performed end-to-end on a real local kind cluster (Docker Desktop on Windows, not the constrained VPS used earlier -- VPS steal time made even minimal cluster boot fail outright, confirmed via a separate failed kubeadm init attempt). Real marker row inserted, `pg_dump` taken and byte-verified to contain it, table dropped with CASCADE, `SELECT` confirmed genuine data loss, restore performed from the dump file, `SELECT` confirmed the exact same row (same UUID, same microsecond timestamp) recovered. RTO for this single-table drill: under 2 minutes.
+- `db` and `neo4j` deployments confirmed to actually reach `1/1 Running` with the fixed SecurityContext + fix-permissions init container pattern, `RESTARTS: 0` sustained.
+
+### Known limitations
+
+- Restoring a full-schema `pg_dump` into an already-initialized (non-empty schema) database produces expected `already exists`/`multiple primary keys` errors for every CREATE statement -- harmless (the actual data COPY statements still succeed), but noisy. A genuinely clean restore drill should target a freshly-provisioned empty database, not layer onto an existing schema the way this test did. Real operational finding, not previously documented.
+- This restore drill covered Postgres only. The neo4j scale-to-zero + `neo4j-admin dump`/`load` restore path (built earlier this session) has NOT yet been live-restore-tested -- only the dump side was previously verified. Real remaining gap.
+- Both fixes (runAsUser, fix-permissions init container) were verified in this session but not yet reflected in the Helm chart's equivalent templates (`helm/ragleap-ops/templates/`) -- only the raw `k8s/` manifests were fixed and tested here. The Helm chart needs the same fix, tracked as a follow-up (same class of bug as the earlier neo4j probe-drift finding between raw manifests and Helm templates).
+
+
 ## [0.3.0] - 2026-09-06
 
 ### Added

--- a/packages/ragleap-ops/k8s/db-deployment.yaml
+++ b/packages/ragleap-ops/k8s/db-deployment.yaml
@@ -17,13 +17,26 @@ spec:
       labels:
         app: ragleap-db
     spec:
+      securityContext:
+        fsGroup: 999
       serviceAccountName: ragleap-db
       automountServiceAccountToken: false
+      initContainers:
+        - name: fix-permissions
+          image: busybox:1.36
+          command: ["sh", "-c", "chown -R 999:999 /var/lib/postgresql/data"]
+          securityContext:
+            runAsUser: 0
+            runAsNonRoot: false
+          volumeMounts:
+            - name: db-data
+              mountPath: /var/lib/postgresql/data
       containers:
         - name: db
           image: pgvector/pgvector:pg16
           securityContext:
             runAsNonRoot: true
+            runAsUser: 999
             allowPrivilegeEscalation: false
             # readOnlyRootFilesystem intentionally NOT enabled yet --
             # this container may write outside its declared volume

--- a/packages/ragleap-ops/k8s/neo4j-deployment.yaml
+++ b/packages/ragleap-ops/k8s/neo4j-deployment.yaml
@@ -17,13 +17,26 @@ spec:
       labels:
         app: ragleap-neo4j
     spec:
+      securityContext:
+        fsGroup: 7474
       serviceAccountName: ragleap-neo4j
       automountServiceAccountToken: false
+      initContainers:
+        - name: fix-permissions
+          image: busybox:1.36
+          command: ["sh", "-c", "chown -R 7474:7474 /data"]
+          securityContext:
+            runAsUser: 0
+            runAsNonRoot: false
+          volumeMounts:
+            - name: neo4j-data
+              mountPath: /data
       containers:
         - name: neo4j
           image: neo4j:5-community
           securityContext:
             runAsNonRoot: true
+            runAsUser: 7474
             allowPrivilegeEscalation: false
             # readOnlyRootFilesystem intentionally NOT enabled yet --
             # this container may write outside its declared volume


### PR DESCRIPTION
… verified via live kind cluster on local Docker Desktop

Prior SecurityContext hardening (runAsNonRoot, added earlier this session) was never live-tested before merging -- honestly flagged as such at the time. This session's live kind test (on a local Windows Docker Desktop environment, not the VPS -- VPS CPU steal made even a minimal cluster fail to boot, confirmed via a separate failed kubeadm init) found and fixed 3 real, layered issues:

1. runAsNonRoot: true alone rejected both pgvector/pgvector:pg16 and neo4j:5-community outright -- both images default to root before their entrypoints drop privileges internally. Fixed with explicit runAsUser (999 postgres, 7474 neo4j), confirmed via 'docker run --rm <image> id <user>', not assumed.
2. Even with the right UID, initdb/neo4j failed with 'chmod: Operation not permitted' against the PVC data directory, which K8s creates owned by root.
3. Pod-level fsGroup alone did not fix this -- it sets group ownership, not directory owner. Fixed with a dedicated fix-permissions init container (root, chown -R, busybox:1.36) running once before the main container starts restricted.

Also performed the actual backup/DR restore drill this fix unblocked: real marker row -> pg_dump -> DROP TABLE CASCADE -> confirmed genuine data loss -> restored from the dump -> confirmed the exact same row (same UUID, same microsecond timestamp) recovered. RTO under 2 minutes for this single-table drill. Full details and known limitations (noisy restore into non-empty schema, neo4j restore side not yet tested, Helm chart templates need the same fix) in CHANGELOG.md.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
