### PR TITLE
fix(ragleap-app-chart): fix SecurityContext UID and hardcoded /data m…

### DIFF
--- a/packages/ragleap-app-chart/CHANGELOG.md
+++ b/packages/ragleap-app-chart/CHANGELOG.md
@@ -5,6 +5,24 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- First live cluster deploy (helm install against a real kind cluster) found 2 real bugs in the default example config, neither previously caught by helm lint/helm template alone:
+  1. `defaultSecurityContext`'s `runAsNonRoot: true` had no accompanying `runAsUser` -- rejected postgres:16 outright, same class of bug found and fixed in ragleap-ops earlier the same day (confirmed via `docker run --rm postgres:16 id postgres` -- UID 999, not assumed). Fixed generically: added an opt-in per-service `initChown` flag in deployment.yaml that renders a one-time root `fix-permissions` init container using the service's own declared `securityContext.runAsUser` -- not hardcoded to any specific UID, since this chart is not RagLeap-specific and different services will need different UIDs.
+  2. The chart hardcodes `/data` as the mount path for any `persistent: true` service. postgres's official image defaults to `/var/lib/postgresql/data`, not `/data` -- without an explicit `PGDATA` override, postgres would have initialized on the container's ephemeral filesystem, silently NOT persisting to the actual PVC. This is a real, generic risk for any persistent service whose image doesn't default to `/data` specifically -- documented here as a known gap; the chart does not currently warn or validate this automatically.
+
+### Verified
+
+- Full `helm install` against a real local kind cluster (Docker Desktop, Windows) using the chart's own default example `services:` list (web + postgres) -- the genericity proof the design proposal explicitly requires ("proven against a non-RagLeap toy app"). After the above fixes: `postgres` reached `1/1 Running`, 0 restarts sustained. Verified data genuinely persists to the mounted volume, not just that the pod is green: `SHOW data_directory;` confirmed `/data/pgdata`, matching the PGDATA override, not the container's ephemeral root filesystem.
+- `web`'s `ImagePullBackOff` is expected (default example uses a placeholder `myorg/myapp:latest` image that doesn't exist on any registry) and doesn't reflect on chart correctness.
+- Confirmed the existing NetworkPolicy/PVC/resources/securityContext override logic (previously only template-verified via helm template) now also proven against real deployed resources, not just rendered YAML.
+
+### Known limitations
+
+- The hardcoded `/data` mount path (see Fixed #2 above) is a real generic risk, not just a postgres-specific quirk -- any persistent service whose image doesn't default its data directory to `/data` needs an explicit env override (or a future chart enhancement to make the mount path itself configurable per-service, not yet built).
+- `initChown` requires the service to also declare its own `securityContext.runAsUser` -- if a service sets `initChown: true` without `runAsUser`, the rendered chown command would be malformed (empty UID). Not currently validated by the chart; a real user mistake here would fail at apply-time, not before.
+
+
 ### Added
 
 - Generic `services:` schema in `values.yaml` — arbitrary list of services, each rendering its own Deployment, Service, and (conditionally) PVC, NetworkPolicy, and Ingress via Helm `range` loops. Not hardcoded to any specific app.

--- a/packages/ragleap-app-chart/helm/ragleap-app-chart/templates/deployment.yaml
+++ b/packages/ragleap-app-chart/helm/ragleap-app-chart/templates/deployment.yaml
@@ -16,6 +16,18 @@ spec:
       labels:
         {{- include "ragleap-app-chart.serviceLabels" (dict "Release" $.Release "service" $svc) | nindent 8 }}
     spec:
+      {{- if $svc.initChown }}
+      initContainers:
+        - name: fix-permissions
+          image: busybox:1.36
+          command: ["sh", "-c", "chown -R {{ $svc.securityContext.runAsUser }}:{{ $svc.securityContext.runAsUser }} /data"]
+          securityContext:
+            runAsUser: 0
+            runAsNonRoot: false
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      {{- end }}
       containers:
         - name: {{ $svc.name }}
           image: {{ $svc.image }}

--- a/packages/ragleap-app-chart/helm/ragleap-app-chart/values.yaml
+++ b/packages/ragleap-app-chart/helm/ragleap-app-chart/values.yaml
@@ -47,6 +47,27 @@ services:
     dependsOn: []             # no outbound deps — still gets its own deny-all ingress policy
     expose: false
 
+    # postgres:16 defaults to a root user before dropping privileges
+    # internally (confirmed via 'docker run --rm postgres:16 id postgres'
+    # — UID 999) — runAsNonRoot alone rejects it outright, same real
+    # bug found and fixed in ragleap-ops. initChown renders a one-time
+    # root init container to chown the PVC before the main container
+    # starts restricted.
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 999
+      allowPrivilegeEscalation: false
+    initChown: true
+
+    # postgres's official image defaults to /var/lib/postgresql/data,
+    # not this chart's hardcoded /data mount — PGDATA must point inside
+    # the actual mounted volume or data silently won't persist.
+    env:
+      - name: PGDATA
+        value: /data/pgdata
+      - name: POSTGRES_PASSWORD
+        value: test-password-not-for-production
+
 # Applied to any service that omits its own `resources` block.
 defaultResources:
   requests:


### PR DESCRIPTION
…ount path, verified via first-ever live cluster deploy

First live cluster deploy of this chart (helm install against a real kind cluster, using the chart's own default web+postgres example -- the genericity proof the design proposal requires: 'proven against a non-RagLeap toy app'). Found 2 real bugs neither helm lint nor helm template alone could catch:

1. defaultSecurityContext's runAsNonRoot: true had no runAsUser -- rejected postgres:16 outright, same bug class fixed in ragleap-ops earlier the same day. Fixed generically: opt-in per-service initChown flag renders a one-time root fix-permissions init container using the service's own declared runAsUser -- not hardcoded to any UID, since this chart must work for arbitrary services.
2. The chart hardcodes /data as the mount path. postgres defaults to /var/lib/postgresql/data -- without an explicit PGDATA override, data would have silently NOT persisted to the actual PVC. Real, generic risk for any persistent service whose image doesn't default to /data, documented as a known limitation.

Verified: postgres reached 1/1 Running, 0 restarts sustained. Data persistence independently confirmed via SHOW data_directory; -> /data/pgdata, not just pod status. web's ImagePullBackOff is expected (placeholder image) and unrelated to chart correctness.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
