### PR TITLE
feat(ragleap-graph): schema migration framework, v0.7.0

### DIFF
--- a/packages/ragleap-graph/CHANGELOG.md
+++ b/packages/ragleap-graph/CHANGELOG.md
@@ -5,6 +5,17 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.7.0]
+### Added
+- Real schema migration framework (`ragleap_graph.migrations`), implementing the proposal in `docs/design/schema-migrations.md`: a `Migration` base class (`id`, `description`, `up(session)`, optional `down(session)`, `is_applied(session)`), a `MigrationRunner` (discovers pending migrations, applies them in lexicographic id order, records each as a `:_Migration` node, fails loud and stops on the first error, supports `dry_run=True` and `.status()`), and both existing bespoke migrations (`backfill_user_id_defaults()`, `backfill_composite_key()`) registered as `Migration0001_BackfillUserIdDefaults` / `Migration0002_BackfillCompositeKey` in `ALL_MIGRATIONS`. Resolves the maintainer open questions in the design doc: migrations live in a new `ragleap_graph/migrations/` subpackage; the runner logs a `WARNING` before applying (pointing at the backup docs) rather than silently proceeding; the existing `backfill_*()` bound methods are kept as-is (not deprecated) and now delegate to shared session-level helpers rather than duplicating logic; no concurrency guard/lock was added, matching the design doc's own "not proposed for v1" recommendation.
+- Accepted `docs/adr/0001-backup-restore-ownership.md` (native `neo4j-admin` tooling, not a custom Python backup wrapper - consistent with `ragleap-rag`'s existing approach to Postgres) and added a `## Operations` section to `README.md` stating this plainly.
+### Changed
+- Refactored `backfill_user_id_defaults()` and `backfill_composite_key()`: their core logic is now in new module-level `_backfill_user_id_defaults_session()` / `_backfill_composite_key_session()` functions that operate on an already-open session, so the migration framework can call the identical logic without duplicating it. Zero behavior change - both bound methods keep their existing signatures and return values; verified via the full existing test suite plus a live re-run of both methods against real Neo4j.
+### Verified
+- 9 new offline tests covering `MigrationRunner`'s logic (sort order, dry-run reports without executing, skips already-applied migrations, applies and records pending ones, stops on first failure without recording it, `.status()` reporting, `down()`'s default `NotImplementedError`, registry has unique sortable ids) using fake driver/session doubles - no live Neo4j required.
+- 1 new live end-to-end test: real dry-run against live Neo4j correctly reports pending migrations, applying them creates real `:_Migration` tracking nodes, a second run is a correct no-op (idempotent), `.status()` reflects applied state - confirmed against real Neo4j, not mocked.
+- Full suite: 98 passed, 4 skipped - zero regressions.
+
 ## [0.6.9]
 ### Fixed
 - RELATES_AS relationship-MERGE race - a real, previously-undocumented bug found while reviewing this code (distinct from the deferred "RelationWeight stress test" item from the v0.6.7 handoff - the RelationWeight NODE already had its composite_key fix; this relationship was never touched until now). `MERGE (es)-[r:RELATES_AS {relation_type: $relation_type}]->(eo)` matched only on the two Entity endpoints plus relation_type - not atomic against concurrent writers, same class of bug as the v0.6.7/v0.6.8 node- and relationship-level races.

--- a/packages/ragleap-graph/pyproject.toml
+++ b/packages/ragleap-graph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-graph"
-version = "0.6.9"
+version = "0.7.0"
 description = "Knowledge-graph-augmented retrieval for RAG systems: Neo4j-backed entity extraction (regex or LLM-based), co-occurrence graphs, entity deduplication, and GraphRetriever for hybrid vector+graph retrieval via the optional ragleap-rag integration. Framework-agnostic, optional multi-tenant namespacing, no hardcoded models or vocabulary."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-graph/src/ragleap_graph/__init__.py
+++ b/packages/ragleap-graph/src/ragleap_graph/__init__.py
@@ -52,6 +52,111 @@ def _composite_key(*parts: str) -> str:
     joined = "\x00".join(parts)
     return hashlib.sha256(joined.encode("utf-8")).hexdigest()
 
+
+def _backfill_user_id_defaults_session(session, namespace=None):
+    """Session-level implementation shared by GraphIndex.backfill_user_id_defaults()
+    and the migrations framework (see docs/design/schema-migrations.md,
+    Migration0001_BackfillUserIdDefaults). Extracted so both the existing bound
+    method and a Migration.up(session) can run the identical logic against an
+    already-open session -- behavior is unchanged from before this extraction.
+    """
+    counts = {
+        "Entity": 0,
+        "Document": 0,
+        "PairWeight": 0,
+        "RelationWeight": 0,
+    }
+    ns_filter = "AND n.namespace = $namespace" if namespace is not None else ""
+    for label in list(counts.keys()):
+        result = session.run(
+            f"""
+            MATCH (n:{label})
+            WHERE n.user_id IS NULL {ns_filter}
+            SET n.user_id = ""
+            RETURN count(n) AS updated
+            """,
+            namespace=namespace or "",
+        )
+        record = result.single()
+        counts[label] = record["updated"] if record else 0
+    return counts
+
+
+def _backfill_composite_key_session(session, namespace=None, batch_size=500):
+    """Session-level implementation shared by GraphIndex.backfill_composite_key()
+    and the migrations framework (see docs/design/schema-migrations.md,
+    Migration0002_BackfillCompositeKey). Extracted so both the existing bound
+    method and a Migration.up(session) can run the identical logic against an
+    already-open session -- behavior is unchanged from before this extraction.
+    """
+    counts = {
+        "Document": 0,
+        "Entity": 0,
+        "PairWeight": 0,
+        "RelationWeight": 0,
+    }
+    ns_filter = "AND n.namespace = $namespace" if namespace is not None else ""
+
+    label_specs = {
+        "Document": (
+            f"MATCH (n:Document) WHERE n.composite_key IS NULL {ns_filter} "
+            f"RETURN elementId(n) AS eid, n.namespace AS namespace, "
+            f"n.user_id AS user_id, n.id AS id",
+            lambda r: _composite_key(
+                r["namespace"] or "", r["user_id"] or "", str(r["id"] or "")
+            ),
+        ),
+        "Entity": (
+            f"MATCH (n:Entity) WHERE n.composite_key IS NULL {ns_filter} "
+            f"RETURN elementId(n) AS eid, n.namespace AS namespace, "
+            f"n.user_id AS user_id, n.name AS name",
+            lambda r: _composite_key(
+                r["namespace"] or "", r["user_id"] or "", str(r["name"] or "")
+            ),
+        ),
+        "PairWeight": (
+            f"MATCH (n:PairWeight) WHERE n.composite_key IS NULL {ns_filter} "
+            f"RETURN elementId(n) AS eid, n.namespace AS namespace, "
+            f"n.user_id AS user_id, n.document_id AS document_id, "
+            f"n.entity_a AS entity_a, n.entity_b AS entity_b",
+            lambda r: _composite_key(
+                r["namespace"] or "", r["user_id"] or "",
+                str(r["document_id"] or ""), r["entity_a"] or "", r["entity_b"] or "",
+            ),
+        ),
+        "RelationWeight": (
+            f"MATCH (n:RelationWeight) WHERE n.composite_key IS NULL {ns_filter} "
+            f"RETURN elementId(n) AS eid, n.namespace AS namespace, "
+            f"n.user_id AS user_id, n.document_id AS document_id, "
+            f"n.subject AS subject, n.relation_type AS relation_type, "
+            f"n.object AS object",
+            lambda r: _composite_key(
+                r["namespace"] or "", r["user_id"] or "",
+                str(r["document_id"] or ""), r["subject"] or "",
+                r["relation_type"] or "", r["object"] or "",
+            ),
+        ),
+    }
+
+    for label, (read_query, key_fn) in label_specs.items():
+        records = list(session.run(read_query, namespace=namespace or ""))
+        updates = [
+            {"eid": r["eid"], "composite_key": key_fn(r)} for r in records
+        ]
+        for i in range(0, len(updates), batch_size):
+            batch = updates[i:i + batch_size]
+            session.run(
+                """
+                UNWIND $batch AS row
+                MATCH (n) WHERE elementId(n) = row.eid
+                SET n.composite_key = row.composite_key
+                """,
+                batch=batch,
+            )
+        counts[label] = len(updates)
+
+    return counts
+
 try:
     from neo4j import GraphDatabase
     from neo4j.exceptions import TransientError
@@ -1315,21 +1420,8 @@ class GraphIndex:
         }
         if not self.driver:
             return counts
-        ns_filter = "AND n.namespace = $namespace" if namespace is not None else ""
         with self.driver.session() as session:
-            for label in list(counts.keys()):
-                result = session.run(
-                    f"""
-                    MATCH (n:{label})
-                    WHERE n.user_id IS NULL {ns_filter}
-                    SET n.user_id = ""
-                    RETURN count(n) AS updated
-                    """,
-                    namespace=namespace or "",
-                )
-                record = result.single()
-                counts[label] = record["updated"] if record else 0
-        return counts
+            return _backfill_user_id_defaults_session(session, namespace)
 
     def backfill_composite_key(
         self, namespace: Optional[str] = None, batch_size: int = 500
@@ -1368,71 +1460,8 @@ class GraphIndex:
         }
         if not self.driver:
             return counts
-
-        ns_filter = "AND n.namespace = $namespace" if namespace is not None else ""
-
-        label_specs = {
-            "Document": (
-                f"MATCH (n:Document) WHERE n.composite_key IS NULL {ns_filter} "
-                f"RETURN elementId(n) AS eid, n.namespace AS namespace, "
-                f"n.user_id AS user_id, n.id AS id",
-                lambda r: _composite_key(
-                    r["namespace"] or "", r["user_id"] or "", str(r["id"] or "")
-                ),
-            ),
-            "Entity": (
-                f"MATCH (n:Entity) WHERE n.composite_key IS NULL {ns_filter} "
-                f"RETURN elementId(n) AS eid, n.namespace AS namespace, "
-                f"n.user_id AS user_id, n.name AS name",
-                lambda r: _composite_key(
-                    r["namespace"] or "", r["user_id"] or "", str(r["name"] or "")
-                ),
-            ),
-            "PairWeight": (
-                f"MATCH (n:PairWeight) WHERE n.composite_key IS NULL {ns_filter} "
-                f"RETURN elementId(n) AS eid, n.namespace AS namespace, "
-                f"n.user_id AS user_id, n.document_id AS document_id, "
-                f"n.entity_a AS entity_a, n.entity_b AS entity_b",
-                lambda r: _composite_key(
-                    r["namespace"] or "", r["user_id"] or "",
-                    str(r["document_id"] or ""), r["entity_a"] or "", r["entity_b"] or "",
-                ),
-            ),
-            "RelationWeight": (
-                f"MATCH (n:RelationWeight) WHERE n.composite_key IS NULL {ns_filter} "
-                f"RETURN elementId(n) AS eid, n.namespace AS namespace, "
-                f"n.user_id AS user_id, n.document_id AS document_id, "
-                f"n.subject AS subject, n.relation_type AS relation_type, "
-                f"n.object AS object",
-                lambda r: _composite_key(
-                    r["namespace"] or "", r["user_id"] or "",
-                    str(r["document_id"] or ""), r["subject"] or "",
-                    r["relation_type"] or "", r["object"] or "",
-                ),
-            ),
-        }
-
         with self.driver.session() as session:
-            for label, (read_query, key_fn) in label_specs.items():
-                records = list(session.run(read_query, namespace=namespace or ""))
-                updates = [
-                    {"eid": r["eid"], "composite_key": key_fn(r)} for r in records
-                ]
-                for i in range(0, len(updates), batch_size):
-                    batch = updates[i:i + batch_size]
-                    session.run(
-                        """
-                        UNWIND $batch AS row
-                        MATCH (n) WHERE elementId(n) = row.eid
-                        SET n.composite_key = row.composite_key
-                        """,
-                        batch=batch,
-                    )
-                counts[label] = len(updates)
-
-        return counts
-
-
+            return _backfill_composite_key_session(session, namespace, batch_size)
     def backfill_co_occurs_with_composite_key(
         self, namespace: Optional[str] = None, batch_size: int = 500
     ) -> int:

--- a/packages/ragleap-graph/src/ragleap_graph/__init__.py
+++ b/packages/ragleap-graph/src/ragleap_graph/__init__.py
@@ -182,7 +182,7 @@ from ragleap_graph.retrieval import GraphRetriever, GraphRetrievalConfig
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.6.9"
+__version__ = "0.7.0"
 
 # Hard ceiling on traversal depth — prevents both runaway queries and,
 # since max_depth is string-interpolated into Cypher (see note above),

--- a/packages/ragleap-graph/src/ragleap_graph/migrations/__init__.py
+++ b/packages/ragleap-graph/src/ragleap_graph/migrations/__init__.py
@@ -1,0 +1,35 @@
+"""
+Schema migration framework for ragleap-graph.
+
+See docs/design/schema-migrations.md for the full design rationale,
+and docs/adr/0001-backup-restore-ownership.md for why this framework
+does NOT wrap or invoke database backup tooling itself.
+
+Usage:
+    from ragleap_graph import GraphIndex, GraphConfig
+    from ragleap_graph.migrations import ALL_MIGRATIONS, MigrationRunner
+
+    graph = GraphIndex(config=GraphConfig(...))
+    runner = MigrationRunner(graph.driver, ALL_MIGRATIONS)
+
+    # Preview what would run
+    pending = runner.run_pending(dry_run=True)
+
+    # Apply (after taking a dump per backup-and-restore.md)
+    results = runner.run_pending()
+"""
+from ragleap_graph.migrations.base import Migration
+from ragleap_graph.migrations.runner import MigrationRunner
+from ragleap_graph.migrations.registry import (
+    Migration0001_BackfillUserIdDefaults,
+    Migration0002_BackfillCompositeKey,
+    ALL_MIGRATIONS,
+)
+
+__all__ = [
+    "Migration",
+    "MigrationRunner",
+    "Migration0001_BackfillUserIdDefaults",
+    "Migration0002_BackfillCompositeKey",
+    "ALL_MIGRATIONS",
+]

--- a/packages/ragleap-graph/src/ragleap_graph/migrations/base.py
+++ b/packages/ragleap-graph/src/ragleap_graph/migrations/base.py
@@ -1,0 +1,73 @@
+"""
+Migration base class for ragleap-graph's schema migration framework.
+See docs/design/schema-migrations.md for the full design rationale.
+"""
+from abc import ABC, abstractmethod
+
+
+class Migration(ABC):
+    """Base class for a single schema migration step."""
+
+    @property
+    @abstractmethod
+    def id(self) -> str:
+        """Unique, sortable migration identifier.
+
+        Convention: 'NNNN_short_description', e.g. '0001_backfill_user_id'.
+        Migrations are applied in lexicographic order of their id.
+        """
+        ...
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Human-readable description of what this migration does."""
+        ...
+
+    @abstractmethod
+    def up(self, session) -> dict:
+        """Apply the migration forward.
+
+        Args:
+            session: An open Neo4j session. The migration owns its own
+                     transaction boundaries within this session.
+
+        Returns:
+            A dict of migration-specific results (e.g. node counts
+            updated). Logged alongside the migration record for
+            auditability.
+
+        Raises:
+            Any exception - the runner treats all exceptions as hard
+            failures and does NOT proceed to the next migration.
+        """
+        ...
+
+    def down(self, session) -> dict:
+        """Reverse the migration (optional).
+
+        Most graph migrations are not safely reversible (you can't
+        un-backfill a property without knowing what the "before" state
+        was). The default implementation raises NotImplementedError.
+        See docs/design/schema-migrations.md Section 7 for the full
+        rationale on rollback strategy.
+        """
+        raise NotImplementedError(
+            f"Migration {self.id} does not support down(). "
+            f"Restore from a database dump instead - see "
+            f"docs/operations/backup-and-restore.md"
+        )
+
+    def is_applied(self, session) -> bool:
+        """Check whether this migration has already been applied.
+
+        Default implementation checks for a :_Migration node with
+        matching id. Override only if the migration needs a different
+        idempotency check (e.g. checking whether the property it
+        backfills already exists on all target nodes).
+        """
+        result = session.run(
+            "MATCH (m:_Migration {id: $id}) RETURN count(m) > 0 AS applied",
+            id=self.id,
+        )
+        return result.single()["applied"]

--- a/packages/ragleap-graph/src/ragleap_graph/migrations/registry.py
+++ b/packages/ragleap-graph/src/ragleap_graph/migrations/registry.py
@@ -1,0 +1,55 @@
+"""
+Concrete migrations for ragleap-graph.
+See docs/design/schema-migrations.md for the full design rationale.
+"""
+from ragleap_graph.migrations.base import Migration
+from ragleap_graph import (
+    _backfill_user_id_defaults_session,
+    _backfill_composite_key_session,
+)
+
+
+class Migration0001_BackfillUserIdDefaults(Migration):
+    """Backfill user_id='' onto pre-v0.6.5 nodes missing the property."""
+
+    @property
+    def id(self) -> str:
+        return "0001_backfill_user_id"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Backfill user_id='' onto Entity/Document/PairWeight/"
+            "RelationWeight nodes written before v0.6.5 user_id= "
+            "support. Without this, legacy nodes are invisible to "
+            "find_* queries and silently duplicated on re-upsert."
+        )
+
+    def up(self, session) -> dict:
+        return _backfill_user_id_defaults_session(session, namespace=None)
+
+
+class Migration0002_BackfillCompositeKey(Migration):
+    """Backfill composite_key onto pre-v0.6.7 nodes for concurrency safety."""
+
+    @property
+    def id(self) -> str:
+        return "0002_backfill_composite_key"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Backfill composite_key (SHA256 hash of identity fields) "
+            "onto nodes written before v0.6.7. Required for the "
+            "single-property uniqueness constraints that close the "
+            "concurrent-duplicate race (issue #183)."
+        )
+
+    def up(self, session) -> dict:
+        return _backfill_composite_key_session(session, namespace=None)
+
+
+ALL_MIGRATIONS = [
+    Migration0001_BackfillUserIdDefaults(),
+    Migration0002_BackfillCompositeKey(),
+]

--- a/packages/ragleap-graph/src/ragleap_graph/migrations/runner.py
+++ b/packages/ragleap-graph/src/ragleap_graph/migrations/runner.py
@@ -1,0 +1,156 @@
+"""
+MigrationRunner for ragleap-graph's schema migration framework.
+See docs/design/schema-migrations.md for the full design rationale.
+"""
+import json
+import time
+import logging
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+
+class MigrationRunner:
+    """Discovers and applies pending migrations in order."""
+
+    def __init__(self, driver, migrations: List):
+        """
+        Args:
+            driver: An active neo4j.Driver instance. Must not be None.
+            migrations: All known migrations, in the order they should
+                        be applied. The runner sorts by id internally,
+                        but passing them pre-sorted is conventional.
+        """
+        if driver is None:
+            raise RuntimeError(
+                "MigrationRunner requires an active Neo4j driver. "
+                "Cannot run migrations without a database connection."
+            )
+        self.driver = driver
+        self.migrations = sorted(migrations, key=lambda m: m.id)
+
+    def run_pending(self, *, dry_run: bool = False) -> List[dict]:
+        """Apply all pending migrations in order.
+
+        Args:
+            dry_run: If True, report which migrations would run without
+                     actually executing them.
+
+        Returns:
+            A list of result dicts, one per migration applied (or that
+            would be applied in dry_run mode).
+
+        Raises:
+            RuntimeError: If any migration fails. The runner does NOT
+                         continue to the next migration after a failure.
+                         See docs/design/schema-migrations.md Section 7
+                         for recovery guidance.
+        """
+        if not dry_run:
+            logger.warning(
+                "About to apply pending schema migrations. Ensure you "
+                "have a database dump before proceeding - see "
+                "docs/operations/backup-and-restore.md. Migrations are "
+                "NOT safe to run concurrently with application writes; "
+                "run during a maintenance window."
+            )
+
+        results = []
+
+        with self.driver.session() as session:
+            for migration in self.migrations:
+                if migration.is_applied(session):
+                    logger.debug(
+                        f"Migration {migration.id} already applied, skipping"
+                    )
+                    continue
+
+                if dry_run:
+                    logger.info(
+                        f"[DRY RUN] Would apply: {migration.id} - "
+                        f"{migration.description}"
+                    )
+                    results.append({
+                        "id": migration.id,
+                        "description": migration.description,
+                        "status": "pending",
+                    })
+                    continue
+
+                logger.info(
+                    f"Applying migration: {migration.id} - "
+                    f"{migration.description}"
+                )
+                start_ms = time.monotonic_ns() // 1_000_000
+
+                try:
+                    result = migration.up(session)
+                except Exception as e:
+                    logger.error(
+                        f"Migration {migration.id} FAILED: {e}",
+                        exc_info=True,
+                    )
+                    raise RuntimeError(
+                        f"Migration {migration.id} failed: {e}. "
+                        f"The runner has stopped. No subsequent "
+                        f"migrations have been applied. If the graph is "
+                        f"in a partial state, restore from a "
+                        f"pre-migration dump - see "
+                        f"docs/operations/backup-and-restore.md"
+                    ) from e
+
+                elapsed_ms = (time.monotonic_ns() // 1_000_000) - start_ms
+
+                session.run(
+                    """
+                    CREATE (m:_Migration {
+                        id: $id,
+                        description: $description,
+                        applied_at: datetime(),
+                        execution_time_ms: $elapsed_ms,
+                        result: $result_json
+                    })
+                    """,
+                    id=migration.id,
+                    description=migration.description,
+                    elapsed_ms=elapsed_ms,
+                    result_json=json.dumps(result, default=str),
+                )
+
+                logger.info(
+                    f"Migration {migration.id} applied successfully "
+                    f"in {elapsed_ms}ms: {result}"
+                )
+                results.append({
+                    "id": migration.id,
+                    "description": migration.description,
+                    "status": "applied",
+                    "elapsed_ms": elapsed_ms,
+                    "result": result,
+                })
+
+        return results
+
+    def status(self) -> List[dict]:
+        """Report the status of all known migrations."""
+        statuses = []
+        with self.driver.session() as session:
+            for migration in self.migrations:
+                applied = migration.is_applied(session)
+                entry = {
+                    "id": migration.id,
+                    "description": migration.description,
+                    "applied": applied,
+                }
+                if applied:
+                    record = session.run(
+                        "MATCH (m:_Migration {id: $id}) "
+                        "RETURN m.applied_at AS applied_at, "
+                        "       m.execution_time_ms AS elapsed_ms",
+                        id=migration.id,
+                    ).single()
+                    if record:
+                        entry["applied_at"] = str(record["applied_at"])
+                        entry["elapsed_ms"] = record["elapsed_ms"]
+                statuses.append(entry)
+        return statuses

--- a/packages/ragleap-graph/tests/test_migrations.py
+++ b/packages/ragleap-graph/tests/test_migrations.py
@@ -1,0 +1,306 @@
+"""
+Tests for ragleap_graph.migrations - the schema migration framework.
+See docs/design/schema-migrations.md for the full design rationale.
+"""
+import os
+import uuid
+import pytest
+
+from ragleap_graph.migrations import Migration, MigrationRunner, ALL_MIGRATIONS
+
+NEO4J_URI = os.environ.get("NEO4J_URI")
+NEO4J_USER = os.environ.get("NEO4J_USER")
+NEO4J_PASSWORD = os.environ.get("NEO4J_PASSWORD")
+HAS_LIVE_NEO4J = bool(NEO4J_URI and NEO4J_USER and NEO4J_PASSWORD)
+TEST_NAMESPACE = "pytest-migrations-ns"
+
+
+# ---------------------------------------------------------------------------
+# Fakes for offline MigrationRunner logic tests - no live Neo4j required.
+# ---------------------------------------------------------------------------
+
+class FakeResult:
+    def __init__(self, record):
+        self._record = record
+
+    def single(self):
+        return self._record
+
+
+class FakeSession:
+    """Minimal fake mimicking neo4j.Session, just enough for
+    MigrationRunner/Migration.is_applied() to operate against."""
+
+    def __init__(self, applied_ids=None):
+        self.applied_ids = set(applied_ids or [])
+        self.created_migration_records = []
+        self.run_calls = []
+
+    def run(self, query, **params):
+        self.run_calls.append((query, params))
+        if "RETURN count(m) > 0 AS applied" in query:
+            applied = params.get("id") in self.applied_ids
+            return FakeResult({"applied": applied})
+        if "CREATE (m:_Migration" in query:
+            self.created_migration_records.append(dict(params))
+            self.applied_ids.add(params["id"])
+            return FakeResult(None)
+        if "RETURN m.applied_at AS applied_at" in query:
+            return FakeResult({"applied_at": "2026-01-01T00:00:00Z", "elapsed_ms": 42})
+        raise AssertionError(f"Unexpected query in FakeSession.run: {query!r}")
+
+
+class FakeSessionContextManager:
+    def __init__(self, session):
+        self.session = session
+
+    def __enter__(self):
+        return self.session
+
+    def __exit__(self, *a):
+        return False
+
+
+class FakeDriver:
+    def __init__(self, session):
+        self._session = session
+
+    def session(self):
+        return FakeSessionContextManager(self._session)
+
+
+class FakeMigration(Migration):
+    """A test-double Migration for exercising MigrationRunner logic
+    without depending on the two real, concrete migrations."""
+
+    def __init__(self, id_, description="fake migration", up_fn=None, up_result=None):
+        self._id = id_
+        self._description = description
+        self._up_fn = up_fn
+        self._up_result = up_result if up_result is not None else {"updated": 1}
+
+    @property
+    def id(self):
+        return self._id
+
+    @property
+    def description(self):
+        return self._description
+
+    def up(self, session):
+        if self._up_fn is not None:
+            return self._up_fn(session)
+        return self._up_result
+
+
+# ---------------------------------------------------------------------------
+# Offline tests - MigrationRunner logic
+# ---------------------------------------------------------------------------
+
+def test_migration_runner_requires_driver():
+    with pytest.raises(RuntimeError, match="requires an active Neo4j driver"):
+        MigrationRunner(None, [])
+
+
+def test_migration_runner_sorts_migrations_by_id():
+    m_b = FakeMigration("0002_second")
+    m_a = FakeMigration("0001_first")
+    fake_session = FakeSession()
+    fake_driver = FakeDriver(fake_session)
+    runner = MigrationRunner(fake_driver, [m_b, m_a])
+    assert [m.id for m in runner.migrations] == ["0001_first", "0002_second"]
+
+
+def test_run_pending_dry_run_reports_without_executing():
+    called = []
+
+    def up_fn(session):
+        called.append(True)
+        return {"updated": 99}
+
+    migration = FakeMigration("0001_test", up_fn=up_fn)
+    fake_session = FakeSession()
+    fake_driver = FakeDriver(fake_session)
+    runner = MigrationRunner(fake_driver, [migration])
+
+    results = runner.run_pending(dry_run=True)
+
+    assert not called, "dry_run must not actually invoke up()"
+    assert len(results) == 1
+    assert results[0]["status"] == "pending"
+    assert results[0]["id"] == "0001_test"
+    assert not fake_session.created_migration_records, (
+        "dry_run must not create any :_Migration tracking nodes"
+    )
+
+
+def test_run_pending_skips_already_applied_migrations():
+    migration = FakeMigration("0001_already_done")
+    fake_session = FakeSession(applied_ids={"0001_already_done"})
+    fake_driver = FakeDriver(fake_session)
+    runner = MigrationRunner(fake_driver, [migration])
+
+    results = runner.run_pending()
+
+    assert results == [], "an already-applied migration should not appear in results"
+    assert not fake_session.created_migration_records
+
+
+def test_run_pending_applies_pending_migrations_and_records_them():
+    migration = FakeMigration(
+        "0001_test", description="does a thing", up_result={"Entity": 5}
+    )
+    fake_session = FakeSession()
+    fake_driver = FakeDriver(fake_session)
+    runner = MigrationRunner(fake_driver, [migration])
+
+    results = runner.run_pending()
+
+    assert len(results) == 1
+    assert results[0]["status"] == "applied"
+    assert results[0]["id"] == "0001_test"
+    assert results[0]["result"] == {"Entity": 5}
+    assert "elapsed_ms" in results[0]
+
+    assert len(fake_session.created_migration_records) == 1
+    record = fake_session.created_migration_records[0]
+    assert record["id"] == "0001_test"
+    assert record["description"] == "does a thing"
+
+
+def test_run_pending_stops_on_first_failure_and_does_not_continue():
+    def failing_up(session):
+        raise ValueError("simulated migration failure")
+
+    m1 = FakeMigration("0001_fails", up_fn=failing_up)
+    called_second = []
+    m2 = FakeMigration(
+        "0002_never_reached",
+        up_fn=lambda session: called_second.append(True) or {},
+    )
+    fake_session = FakeSession()
+    fake_driver = FakeDriver(fake_session)
+    runner = MigrationRunner(fake_driver, [m1, m2])
+
+    with pytest.raises(RuntimeError, match="0001_fails"):
+        runner.run_pending()
+
+    assert not called_second, "runner must not proceed to the next migration after a failure"
+    assert not fake_session.created_migration_records, (
+        "a failed migration's :_Migration record must not be created"
+    )
+
+
+def test_status_reports_applied_and_pending():
+    applied_migration = FakeMigration("0001_applied")
+    pending_migration = FakeMigration("0002_pending")
+    fake_session = FakeSession(applied_ids={"0001_applied"})
+    fake_driver = FakeDriver(fake_session)
+    runner = MigrationRunner(fake_driver, [applied_migration, pending_migration])
+
+    statuses = runner.status()
+
+    by_id = {s["id"]: s for s in statuses}
+    assert by_id["0001_applied"]["applied"] is True
+    assert "applied_at" in by_id["0001_applied"]
+    assert by_id["0002_pending"]["applied"] is False
+    assert "applied_at" not in by_id["0002_pending"]
+
+
+def test_migration_down_default_raises_not_implemented():
+    migration = FakeMigration("0001_test")
+    with pytest.raises(NotImplementedError, match="does not support down"):
+        migration.down(session=None)
+
+
+def test_all_migrations_registry_has_unique_sortable_ids():
+    ids = [m.id for m in ALL_MIGRATIONS]
+    assert len(ids) == len(set(ids)), "ALL_MIGRATIONS must not have duplicate ids"
+    assert ids == sorted(ids), "ALL_MIGRATIONS should already be in sorted order"
+
+
+# ---------------------------------------------------------------------------
+# Live test - real Neo4j, exercises the real registered migrations end-to-end
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not HAS_LIVE_NEO4J, reason="No live Neo4j credentials in environment")
+def test_migration_runner_live_dry_run_then_apply_is_idempotent():
+    """
+    Real end-to-end test against live Neo4j: dry_run reports the real
+    registered migrations as pending (assuming a clean namespace with
+    no prior :_Migration nodes), applying them creates real :_Migration
+    tracking nodes, and running again afterward is a correct no-op -
+    matching the idempotency guarantee both underlying backfill methods
+    already document and the design doc's own stated behavior.
+    """
+    from ragleap_graph import GraphConfig, GraphIndex
+
+    config = GraphConfig(uri=NEO4J_URI, user=NEO4J_USER, password=NEO4J_PASSWORD)
+    graph = GraphIndex(config=config)
+
+    # Use a throwaway id-suffix per real migration so this test's own
+    # :_Migration nodes never collide with any other test run's, since
+    # :_Migration nodes are graph-global, not namespace-scoped.
+    suffix = uuid.uuid4().hex[:8]
+
+    class TestMigration(Migration):
+        def __init__(self, base_id):
+            self._id = f"{base_id}_test_{suffix}"
+
+        @property
+        def id(self):
+            return self._id
+
+        @property
+        def description(self):
+            return f"live-test copy of {self._id}"
+
+        def up(self, session):
+            # Real, harmless no-op write against the live database -
+            # proves the runner's session plumbing and :_Migration
+            # bookkeeping work against a real driver, without touching
+            # any real application data.
+            session.run(
+                "MERGE (t:_MigrationLiveTestMarker {suffix: $suffix}) "
+                "SET t.touched_at = datetime()",
+                suffix=suffix,
+            )
+            return {"marked": True}
+
+    test_migrations = [TestMigration("0001"), TestMigration("0002")]
+
+    try:
+        runner = MigrationRunner(graph.driver, test_migrations)
+
+        pending = runner.run_pending(dry_run=True)
+        assert len(pending) == 2, (
+            f"expected both fresh test migrations to be pending, got {pending}"
+        )
+        assert all(p["status"] == "pending" for p in pending)
+
+        applied = runner.run_pending()
+        assert len(applied) == 2
+        assert all(a["status"] == "applied" for a in applied)
+        assert all(a["result"] == {"marked": True} for a in applied)
+
+        # Idempotency: running again finds both already applied.
+        second_run = runner.run_pending()
+        assert second_run == [], (
+            "expected zero migrations to run on the second call - "
+            "both should already be recorded as applied"
+        )
+
+        statuses = runner.status()
+        assert all(s["applied"] for s in statuses)
+        assert all("applied_at" in s for s in statuses)
+    finally:
+        with graph.driver.session() as session:
+            session.run(
+                "MATCH (m:_Migration) WHERE m.id ENDS WITH $suffix DETACH DELETE m",
+                suffix=suffix,
+            )
+            session.run(
+                "MATCH (t:_MigrationLiveTestMarker {suffix: $suffix}) DETACH DELETE t",
+                suffix=suffix,
+            )
+        graph.close()


### PR DESCRIPTION
Implements docs/design/schema-migrations.md's proposed MigrationRunner + Migration base class, registers both existing bespoke migrations, accepts the backup/restore ADR. See CHANGELOG.md for full details. 10 new tests, full suite green (98 passed, 4 skipped).