### PR TITLE
feat: wire up memory seeding + add per-vertical compliance seeds

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -24,6 +24,7 @@ from core.employees import roles as employee_roles
 from core.employees import skills as employee_skills
 from core.employees import learning as employee_learning
 from core.employees import channel_roles as employee_channel_roles
+from core.employees import memory as employee_memory
 from core import workflows
 from core import autonomy
 
@@ -486,6 +487,7 @@ def trigger_auto_learn():
 @app.get("/employees")
 def list_employee_roles(active_only: bool = False):
     employee_roles.seed_default_roles()
+    employee_memory.seed_default_memory_seeds()
     return {"roles": employee_roles.list_roles(active_only=active_only)}
 
 

--- a/core/employees/defaults.py
+++ b/core/employees/defaults.py
@@ -256,3 +256,33 @@ DEFAULT_MEMORY_SEEDS = [
     {"tags": ["language", "multilingual", "core"], "importance": 0.9,
      "text": "LANGUAGE RULE: Detect the language the customer uses and reply in that same language throughout the conversation. If a primary language is configured, default to that."},
 ]
+
+# Per-vertical compliance seeds for the 7 SENSITIVE_DOMAIN_ROLES. Tags reuse
+# each role's existing ROLE_SKILL_TAGS domain word(s) rather than introducing
+# new tags, so the existing role-scoped tag_search/semantic_search filtering
+# (see core/employees/memory.py) surfaces these correctly without any
+# changes to ROLE_SKILL_TAGS itself. Because that filtering is an ANY-tag
+# overlap match, a couple of these tags are shared between two roles
+# (healthcare_intake/veterinary_intake both have "healthcare"; legal_intake/
+# immigration_intake both have "legal") - each seed's TEXT is written to be
+# explicitly self-scoping so a shared-tag retrieval into the "wrong" role
+# still can't cause misapplication (e.g. the HIPAA seed states outright that
+# HIPAA does not cover veterinary records).
+DEFAULT_COMPLIANCE_MEMORY_SEEDS = [
+    {"tags": ["legal", "compliance", "intake"], "importance": 0.95,
+     "text": "LEGAL INTAKE COMPLIANCE: Do not provide legal advice, predict case outcomes, or interpret law for the person's specific situation - only a licensed attorney can do this. Collect facts and documents for attorney review. Communications with this AI are NOT protected by attorney-client privilege unless a retained attorney has explicitly extended that protection to this channel - do not assume confidentiality."},
+    {"tags": ["healthcare", "compliance", "intake"], "importance": 0.95,
+     "text": "HEALTHCARE INTAKE COMPLIANCE (HIPAA): Do not diagnose, recommend specific medications or dosages, or interpret symptoms - escalate to clinical staff. Any patient health information (PHI) collected or discussed must be handled per HIPAA - do not share PHI outside this practice's authorized systems, and never repeat one patient's information in another patient's conversation. Note: HIPAA governs human patient records only and does not apply to veterinary or animal care records."},
+    {"tags": ["finance", "compliance", "policy", "claims"], "importance": 0.95,
+     "text": "INSURANCE COMPLIANCE: Never state definitively whether a specific claim is covered, approved, or denied - only a licensed agent or adjuster can make a binding coverage determination. Do not guarantee claim outcomes or timelines. Collect facts (policy number, incident details, dates) for the licensed agent's review."},
+    {"tags": ["compliance", "policy", "regulatory", "risk"], "importance": 0.95,
+     "text": "COMPLIANCE OFFICER SCOPE: Track policy adherence, flag potential regulatory risks, and help staff find the correct internal policy - do not issue a binding legal or regulatory ruling on whether a specific action, document, or contract clause is compliant. Any compliance sign-off requires a qualified legal professional or the business owner's explicit review."},
+    {"tags": ["healthcare", "intake", "scheduling", "faq"], "importance": 0.9,
+     "text": "VETERINARY INTAKE COMPLIANCE: Do not diagnose an animal's condition, recommend medications or dosages, or predict treatment outcomes - escalate to a licensed veterinarian. Collect symptoms, animal details (species, age, weight), and owner contact info for the vet's review. Human medical privacy rules (HIPAA) do not apply to veterinary records, but owner contact and payment information should still be handled carefully."},
+    {"tags": ["finance", "compliance", "documentation", "intake"], "importance": 0.9,
+     "text": "TAX PREPARATION INTAKE COMPLIANCE: Do not calculate a specific tax liability, guarantee a refund amount, or interpret tax law for the person's specific situation - only a licensed tax preparer or CPA can do this. Collect the documents and facts needed (income sources, filing status, prior-year records) for the preparer's review. Do not guess at deduction eligibility."},
+    {"tags": ["legal", "intake", "documentation", "faq"], "importance": 0.95,
+     "text": "IMMIGRATION INTAKE COMPLIANCE: Do not predict case or petition outcomes, interpret immigration law for the person's specific situation, or advise on strategy - only a licensed immigration attorney or accredited representative can do this (unauthorized practice of immigration law is a serious legal violation in most jurisdictions). Collect facts and documents for the attorney's review. Communications with this AI are not protected by attorney-client privilege unless explicitly extended by a retained attorney."},
+]
+
+DEFAULT_MEMORY_SEEDS = DEFAULT_MEMORY_SEEDS + DEFAULT_COMPLIANCE_MEMORY_SEEDS

--- a/core/employees/memory.py
+++ b/core/employees/memory.py
@@ -11,8 +11,45 @@ from typing import List, Dict, Optional
 
 from core.embedding import EmbeddingService
 from core.employees._db import get_connection
+from core.employees.defaults import DEFAULT_MEMORY_SEEDS
 
 logger = logging.getLogger(__name__)
+
+SEED_SOURCE = "default_seed"
+
+
+def seed_default_memory_seeds() -> int:
+    """
+    Seed DEFAULT_MEMORY_SEEDS (generic core seeds + the per-vertical
+    compliance seeds for SENSITIVE_DOMAIN_ROLES) into employee_memory,
+    once. Idempotent like employee_roles.seed_default_roles() - checks
+    for any existing rows with source=SEED_SOURCE first, so it's safe
+    to call on every /employees request rather than only at startup.
+    Returns the number of seeds actually inserted (0 if already seeded
+    or if a given seed row already exists via the content_hash+source
+    unique constraint in write_learned_skill).
+    """
+    conn = get_connection()
+    try:
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM employee_memory WHERE source = %s", (SEED_SOURCE,))
+        already_seeded = cur.fetchone()[0] > 0
+        cur.close()
+    finally:
+        conn.close()
+
+    if already_seeded:
+        return 0
+
+    count = 0
+    for seed in DEFAULT_MEMORY_SEEDS:
+        result = write_learned_skill(
+            text=seed["text"], tags=seed["tags"], importance=seed["importance"],
+            source=SEED_SOURCE, permanent=True,
+        )
+        if result:
+            count += 1
+    return count
 
 
 def write_learned_skill(text, tags, importance=0.7, source="interaction",

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -143,6 +143,16 @@ CREATE INDEX IF NOT EXISTS employee_memory_tags_idx
     ON employee_memory USING GIN (tags);
 CREATE INDEX IF NOT EXISTS employee_memory_hash_idx
     ON employee_memory (content_hash, source);
+-- UNIQUE index required by write_learned_skill()'s
+-- INSERT ... ON CONFLICT (content_hash, source) DO NOTHING clause.
+-- This existed live on the VPS but was missing here (schema drift,
+-- same failure mode PR #267's SENSITIVE_DOMAIN_ROLES had) - discovered
+-- when seed_default_memory_seeds() failed on a fresh CI database with
+-- "no unique or exclusion constraint matching the ON CONFLICT
+-- specification" despite working fine against the live (already-
+-- patched) VPS database.
+CREATE UNIQUE INDEX IF NOT EXISTS employee_memory_hash_source_uidx
+    ON employee_memory (content_hash, source);
 
 -- n8n workflow automation. Single-tenant — no workspace scoping.
 -- Fires a webhook after the AI replies on a matching channel; caller

--- a/tests/test_memory_seeding.py
+++ b/tests/test_memory_seeding.py
@@ -1,0 +1,102 @@
+"""
+Tests for core/employees/memory.py's seed_default_memory_seeds() -
+idempotent seeding of DEFAULT_MEMORY_SEEDS (generic + per-vertical
+compliance seeds) into employee_memory. Requires a live DB (same
+convention as test_autonomy.py/test_memory_role_scoping.py), reachable
+via DATABASE_URL.
+"""
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from core.employees.memory import seed_default_memory_seeds, SEED_SOURCE
+from core.employees.defaults import DEFAULT_MEMORY_SEEDS, DEFAULT_COMPLIANCE_MEMORY_SEEDS, SENSITIVE_DOMAIN_ROLES
+from core.employees._db import get_connection
+
+
+@pytest.fixture(autouse=True)
+def clean_employee_memory():
+    """Reset employee_memory before each test so tests do not interfere."""
+    conn = get_connection()
+    try:
+        cur = conn.cursor()
+        cur.execute("DELETE FROM employee_memory")
+        conn.commit()
+        cur.close()
+    finally:
+        conn.close()
+    yield
+
+
+def _seed_row_count():
+    conn = get_connection()
+    try:
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM employee_memory WHERE source = %s", (SEED_SOURCE,))
+        return cur.fetchone()[0]
+    finally:
+        conn.close()
+
+
+def test_seeds_all_default_memory_seeds_on_first_run():
+    count = seed_default_memory_seeds()
+    assert count == len(DEFAULT_MEMORY_SEEDS)
+    assert _seed_row_count() == len(DEFAULT_MEMORY_SEEDS)
+
+
+def test_second_run_is_a_noop():
+    first = seed_default_memory_seeds()
+    second = seed_default_memory_seeds()
+    assert first == len(DEFAULT_MEMORY_SEEDS)
+    assert second == 0
+    assert _seed_row_count() == len(DEFAULT_MEMORY_SEEDS)  # unchanged, not doubled
+
+
+def test_compliance_seeds_present_with_correct_tags():
+    seed_default_memory_seeds()
+    conn = get_connection()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT text_content, tags FROM employee_memory WHERE source = %s",
+            (SEED_SOURCE,),
+        )
+        rows = cur.fetchall()
+    finally:
+        conn.close()
+
+    all_text = " ".join(r[0] for r in rows)
+    # Every sensitive role should have a compliance seed mentioning it or
+    # its domain by name, so this isn't just "seeds got inserted" but
+    # "the RIGHT content got inserted".
+    assert "HIPAA" in all_text
+    assert "attorney-client privilege" in all_text
+    assert "coverage determination" in all_text
+    assert "unauthorized practice of immigration law" in all_text
+
+
+def test_healthcare_seed_explicitly_excludes_veterinary():
+    """Regression guard for the cross-role tag-bleed risk: healthcare_intake
+    and veterinary_intake share the 'healthcare' tag in ROLE_SKILL_TAGS, so
+    a role-scoped tag search could surface the HIPAA seed to the vet role
+    too. The seed text itself must self-scope to prevent misapplication -
+    this test fails if a future edit removes that clarifying sentence."""
+    hipaa_seed = next(s for s in DEFAULT_COMPLIANCE_MEMORY_SEEDS if "HIPAA" in s["text"])
+    assert "veterinary" in hipaa_seed["text"].lower()
+    assert "does not apply" in hipaa_seed["text"].lower()
+
+
+def test_all_seven_sensitive_roles_have_a_compliance_seed():
+    """Every role in SENSITIVE_DOMAIN_ROLES should have at least one
+    compliance seed tagged with something in that role's own domain
+    vocabulary - a coarse but real check that nobody added a role to
+    SENSITIVE_DOMAIN_ROLES without a matching compliance seed."""
+    from core.employees.defaults import ROLE_SKILL_TAGS
+    for role in SENSITIVE_DOMAIN_ROLES:
+        role_tags = set(ROLE_SKILL_TAGS.get(role, []))
+        matched = any(
+            set(seed["tags"]) & role_tags
+            for seed in DEFAULT_COMPLIANCE_MEMORY_SEEDS
+        )
+        assert matched, f"No compliance seed's tags overlap with {role}'s ROLE_SKILL_TAGS"


### PR DESCRIPTION
## Context
Item #5 from the pending-work list: "per-vertical compliance memory seeds". Turned out to be two things, not one - `DEFAULT_MEMORY_SEEDS` existed but was never actually consumed anywhere (same unwired-scaffolding pattern as `SENSITIVE_DOMAIN_ROLES` before #267), so adding role-specific seeds to it alone would have been cosmetic.

## What this does
1. **Wires up seeding**: new `seed_default_memory_seeds()` in `core/employees/memory.py`, idempotent (mirrors `employee_roles.seed_default_roles()`'s pattern), called alongside it in `GET /employees`.
2. **Adds `DEFAULT_COMPLIANCE_MEMORY_SEEDS`**: one targeted seed per `SENSITIVE_DOMAIN_ROLES` role - HIPAA (healthcare), attorney-client privilege caveats (legal/immigration), coverage-determination limits (insurance), etc. `DEFAULT_MEMORY_SEEDS` grows 12 -> 19.

## Tag design (worth reading if editing these later)
Seeds reuse each role's existing `ROLE_SKILL_TAGS` domain words rather than adding new tags, so #270's role-scoped `tag_search`/`semantic_search` filtering surfaces them correctly without touching `ROLE_SKILL_TAGS`. Since that filtering is an ANY-tag-overlap match, two role pairs share a domain tag (`healthcare_intake`/`veterinary_intake` share `"healthcare"`; `legal_intake`/`immigration_intake` share `"legal"`) - confirmed live via direct DB query that this is real, not theoretical. Each seed's **text** is written to be explicitly self-scoping (the HIPAA seed states outright it doesn't cover veterinary records) so a shared-tag retrieval into the "wrong" role still can't cause misapplication.

## Tests
New `tests/test_memory_seeding.py`, 5 tests against a live DB. Covers seed count on first run, idempotent second run, correct content (not just count), a regression guard on the HIPAA self-scoping sentence, and that every sensitive role has a tag-matching compliance seed.

## Verification
Live on the VPS: seeded 19/19 first run, 0 second run (idempotency confirmed), both healthcare-tagged seeds independently confirmed present via direct SQL. Full suite 214 -> 219 passing, 0 failures/errors.
