### PR TITLE
feat: provider-agnostic truncation retry safeguard + tests

### DIFF
--- a/core/generation.py
+++ b/core/generation.py
@@ -27,6 +27,17 @@ MAX_OUTPUT_TOKENS = int(os.environ.get("MAX_OUTPUT_TOKENS", "1024"))
 # override via GEMINI_THINKING_BUDGET if extended reasoning is wanted.
 GEMINI_THINKING_BUDGET = int(os.environ.get("GEMINI_THINKING_BUDGET", "0"))
 
+# Provider-agnostic truncation safeguard. Any provider/model — cloud or
+# local, Gemini thinking-token starvation, a small Ollama model, anything —
+# can hit its max_tokens cap mid-answer. Detected via each provider's own
+# finish_reason field; on a match, generate_answer() retries once with a
+# larger budget before falling through to the next provider in the chain.
+# (Streaming cannot retry after tokens are already being sent to the user —
+# not covered here; see generate_answer_stream docstring.)
+TRUNCATED_FINISH_REASONS = {"MAX_TOKENS", "max_tokens", "length"}
+TRUNCATION_RETRY_MULTIPLIER = float(os.environ.get("TRUNCATION_RETRY_MULTIPLIER", "2.0"))
+TRUNCATION_MAX_RETRY_TOKENS = int(os.environ.get("TRUNCATION_MAX_RETRY_TOKENS", "4096"))
+
 LLM_FALLBACK_PROVIDERS = [
     p.strip().lower() for p in os.environ.get("LLM_FALLBACK_PROVIDERS", "").split(",") if p.strip()
 ]
@@ -252,6 +263,22 @@ Answer:"""
         for i, config in enumerate(chain):
             try:
                 answer_text, usage = self._call_provider(config, prompt, temp, max_tok)
+                if usage and usage.get("finish_reason") in TRUNCATED_FINISH_REASONS and max_tok < TRUNCATION_MAX_RETRY_TOKENS:
+                    retry_max_tok = min(int(max_tok * TRUNCATION_RETRY_MULTIPLIER), TRUNCATION_MAX_RETRY_TOKENS)
+                    if retry_max_tok > max_tok:
+                        logger.warning(
+                            f"Provider '{config['provider']}' truncated the answer "
+                            f"(finish_reason={usage.get('finish_reason')!r}), retrying once with "
+                            f"max_tokens={retry_max_tok} (was {max_tok})"
+                        )
+                        try:
+                            retry_text, retry_usage = self._call_provider(config, prompt, temp, retry_max_tok)
+                            answer_text, usage = retry_text, retry_usage
+                        except Exception as retry_e:
+                            logger.warning(
+                                f"Truncation retry failed for '{config['provider']}': {retry_e}; "
+                                f"keeping original (possibly truncated) answer"
+                            )
                 if i > 0:
                     logger.info(f"Answer generated via fallback provider '{config['provider']}' (primary failed)")
                 return {
@@ -333,6 +360,10 @@ Answer:"""
             ),
         )
         text = response.text.strip() if response.text else "No answer generated."
+        finish_reason = None
+        if response.candidates:
+            fr = response.candidates[0].finish_reason
+            finish_reason = getattr(fr, "name", str(fr))
         usage = None
         if getattr(response, "usage_metadata", None):
             um = response.usage_metadata
@@ -340,6 +371,7 @@ Answer:"""
                 "prompt_tokens": um.prompt_token_count,
                 "completion_tokens": um.candidates_token_count,
                 "total_tokens": um.total_token_count,
+                "finish_reason": finish_reason,
             }
         return text, usage
 
@@ -376,6 +408,7 @@ Answer:"""
                 "prompt_tokens": response.usage.input_tokens,
                 "completion_tokens": response.usage.output_tokens,
                 "total_tokens": response.usage.input_tokens + response.usage.output_tokens,
+                "finish_reason": getattr(response, "stop_reason", None),
             }
         return text, usage
 
@@ -407,6 +440,7 @@ Answer:"""
                 "prompt_tokens": response.usage.prompt_tokens,
                 "completion_tokens": response.usage.completion_tokens,
                 "total_tokens": response.usage.total_tokens,
+                "finish_reason": response.choices[0].finish_reason if response.choices else None,
             }
         return text, usage
 

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -1,0 +1,120 @@
+"""
+Tests for core/generation.py - provider-agnostic truncation retry safeguard.
+No DB or live API required - _call_provider is mocked directly so this
+tests generate_answer()'s retry logic in isolation from any real provider,
+covering Gemini/Anthropic/OpenAI-compatible (including Ollama) alike since
+they all normalize to a "finish_reason" key in the usage dict.
+"""
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from core.generation import GenerationService
+from core import generation
+
+
+def _make_service(primary_provider="testprovider"):
+    """Build a GenerationService without hitting _resolve_provider_config
+    (which requires real env-configured API keys) - set primary_config
+    directly instead."""
+    service = object.__new__(GenerationService)
+    service.primary_config = {"provider": primary_provider, "api_key": "x", "model": "m", "base_url": None}
+    service.provider = primary_provider
+    return service
+
+
+def test_no_retry_when_not_truncated():
+    service = _make_service()
+    with patch.object(
+        service, "_call_provider",
+        return_value=("complete answer", {"finish_reason": "stop", "completion_tokens": 5}),
+    ) as mock_call:
+        result = service.generate_answer("question", [], max_tokens=100)
+    assert mock_call.call_count == 1
+    assert result["answer"] == "complete answer"
+    assert result["usage"]["finish_reason"] == "stop"
+
+
+def test_retries_once_on_truncation_and_uses_retry_result():
+    service = _make_service()
+    calls = []
+
+    def fake_call(config, prompt, temperature, max_tokens):
+        calls.append(max_tokens)
+        if max_tokens == 100:
+            return "truncated ans", {"finish_reason": "MAX_TOKENS", "completion_tokens": 100}
+        return "complete answer after retry", {"finish_reason": "stop", "completion_tokens": 150}
+
+    with patch.object(service, "_call_provider", side_effect=fake_call):
+        result = service.generate_answer("question", [], max_tokens=100)
+
+    assert calls == [100, 200]  # default 2x multiplier
+    assert result["answer"] == "complete answer after retry"
+    assert result["usage"]["finish_reason"] == "stop"
+
+
+def test_retry_result_still_truncated_returns_it_anyway():
+    """If the retry is ALSO truncated, generate_answer should still return
+    that (larger) answer rather than looping forever - only one retry."""
+    service = _make_service()
+    calls = []
+
+    def fake_call(config, prompt, temperature, max_tokens):
+        calls.append(max_tokens)
+        return f"truncated at {max_tokens}", {"finish_reason": "length", "completion_tokens": max_tokens}
+
+    with patch.object(service, "_call_provider", side_effect=fake_call):
+        result = service.generate_answer("question", [], max_tokens=100)
+
+    assert calls == [100, 200]  # only ONE retry attempt, no loop
+    assert result["answer"] == "truncated at 200"
+
+
+def test_no_retry_when_already_at_max_retry_cap():
+    """max_tok already >= TRUNCATION_MAX_RETRY_TOKENS should not retry."""
+    service = _make_service()
+    with patch.object(
+        service, "_call_provider",
+        return_value=("cut off", {"finish_reason": "MAX_TOKENS", "completion_tokens": generation.TRUNCATION_MAX_RETRY_TOKENS}),
+    ) as mock_call:
+        result = service.generate_answer("question", [], max_tokens=generation.TRUNCATION_MAX_RETRY_TOKENS)
+    assert mock_call.call_count == 1
+    assert result["answer"] == "cut off"
+
+
+def test_retry_failure_falls_back_to_original_answer():
+    """If the retry call itself raises, keep the original (possibly
+    truncated) answer instead of crashing the whole request."""
+    service = _make_service()
+    calls = []
+
+    def fake_call(config, prompt, temperature, max_tokens):
+        calls.append(max_tokens)
+        if max_tokens == 100:
+            return "truncated ans", {"finish_reason": "MAX_TOKENS", "completion_tokens": 100}
+        raise RuntimeError("provider unreachable on retry")
+
+    with patch.object(service, "_call_provider", side_effect=fake_call):
+        result = service.generate_answer("question", [], max_tokens=100)
+
+    assert calls == [100, 200]
+    assert result["answer"] == "truncated ans"
+
+
+def test_ollama_style_finish_reason_triggers_retry():
+    """OpenAI-compatible hosts (including Ollama) report finish_reason='length'."""
+    service = _make_service(primary_provider="ollama")
+    calls = []
+
+    def fake_call(config, prompt, temperature, max_tokens):
+        calls.append(max_tokens)
+        if max_tokens == 50:
+            return "cut", {"finish_reason": "length", "completion_tokens": 50}
+        return "full answer", {"finish_reason": "stop", "completion_tokens": 80}
+
+    with patch.object(service, "_call_provider", side_effect=fake_call):
+        result = service.generate_answer("question", [], max_tokens=50)
+
+    assert calls == [50, 100]
+    assert result["answer"] == "full answer"


### PR DESCRIPTION
## Context
Follow-up to #305 (merged). That PR's second and third commits (provider-agnostic retry logic + tests) never made it into #305 due to a concurrent-session race: something else merged #305 right after its first commit landed, while this session was still pushing commits 2-3 to the same branch — silently dropping them when the branch got deleted post-merge. Recovered cleanly via `git cherry-pick` (commits still existed locally, branch ref deletion doesn't remove commit objects).

## What this PR adds (on top of #305's Gemini thinking-budget fix, already on main)
Provider-agnostic truncation safeguard: any provider or model — cloud or local, Gemini thinking-token starvation, a small Ollama model, anything — can hit its max_tokens cap mid-answer independent of thinking tokens. This project is BYOK across ~16 providers plus local Ollama models, so a Gemini-only fix wasn't sufficient on its own.

- Every provider path (`_call_gemini`, `_call_anthropic`, `_call_openai_compatible` — covers every OpenAI-compatible host including Ollama) now captures its own `finish_reason`/`stop_reason`.
- `generate_answer()` retries once with a larger budget (default 2x, capped at `TRUNCATION_MAX_RETRY_TOKENS=4096`) when truncation is detected, before falling through to the next provider in the fallback chain.
- Retry failure is caught and falls back to the original answer rather than crashing the request.
- New `tests/test_generation.py` (module had zero coverage before this) — 6 tests, `_call_provider` mocked directly, no DB/live API needed. Covers: no-retry-when-complete, retry-and-use-result, retry-still-truncated-returns-anyway (no infinite loop), no-retry-at-cap, retry-failure-falls-back, and an Ollama-style `finish_reason='length'` case confirming the safeguard genuinely isn't Gemini-specific.

## Known gap (documented, not hidden)
`generate_answer_stream()` cannot retry after tokens are already streaming to the user — this only covers blocking calls. Streaming's only truncation safeguard remains #305's `thinking_budget=0` default.

Full suite: 200 → 206 tests.
