### PR TITLE
feat: wire owner approval/rejection into the learning system

### DIFF
--- a/core/autonomy.py
+++ b/core/autonomy.py
@@ -38,6 +38,7 @@ from datetime import datetime, timezone
 from typing import Callable, Dict, List, Optional
 
 from core.employees._db import get_connection
+from core.employees import learning as employee_learning
 
 logger = logging.getLogger(__name__)
 
@@ -302,10 +303,16 @@ def process_approval_response(message: str) -> Optional[str]:
 
     if not approved:
         log_autonomous_action(action_type, channel, target, content, "REJECTED by owner", approved=False, role=role)
+        employee_learning.learn_from_owner_approval(
+            action_type, content, "REJECTED by owner", approved=False
+        )
         return f"Action {action_id} rejected and cancelled."
 
     result = _send_via_channel(channel, target, content)
     log_autonomous_action(action_type, channel, target, content, result, approved=True, role=role)
+    employee_learning.learn_from_owner_approval(
+        action_type, content, result, approved=True
+    )
     return f"Action {action_id} approved and executed.\n{result}"
 
 

--- a/core/employees/learning.py
+++ b/core/employees/learning.py
@@ -47,10 +47,24 @@ def learn_from_conversation(channel, user_message, ai_reply, resolved=True, scor
                                 importance=min(score, 0.85), source="conversation")
 
 
-def learn_from_owner_approval(action_type, action_detail, outcome):
-    text = f"OWNER APPROVED ACTION [{action_type}]: {action_detail[:300]}\nOutcome: {outcome[:200]}"
-    memory.write_learned_skill(text=text, tags=["learned_pattern", "approval", "owner_approved", action_type],
-                                importance=0.95, source="owner_approval", permanent=True)
+def learn_from_owner_approval(action_type, action_detail, outcome, approved: bool = True):
+    """
+    Records the owner's real approve/reject decision on a proposed
+    autonomous action as a learned skill. Rejections are recorded
+    distinctly (not mislabeled as approvals) - this is the raw
+    material a future auto-improvement loop over autonomy_log
+    rejections would read from (Issue #258 / pending item #6),
+    and on its own already lets retrieval surface "the owner
+    rejected this kind of action before" as context for a role
+    considering a similar action again.
+    """
+    if approved:
+        text = f"OWNER APPROVED ACTION [{action_type}]: {action_detail[:300]}\nOutcome: {outcome[:200]}"
+        tags = ["learned_pattern", "approval", "owner_approved", action_type]
+    else:
+        text = f"OWNER REJECTED ACTION [{action_type}]: {action_detail[:300]}\nReason/outcome: {outcome[:200]}"
+        tags = ["learned_pattern", "approval", "owner_rejected", action_type]
+    memory.write_learned_skill(text=text, tags=tags, importance=0.95, source="owner_approval", permanent=True)
 
 
 def learn_from_lead_capture(lead_info, channel):

--- a/tests/test_learning.py
+++ b/tests/test_learning.py
@@ -1,0 +1,55 @@
+"""
+Tests for core/employees/learning.py's learn_from_owner_approval() -
+records the owner's real approve/reject decision as a learned skill,
+distinctly for each outcome (not mislabeling a rejection as an
+approval). write_learned_skill is mocked, no live DB/API needed.
+"""
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from core.employees import learning
+
+
+def test_approved_action_recorded_as_approved():
+    with patch.object(learning.memory, "write_learned_skill") as mock_write:
+        learning.learn_from_owner_approval("send_email", "Send invoice to client", "sent OK", approved=True)
+    assert mock_write.call_count == 1
+    _, kwargs = mock_write.call_args
+    assert "OWNER APPROVED ACTION" in kwargs["text"]
+    assert "owner_approved" in kwargs["tags"]
+    assert "owner_rejected" not in kwargs["tags"]
+    assert kwargs["source"] == "owner_approval"
+
+
+def test_rejected_action_recorded_as_rejected_not_approved():
+    with patch.object(learning.memory, "write_learned_skill") as mock_write:
+        learning.learn_from_owner_approval("send_email", "Send invoice to client", "REJECTED by owner", approved=False)
+    assert mock_write.call_count == 1
+    _, kwargs = mock_write.call_args
+    assert "OWNER REJECTED ACTION" in kwargs["text"]
+    assert "OWNER APPROVED ACTION" not in kwargs["text"]
+    assert "owner_rejected" in kwargs["tags"]
+    assert "owner_approved" not in kwargs["tags"]
+
+
+def test_default_approved_true_for_backward_compatibility():
+    """approved defaults to True so any other/future caller that
+    doesn't pass it keeps the original approved-only behavior."""
+    with patch.object(learning.memory, "write_learned_skill") as mock_write:
+        learning.learn_from_owner_approval("send_email", "detail", "outcome")
+    _, kwargs = mock_write.call_args
+    assert "OWNER APPROVED ACTION" in kwargs["text"]
+
+
+def test_action_type_included_in_tags_for_both_outcomes():
+    with patch.object(learning.memory, "write_learned_skill") as mock_write:
+        learning.learn_from_owner_approval("post_to_slack", "detail", "outcome", approved=True)
+    _, kwargs = mock_write.call_args
+    assert "post_to_slack" in kwargs["tags"]
+
+    with patch.object(learning.memory, "write_learned_skill") as mock_write:
+        learning.learn_from_owner_approval("post_to_slack", "detail", "outcome", approved=False)
+    _, kwargs = mock_write.call_args
+    assert "post_to_slack" in kwargs["tags"]


### PR DESCRIPTION
## Context
Investigating item #6 (auto-improvement loop from `autonomy_log` rejections) surfaced a bigger, real finding: 6 of 7 `learn_from_*` functions in `core/employees/learning.py` are fully built but never called from live code - only `learn_from_owner_instruction` was wired. Confirmed on the live VPS: despite many `/chat` calls this session, `employee_memory` had zero rows from any real interaction-learning source, only our own seed data.

## What this does
Wires the clearest one first: `learn_from_owner_approval`, into both branches of `process_approval_response()`'s `"YES <id>"`/`"NO <id>"` owner-reply flow - which already has an unambiguous, real signal, unlike e.g. `learn_from_conversation` which needs a "resolved" concept that doesn't exist yet.

Generalized the function (`approved: bool = True`) rather than adding a duplicate rejection variant - a rejection is recorded distinctly (`"OWNER REJECTED ACTION"`, tags include `owner_rejected` not `owner_approved`) rather than mislabeled as an approval. `approved` defaults `True` for backward compatibility.

This is the actual raw material a real item #6 loop would read from - `autonomy_log` already recorded rejections as structured rows, but nothing turned them into retrievable, role-scoped memory content a future role could learn from before repeating the same mistake.

## Tests
New `tests/test_learning.py`, 4 tests, `write_learned_skill` mocked, no live DB needed.

Full suite: 219 -> 223 passing.
