### PR TITLE
fix: disable Gemini thinking budget by default to prevent answer truncation

### DIFF
--- a/core/generation.py
+++ b/core/generation.py
@@ -20,6 +20,13 @@ GEMINI_CHAT_MODEL = os.environ.get("GEMINI_CHAT_MODEL", "gemini-2.5-flash")
 DEFAULT_TEMPERATURE = float(os.environ.get("DEFAULT_TEMPERATURE", "0.3"))
 MAX_OUTPUT_TOKENS = int(os.environ.get("MAX_OUTPUT_TOKENS", "1024"))
 
+# Gemini "thinking" models (e.g. gemini-3.5-flash) spend part of
+# max_output_tokens on internal reasoning before the visible answer,
+# which can silently truncate the answer on hard queries. Default to
+# 0 (thinking disabled) so the full token budget goes to the answer;
+# override via GEMINI_THINKING_BUDGET if extended reasoning is wanted.
+GEMINI_THINKING_BUDGET = int(os.environ.get("GEMINI_THINKING_BUDGET", "0"))
+
 LLM_FALLBACK_PROVIDERS = [
     p.strip().lower() for p in os.environ.get("LLM_FALLBACK_PROVIDERS", "").split(",") if p.strip()
 ]
@@ -322,6 +329,7 @@ Answer:"""
             config=types.GenerateContentConfig(
                 temperature=temperature,
                 max_output_tokens=max_tokens,
+                thinking_config=types.ThinkingConfig(thinking_budget=GEMINI_THINKING_BUDGET),
             ),
         )
         text = response.text.strip() if response.text else "No answer generated."
@@ -345,6 +353,7 @@ Answer:"""
             config=types.GenerateContentConfig(
                 temperature=temperature,
                 max_output_tokens=max_tokens,
+                thinking_config=types.ThinkingConfig(thinking_budget=GEMINI_THINKING_BUDGET),
             ),
         )
         for chunk in stream:


### PR DESCRIPTION
## Problem
LLM answers could get silently truncated mid-sentence with no error surfaced, for two distinct reasons:

1. `gemini-3.5-flash` is a thinking model — part of `max_output_tokens` gets spent on internal reasoning before the visible answer. Found via the in-progress role eval harness: the `compliance_officer` GDPR-clause case reproducibly truncated to 10-40 completion tokens even with `max_tokens=300` explicitly set. Root-caused live: `thoughts_token_count=358` on a call with `max_output_tokens=300` — thinking alone exceeded the entire budget.
2. More generally: **any** provider or model this project supports — cloud APIs, self-hosted, local Ollama models — can legitimately hit its token cap mid-answer on a hard query, independent of thinking tokens. This project is BYOK across ~16 providers plus local models, so a Gemini-only fix wasn't enough.

## Fix (2 commits)
**1st commit — Gemini-specific:**
- New `GEMINI_THINKING_BUDGET` env var, default `0` (thinking disabled).
- `thinking_config` added to `_call_gemini`/`_stream_gemini`.

**2nd commit — provider-agnostic:**
- Every provider path (`_call_gemini`, `_call_anthropic`, `_call_openai_compatible` — the last one covers every OpenAI-compatible host including Ollama) now captures its own `finish_reason`/`stop_reason`.
- `generate_answer()` retries once with a larger budget (default 2x, capped at `TRUNCATION_MAX_RETRY_TOKENS=4096`) when a truncation signal is detected, before falling through to the next provider in the fallback chain.
- Retry failure is caught and falls back to the original answer rather than crashing the request.

## Known gap (documented, not hidden)
`generate_answer_stream()` cannot retry after tokens are already streaming to the user — this fix only covers blocking calls (`generate_answer()`). Streaming's only truncation safeguard is the Gemini `thinking_budget=0` default from commit 1.

## Verification
Reproduced the original failing case live before and after the Gemini-specific fix:
- **Before:** `thoughts_token_count=358`, answer cut off at 12 tokens mid-word
- **After:** `thoughts_token_count=None`, answer used 296/300 tokens, complete

The retry-safeguard commit hasn't yet been exercised against a live truncation case (existing tests + CI cover syntax/logic; a live end-to-end retry trigger wasn't reproduced separately since the Gemini fix already resolves the original case). Flagging that honestly — CI should still validate nothing broke, but if we want a dedicated regression test proving retry fires and works, that's a reasonable follow-up.
