### PR TITLE
feat: retry embeddings on transient errors (429/503), same provider only

### DIFF
--- a/core/embedding.py
+++ b/core/embedding.py
@@ -7,6 +7,7 @@ Bring-your-own-key only: this service NEVER falls back to a shared or
 system-provided key. You must supply your own GEMINI_API_KEY.
 """
 import os
+import time
 import logging
 from typing import List, Optional
 
@@ -14,6 +15,22 @@ logger = logging.getLogger(__name__)
 
 GEMINI_EMBEDDING_MODEL = os.environ.get("GEMINI_EMBEDDING_MODEL", "models/gemini-embedding-001")
 EMBEDDING_DIMENSIONS = int(os.environ.get("EMBEDDING_DIMENSIONS", "3072"))
+
+# Deliberately NOT a cross-provider fallback: every stored chunk is embedded
+# with this exact model at EMBEDDING_DIMENSIONS, so a different provider's
+# embedding would land in a different, incompatible vector space and
+# corrupt similarity search silently rather than failing loudly. This is a
+# same-provider retry for genuinely transient errors only (429 rate limit,
+# 503 server overload) - anything else (bad key, malformed request) fails
+# fast on the first try, as before.
+EMBEDDING_RETRY_CODES = {429, 503}
+EMBEDDING_MAX_RETRIES = int(os.environ.get("EMBEDDING_MAX_RETRIES", "3"))
+EMBEDDING_RETRY_BASE_DELAY = float(os.environ.get("EMBEDDING_RETRY_BASE_DELAY", "1.0"))
+
+
+def _is_transient(exc: Exception) -> bool:
+    code = getattr(exc, "code", None)
+    return code in EMBEDDING_RETRY_CODES
 
 
 class EmbeddingService:
@@ -43,11 +60,24 @@ class EmbeddingService:
         try:
             import google.genai as genai
             client = genai.Client(api_key=self.api_key)
-            response = client.models.embed_content(
-                model=self.model,
-                contents=text,
-            )
-            return response.embeddings[0].values
+            for attempt in range(EMBEDDING_MAX_RETRIES + 1):
+                try:
+                    response = client.models.embed_content(
+                        model=self.model,
+                        contents=text,
+                    )
+                    return response.embeddings[0].values
+                except Exception as e:
+                    if _is_transient(e) and attempt < EMBEDDING_MAX_RETRIES:
+                        delay = EMBEDDING_RETRY_BASE_DELAY * (2 ** attempt)
+                        logger.warning(
+                            f"Embedding request hit a transient error "
+                            f"(code={getattr(e, 'code', '?')}), retrying in "
+                            f"{delay:.1f}s (attempt {attempt + 1}/{EMBEDDING_MAX_RETRIES})"
+                        )
+                        time.sleep(delay)
+                        continue
+                    raise
         except Exception as e:
             logger.error(f"Embedding generation failed: {e}")
             return None
@@ -60,11 +90,24 @@ class EmbeddingService:
         try:
             import google.genai as genai
             client = genai.Client(api_key=self.api_key)
-            response = client.models.embed_content(
-                model=self.model,
-                contents=texts,
-            )
-            return [e.values for e in response.embeddings]
+            for attempt in range(EMBEDDING_MAX_RETRIES + 1):
+                try:
+                    response = client.models.embed_content(
+                        model=self.model,
+                        contents=texts,
+                    )
+                    return [e.values for e in response.embeddings]
+                except Exception as e:
+                    if _is_transient(e) and attempt < EMBEDDING_MAX_RETRIES:
+                        delay = EMBEDDING_RETRY_BASE_DELAY * (2 ** attempt)
+                        logger.warning(
+                            f"Batch embedding request hit a transient error "
+                            f"(code={getattr(e, 'code', '?')}), retrying in "
+                            f"{delay:.1f}s (attempt {attempt + 1}/{EMBEDDING_MAX_RETRIES})"
+                        )
+                        time.sleep(delay)
+                        continue
+                    raise
         except Exception as e:
             logger.error(f"Batch embedding generation failed: {e}")
             return [None] * len(texts)

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -1,0 +1,167 @@
+"""
+Tests for core/embedding.py - same-provider retry-on-transient-error logic.
+No live API calls - google.genai.Client is mocked directly. Deliberately
+does NOT test cross-provider fallback because there isn't one: every stored
+chunk is embedded via this exact model/dimensions, so a different provider
+would land in a different, incompatible vector space (see embedding.py's
+module docstring/comments for why).
+"""
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+os.environ.setdefault("GEMINI_API_KEY", "test-key-for-mocked-tests")
+
+from core import embedding
+from core.embedding import EmbeddingService
+
+
+# Other test files in this suite (test_bigquery_connector.py,
+# test_gmail_connector.py) replace sys.modules['google'] with a
+# MagicMock at import time to stub a heavy optional dependency, with no
+# cleanup - this leaks into any test running later in the same pytest
+# process and breaks a real `import google.genai`, which is what
+# core/embedding.py needs. Capture the REAL google.genai modules once,
+# here at collection time (forcing one real import if needed), so the
+# per-test fixture below only has to do cheap dict swaps rather than a
+# fresh heavy SDK import on every single test.
+_saved_at_collection = {k: v for k, v in sys.modules.items() if k == "google" or k.startswith("google.")}
+for _k in list(_saved_at_collection):
+    del sys.modules[_k]
+import google.genai  # noqa: F401 - forces one real import, now cached below
+_REAL_GOOGLE_MODULES = {k: v for k, v in sys.modules.items() if k == "google" or k.startswith("google.")}
+for _k in list(sys.modules):
+    if _k == "google" or _k.startswith("google."):
+        del sys.modules[_k]
+sys.modules.update(_saved_at_collection)  # restore whatever state collection order left us with
+
+
+@pytest.fixture(autouse=True)
+def _real_google_genai_import():
+    """Swap in the real, pre-imported google.genai modules (cheap dict
+    update, no re-import) before each test, and restore prior state
+    after - see the module-level comment above for why this is needed."""
+    saved = {k: v for k, v in sys.modules.items() if k == "google" or k.startswith("google.")}
+    for k in list(saved):
+        del sys.modules[k]
+    sys.modules.update(_REAL_GOOGLE_MODULES)
+    yield
+    for k in list(sys.modules):
+        if k == "google" or k.startswith("google."):
+            del sys.modules[k]
+    sys.modules.update(saved)
+
+
+class FakeAPIError(Exception):
+    """Mimics google.genai.errors.APIError's shape: a .code attribute."""
+    def __init__(self, code, message="fake api error"):
+        self.code = code
+        super().__init__(f"{code} {message}")
+
+
+def _make_response(values):
+    resp = MagicMock()
+    resp.embeddings = [MagicMock(values=values)]
+    return resp
+
+
+def test_embed_text_succeeds_first_try_no_retry():
+    service = EmbeddingService()
+    mock_client = MagicMock()
+    mock_client.models.embed_content.return_value = _make_response([0.1, 0.2])
+    with patch("google.genai.Client", return_value=mock_client):
+        result = service.embed_text("hello")
+    assert result == [0.1, 0.2]
+    assert mock_client.models.embed_content.call_count == 1
+
+
+def test_embed_text_retries_on_429_then_succeeds():
+    service = EmbeddingService()
+    mock_client = MagicMock()
+    mock_client.models.embed_content.side_effect = [
+        FakeAPIError(429),
+        FakeAPIError(429),
+        _make_response([0.3, 0.4]),
+    ]
+    with patch("google.genai.Client", return_value=mock_client), \
+         patch("time.sleep"):  # skip real backoff delay in tests
+        result = service.embed_text("hello")
+    assert result == [0.3, 0.4]
+    assert mock_client.models.embed_content.call_count == 3
+
+
+def test_embed_text_retries_on_503_then_succeeds():
+    service = EmbeddingService()
+    mock_client = MagicMock()
+    mock_client.models.embed_content.side_effect = [
+        FakeAPIError(503),
+        _make_response([0.5]),
+    ]
+    with patch("google.genai.Client", return_value=mock_client), \
+         patch("time.sleep"):
+        result = service.embed_text("hello")
+    assert result == [0.5]
+    assert mock_client.models.embed_content.call_count == 2
+
+
+def test_embed_text_does_not_retry_on_non_transient_error():
+    """A 401/403 (bad key) or 400 (malformed request) should fail fast,
+    not burn retries - retrying a permanently-broken key just wastes time."""
+    service = EmbeddingService()
+    mock_client = MagicMock()
+    mock_client.models.embed_content.side_effect = FakeAPIError(401, "invalid api key")
+    with patch("google.genai.Client", return_value=mock_client), \
+         patch("time.sleep") as mock_sleep:
+        result = service.embed_text("hello")
+    assert result is None
+    assert mock_client.models.embed_content.call_count == 1
+    mock_sleep.assert_not_called()
+
+
+def test_embed_text_gives_up_after_max_retries():
+    service = EmbeddingService()
+    mock_client = MagicMock()
+    mock_client.models.embed_content.side_effect = FakeAPIError(429)  # always fails
+    with patch("google.genai.Client", return_value=mock_client), \
+         patch("time.sleep"):
+        result = service.embed_text("hello")
+    assert result is None
+    # initial attempt + EMBEDDING_MAX_RETRIES retries
+    assert mock_client.models.embed_content.call_count == embedding.EMBEDDING_MAX_RETRIES + 1
+
+
+def test_embed_batch_retries_on_transient_error():
+    service = EmbeddingService()
+    mock_client = MagicMock()
+    mock_client.models.embed_content.side_effect = [
+        FakeAPIError(429),
+        _make_response(None).__class__() if False else MagicMock(
+            embeddings=[MagicMock(values=[0.1]), MagicMock(values=[0.2])]
+        ),
+    ]
+    with patch("google.genai.Client", return_value=mock_client), \
+         patch("time.sleep"):
+        result = service.embed_batch(["a", "b"])
+    assert result == [[0.1], [0.2]]
+    assert mock_client.models.embed_content.call_count == 2
+
+
+def test_embed_batch_empty_input_returns_empty_no_api_call():
+    service = EmbeddingService()
+    mock_client = MagicMock()
+    with patch("google.genai.Client", return_value=mock_client):
+        result = service.embed_batch([])
+    assert result == []
+    mock_client.models.embed_content.assert_not_called()
+
+
+def test_embed_text_empty_string_returns_none_no_api_call():
+    service = EmbeddingService()
+    mock_client = MagicMock()
+    with patch("google.genai.Client", return_value=mock_client):
+        result = service.embed_text("   ")
+    assert result is None
+    mock_client.models.embed_content.assert_not_called()


### PR DESCRIPTION
## Context
Follow-up to the generation-side fallback work (#305/#306/#308). This session also hit real Gemini 429 quota exhaustion during eval runs - worth checking whether the *embedding* step (used for retrieval, separate code path from generation) had the same fragility.

## Why this is NOT a cross-provider fallback (important distinction)
`core/embedding.py`'s docstring is explicit: "Bring-your-own-key only... NEVER falls back to a shared or system-provided key." That's deliberate, and for a real reason beyond BYOK philosophy: every chunk already stored in the vector DB was embedded with this exact Gemini model at `EMBEDDING_DIMENSIONS=3072`. If a query ever embedded via a *different* provider's model, that vector would land in a different, incompatible vector space - cosine similarity search against it would return near-random nearest-neighbors, **silently**. That's worse than the current honest failure. So this PR does not add cross-provider fallback here, unlike `generation.py`.

## Fix
Same-provider retry with exponential backoff, for genuinely transient errors only:
- Catches `google.genai.errors.APIError` and retries only when `.code in {429, 503}` - rate limit / server overload. Anything else (bad key, malformed request) fails fast on the first try, exactly as before.
- New `EMBEDDING_MAX_RETRIES` (default 3) and `EMBEDDING_RETRY_BASE_DELAY` (default 1.0s) env vars. Backoff: 1s, 2s, 4s by default.
- Applied to both `embed_text` and `embed_batch`.

## Tests
New `tests/test_embedding.py`, 8 tests, no live API calls (`google.genai.Client` mocked). Covers success-first-try, retry-then-succeed on both 429 and 503, no-retry on non-transient errors (asserts `sleep` never called), gives-up-after-max-retries, batch retry, and the pre-existing empty-input guards.

## Bonus fix: real test-suite pollution
Discovered while writing these tests: `test_bigquery_connector.py` and `test_gmail_connector.py` replace `sys.modules['google']` with a `MagicMock` at import time with **no cleanup** - this leaks into any test running later in the same pytest process that needs the real `google.genai` SDK (ours is the first to hit this). Added a scoped `autouse` fixture in `test_embedding.py` that swaps in a real, once-cached `google.genai` before each test and restores prior state after. Doesn't touch the other files or their existing mocking pattern (which works fine for their own purposes) - just makes our own tests immune to the leak regardless of run order.

## Known follow-up (not in this PR)
This only covers transient-error retry. If Gemini goes down entirely (not just rate-limited), retrieval still fails outright with no fallback - that's the deliberate BYOK/vector-space-consistency trade-off, not a bug, but worth knowing.
