### PR TITLE
feat: allow per-provider base URL override, add Docker host-gateway access

### DIFF
--- a/core/generation.py
+++ b/core/generation.py
@@ -112,7 +112,15 @@ def _resolve_provider_config(provider: str, required: bool = True) -> Optional[D
         key_env = f"{provider.upper()}_API_KEY"
         api_key = os.environ.get(key_env)
         model = os.environ.get(f"{provider.upper()}_MODEL", "")
-        base_url = os.environ.get("CUSTOM_BASE_URL") if provider == "custom" else PROVIDER_BASE_URLS[provider]
+        # Any provider's base URL can be overridden via {PROVIDER}_BASE_URL,
+        # e.g. OLLAMA_BASE_URL=http://host.docker.internal:11434/v1 when
+        # running in Docker (the "localhost" default only works when the
+        # app runs on bare metal alongside Ollama, not inside a container).
+        # 'custom' keeps its own CUSTOM_BASE_URL name for backward compat.
+        if provider == "custom":
+            base_url = os.environ.get("CUSTOM_BASE_URL")
+        else:
+            base_url = os.environ.get(f"{provider.upper()}_BASE_URL", PROVIDER_BASE_URLS[provider])
 
         if not api_key and provider != "ollama":
             return _fail(f"{key_env} is not set. Add your {provider} API key to .env.")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,12 @@ services:
       - .env
     environment:
       DATABASE_URL: postgresql://ragleap:ragleap@db:5432/ragleap_core
+    extra_hosts:
+      # Lets the container reach services on the host (e.g. a local Ollama
+      # instance) via host.docker.internal, matching Docker Desktop's
+      # built-in behavior which plain Linux Docker Engine doesn't have
+      # by default. Requires Docker Engine >=20.10.
+      - "host.docker.internal:host-gateway"
     ports:
       - "8000:8000"
 


### PR DESCRIPTION
## Context
This project is BYOK across ~16 providers plus local/self-hosted models (Ollama, custom OpenAI-compatible endpoints). Wiring up Ollama as a live fallback (after discovering real Gemini 429 quota exhaustion during eval runs - not just transient 503s as originally assumed) surfaced that local Docker-hosted providers were silently unusable: `PROVIDER_BASE_URLS["ollama"]` hardcodes `http://localhost:11434/v1`, which refers to the container itself when the app runs in Docker, not the host machine.

## Fix
- `core/generation.py`: every non-`custom` provider's base URL can now be overridden via `{PROVIDER}_BASE_URL` (e.g. `OLLAMA_BASE_URL=http://172.18.0.1:11434/v1`), falling back to the existing default when unset. Generalized rather than Ollama-specific, since any self-hosted provider could need this.
- `docker-compose.yml`: added `extra_hosts: host.docker.internal -> host-gateway` on the `app` service (plain Linux Docker Engine doesn't resolve `host.docker.internal` by default, unlike Docker Desktop).

## Full debugging trail (for next time this breaks)
1. `host.docker.internal` resolved to the *wrong* bridge network's gateway (`172.17.0.1`, the default `bridge` network) instead of this project's actual compose network gateway (`172.18.0.1`, `ragleap-core_default`) - confirmed via `docker inspect`. A real Docker Engine quirk on this version, not user error - worth using the explicit gateway IP as the reliable option if `host.docker.internal` misbehaves again.
2. Even reaching the right gateway IP, `ufw`'s default DROP policy on the `INPUT` chain silently blocked port 11434 - traffic from a container to its own host's bridge gateway hits `INPUT`, not `FORWARD`/`DOCKER-USER`. Needs an explicit `ufw allow` rule scoped to the Docker bridge subnet only (not opened to the public internet).
3. Ollama itself defaults to binding `127.0.0.1` only - needed a systemd override (`OLLAMA_HOST=0.0.0.0`) to accept connections from the Docker bridge network at all.

Steps 2-3 are VPS/host-level config, not captured in this repo - a fresh VPS wanting a local Docker fallback provider needs to redo the `ufw` rule and Ollama bind override manually. Worth adding to setup docs as a follow-up (not done in this PR).

## Verification
Verified end-to-end on the live VPS: forced Gemini failure (bad model name) -> correctly fell through to Groq -> forced Groq failure too (found `GROQ_MODEL` was pointing at a since-retired model, `llama-3.3-70b-versatile` - fixed separately as unrelated config drift, not a code issue) -> correctly fell through to Ollama, which returned a complete, correctly-guardrailed answer from a local 0.5B model.
