### PR TITLE
docs(ragleap-app-chart): add architecture diagram, update Status to r…

### DIFF
--- a/packages/ragleap-app-chart/README.md
+++ b/packages/ragleap-app-chart/README.md
@@ -8,12 +8,16 @@ services), this chart takes an arbitrary `services:` list in
 `values.yaml` and renders resources for each service via range loops.
 Point it at your own app; it doesn't know or care what RagLeap is.
 
+<img src="https://mermaid.ink/svg/Zmxvd2NoYXJ0IFRECiAgICBjbGFzc0RlZiBzb3VyY2UgZmlsbDojMWUzYTVmLHN0cm9rZTojNGE5MGQ5LGNvbG9yOiNmZmYKICAgIGNsYXNzRGVmIG1hbmlmZXN0IGZpbGw6IzRkMzMxOSxzdHJva2U6I2Y1OWUwYixjb2xvcjojZmZmCiAgICBjbGFzc0RlZiBjaGFydCBmaWxsOiMzZDI2NDUsc3Ryb2tlOiNhODU1ZjcsY29sb3I6I2ZmZgogICAgY2xhc3NEZWYgY2x1c3RlciBmaWxsOiMxYTRkM2Esc3Ryb2tlOiMyMmM1NWUsY29sb3I6I2ZmZgoKICAgIFZhbHVlc1sidmFsdWVzLnlhbWw8YnIvPmFyYml0cmFyeSBzZXJ2aWNlczogbGlzdDxici8+bm90IGhhcmRjb2RlZCB0byBSYWdMZWFwIl06Ojpzb3VyY2UgLS0+IFJhbmdlWyJIZWxtIHJhbmdlIGxvb3BzPGJyLz5wZXItc2VydmljZSByZW5kZXJpbmciXTo6OmNoYXJ0CgogICAgUmFuZ2UgLS0+IERlcGxveVsiRGVwbG95bWVudCArIFNlcnZpY2U8YnIvPnBlciBzZXJ2aWNlIl06OjptYW5pZmVzdAogICAgUmFuZ2UgLS0+IFBWQ1siUFZDPGJyLz5pZiBwZXJzaXN0ZW50OiB0cnVlIl06OjptYW5pZmVzdAogICAgUmFuZ2UgLS0+IE5ldFBvbFsiTmV0d29ya1BvbGljeTxici8+ZGVueS1ieS1kZWZhdWx0LCBkZXJpdmVkIGZyb20gZGVwZW5kc09uIl06OjptYW5pZmVzdAogICAgUmFuZ2UgLS0+IEluZ3Jlc3NbIkluZ3Jlc3MgKyBUTFM8YnIvPmlmIGV4cG9zZTogdHJ1ZSJdOjo6bWFuaWZlc3QKCiAgICBEZXBsb3kgLS0+IEtpbmRUZXN0WyJMaXZlIGtpbmQgY2x1c3RlciB0ZXN0PGJyLz53ZWIgKyBwb3N0Z3JlcyBleGFtcGxlIl06OjpjbHVzdGVyCiAgICBQVkMgLS0+IEtpbmRUZXN0CiAgICBOZXRQb2wgLS0+IEtpbmRUZXN0CiAgICBJbmdyZXNzIC0tPiBLaW5kVGVzdAoKICAgIEtpbmRUZXN0IC0tPiBWZXJpZnlbInBvc3RncmVzIHJlYWNoZWQgMS8xIFJ1bm5pbmc8YnIvPjAgcmVzdGFydHMsIGRhdGEgdmVyaWZpZWQgcGVyc2lzdGVkPGJyLz50byAvZGF0YS9wZ2RhdGEgdmlhIFNIT1cgZGF0YV9kaXJlY3RvcnkiXTo6OmNsdXN0ZXIK" alt="ragleap-app-chart generic services rendering and verification flow" width="100%">
+
 ## Status
 
-Design only. See `GENERIC-K8S-CHART-PROPOSAL.md` at the repo root for
-the full design rationale. No templates or live testing exist yet —
-this scaffold exists so release automation can version this package
-once real chart content is built.
+v0.1.0 published on PyPI. Generic `services:` schema and range-loop
+Helm templates are live-tested end-to-end on a real kind cluster (not
+just `helm lint`/`helm template`) -- see CHANGELOG.md for the real
+bugs found and fixed via live testing. See
+`GENERIC-K8S-CHART-PROPOSAL.md` at the repo root for the full design
+rationale.
 
 ## Design principles (from the proposal doc)
 


### PR DESCRIPTION
…eflect v0.1.0 shipped

Matches ragleap-ops's README convention (base64-encoded mermaid source in a mermaid.ink img tag). Diagram shows the values.yaml -> range loop -> per-resource-type rendering -> live kind cluster verification flow.

Status section was stale (still said 'Design only... no templates or live testing exist yet') despite the package now being fully built, live-tested, and published to PyPI as v0.1.0.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
