### PR TITLE
vectorstores: v0.3.3 - fix RedisBackend key_prefix data-isolation bug

### DIFF
--- a/packages/ragleap-vectorstores/CHANGELOG.md
+++ b/packages/ragleap-vectorstores/CHANGELOG.md
@@ -5,6 +5,32 @@ loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-09-06
+### Fixed
+- REAL BUG, live-verified: RedisBackend's key_prefix used to default to
+  the same literal string ("ragleap:chunk:") regardless of index_name.
+  Two RedisBackend instances with different index_name but both left
+  at the default key_prefix silently shared the same Redis keyspace -
+  creating the second index caused RediSearch to auto-index the first
+  instance's leftover chunks too, and a fresh KNN query could return
+  stale data from a completely unrelated instance. Reproduced live:
+  three separate verification runs with different index_names, all
+  writing into the same "ragleap:chunk:*" keyspace, and a top_k=1
+  query on the newest instance returned a chunk from an unrelated
+  earlier run. Fixed by deriving the default key_prefix from
+  index_name, so two different indexes never collide unless the
+  caller explicitly passes the same key_prefix on purpose. Added a
+  dedicated regression test (two instances, different index_name, no
+  explicit key_prefix, each must only ever see its own chunks) - this
+  test fails against the old code and passes against the fix.
+
+This is a data-isolation fix, not just a docs fix: anyone running two
+RedisBackend-backed RagLeap deployments against the same Redis server
+without an explicit key_prefix was at risk of their data silently
+mixing. Given the package is still alpha and RedisBackend shipped only
+days ago, fixing the default now (before wider adoption) was judged
+better than leaving the footgun in place.
+
 ## [0.3.2] - 2026-09-06
 ### Fixed
 - README's "Available backends" table was missing a Redis row entirely

--- a/packages/ragleap-vectorstores/pyproject.toml
+++ b/packages/ragleap-vectorstores/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-vectorstores"
-version = "0.3.2"
+version = "0.3.3"
 description = "Pluggable vector backends beyond ragleap-rag core's 6 (PgVector, FAISS, Pinecone, Weaviate, Qdrant, Milvus) - additional VectorBackend implementations as optional extras, no vendor lock-in, no bloated core dependency footprint."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-vectorstores/src/ragleap_vectorstores/__init__.py
+++ b/packages/ragleap-vectorstores/src/ragleap_vectorstores/__init__.py
@@ -8,7 +8,7 @@ the package.
 """
 from ragleap.vectorstores.base import VectorBackend
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 __all__ = ["VectorBackend", "__version__"]
 

--- a/packages/ragleap-vectorstores/src/ragleap_vectorstores/redis_backend.py
+++ b/packages/ragleap-vectorstores/src/ragleap_vectorstores/redis_backend.py
@@ -87,7 +87,7 @@ class RedisBackend(VectorBackend):
         self,
         redis_url: str,
         index_name: str = "ragleap_idx",
-        key_prefix: str = "ragleap:chunk:",
+        key_prefix: Optional[str] = None,
         registry_path: Optional[str] = None,
     ):
         try:
@@ -111,7 +111,20 @@ class RedisBackend(VectorBackend):
 
         self.redis_url = redis_url
         self.index_name = index_name
-        self.key_prefix = key_prefix
+        # REAL BUG FIX, live-verified: key_prefix used to default to the
+        # same literal string ("ragleap:chunk:") regardless of index_name.
+        # Two RedisBackend instances with different index_name but both
+        # left at the default key_prefix would silently share the same
+        # Redis keyspace - creating a second index over that prefix makes
+        # RediSearch auto-index every existing key there, including chunks
+        # inserted by a completely unrelated earlier instance. Reproduced
+        # live: three separate verification runs with different
+        # index_names all wrote into "ragleap:chunk:*", and a fresh
+        # top_k=1 KNN query on the newest instance returned a stale chunk
+        # from an unrelated earlier run. Default now derives from
+        # index_name so two different indices never collide unless the
+        # caller explicitly passes the same key_prefix on purpose.
+        self.key_prefix = key_prefix or f"ragleap:{index_name}:chunk:"
         self._client = None
         self._dimensions = None
         self._lock = threading.Lock()

--- a/packages/ragleap-vectorstores/tests/test_redis_backend.py
+++ b/packages/ragleap-vectorstores/tests/test_redis_backend.py
@@ -181,3 +181,54 @@ def test_init_schema_idempotent(backend):
     backend.init_schema(dimensions=3)
     results = backend.search_dense([0.1, 0.2, 0.3], top_k=5)
     assert len(results) == 3
+
+
+def test_default_key_prefix_isolates_different_indexes(tmp_path):
+    """Regression guard for a real bug, live-verified: key_prefix used to
+    default to the same literal string regardless of index_name, so two
+    RedisBackend instances with different index_name but both left at the
+    default key_prefix silently shared the same Redis keyspace - creating
+    the second index caused RediSearch to auto-index the first instance's
+    leftover chunks too, and a fresh KNN query could return stale data
+    from a completely unrelated instance. Reproduced live: three separate
+    verification runs with different index_names, default key_prefix,
+    all landed in "ragleap:chunk:*", and a top_k=1 query on the newest
+    one returned an old chunk from an earlier one. This test creates two
+    instances with different index_name and NO explicit key_prefix, and
+    verifies each only ever sees its own chunks."""
+    suffix_a = uuid.uuid4().hex[:8]
+    suffix_b = uuid.uuid4().hex[:8]
+    a = RedisBackend(
+        redis_url=REDIS_TEST_URL,
+        index_name=f"isolation_a_{suffix_a}",
+        registry_path=str(tmp_path / "registry_a.sqlite3"),
+    )
+    b = RedisBackend(
+        redis_url=REDIS_TEST_URL,
+        index_name=f"isolation_b_{suffix_b}",
+        registry_path=str(tmp_path / "registry_b.sqlite3"),
+    )
+    try:
+        a.init_schema(dimensions=3)
+        b.init_schema(dimensions=3)
+
+        assert a.key_prefix != b.key_prefix, "default key_prefix must differ when index_name differs"
+
+        a.insert_document("doc_a", "a.txt", {})
+        a.insert_chunk("doc_a", "a.txt", 0, "chunk from instance A", 3, [0.1, 0.1, 0.1], {})
+        b.insert_document("doc_b", "b.txt", {})
+        b.insert_chunk("doc_b", "b.txt", 0, "chunk from instance B", 3, [0.1, 0.1, 0.1], {})
+
+        results_a = a.search_dense([0.1, 0.1, 0.1], top_k=5)
+        results_b = b.search_dense([0.1, 0.1, 0.1], top_k=5)
+
+        assert len(results_a) == 1, "instance A must only see its own chunk, not instance B's"
+        assert results_a[0]["document_id"] == "doc_a"
+        assert len(results_b) == 1, "instance B must only see its own chunk, not instance A's"
+        assert results_b[0]["document_id"] == "doc_b"
+    finally:
+        for inst in (a, b):
+            try:
+                inst._client.ft(inst.index_name).dropindex(delete_documents=True)
+            except Exception:
+                pass


### PR DESCRIPTION
Real data-isolation bug fix, not just docs.

**The bug**: `RedisBackend`'s `key_prefix` defaulted to the same literal string regardless of `index_name`. Two instances with different `index_name` but both left at the default `key_prefix` silently shared the same Redis keyspace — creating a second index caused RediSearch to auto-index the first instance's leftover chunks too, and a fresh KNN query could return stale data from a completely unrelated instance.

**How it was found**: reproduced live during post-release PyPI verification — three separate verification runs with different `index_name`s all wrote into the same keyspace, and a query on the newest instance returned a chunk from an unrelated earlier run.

**The fix**: default `key_prefix` now derives from `index_name`, so two different indexes never collide unless the caller explicitly passes the same `key_prefix` on purpose.

Added a dedicated regression test (two instances, different `index_name`, no explicit `key_prefix`, each must only ever see its own chunks) — confirmed this test fails against the old code and passes against the fix. Full suite: 41/41 passing.