### PR TITLE
feat: wire learn_from_conversation into /chat/feedback

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -158,6 +158,14 @@ class ChannelRoleRequest(BaseModel):
 class MemoryFeedbackRequest(BaseModel):
     role_memory_ids: list[str]
     success: bool
+    # Optional: when supplied alongside a successful outcome, the
+    # exchange is also recorded as a new learned skill via
+    # learn_from_conversation (not just reinforcing existing
+    # memories via role_memory_ids). Omit these to keep the original
+    # reinforce-only behavior - fully backward compatible.
+    channel: str | None = None
+    user_message: str | None = None
+    ai_reply: str | None = None
 
 
 class DataSourceCreateRequest(BaseModel):
@@ -316,6 +324,11 @@ def chat_feedback(req: MemoryFeedbackRequest):
     updated = employee_learning.record_role_memory_outcome(
         req.role_memory_ids, success=req.success
     )
+    if req.channel and req.user_message and req.ai_reply:
+        employee_learning.learn_from_conversation(
+            req.channel, req.user_message, req.ai_reply,
+            resolved=req.success, score=0.85 if req.success else 0.3,
+        )
     return {"updated": updated}
 
 

--- a/tests/test_chat_feedback.py
+++ b/tests/test_chat_feedback.py
@@ -1,0 +1,81 @@
+"""
+Tests for core/api.py's /chat/feedback endpoint (chat_feedback function
+called directly, not via HTTP/TestClient - it's a plain function under
+the @app.post decorator). Covers the new optional channel/user_message/
+ai_reply fields that additionally record a learned skill via
+learn_from_conversation, on top of the existing reinforce-only
+behavior via record_role_memory_outcome. employee_learning is mocked,
+no live DB/API needed.
+
+Requires DATABASE_URL to be set before import (core/api.py's module-
+level setup needs it), even though these tests themselves don't touch
+the DB - see the DATABASE_URL default below.
+"""
+import os
+import sys
+from unittest.mock import patch
+
+os.environ.setdefault("DATABASE_URL", "postgresql://ragleap:ragleap@localhost:5433/ragleap_core")
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from core.api import chat_feedback, MemoryFeedbackRequest, employee_learning
+
+
+def test_feedback_without_conversation_fields_only_reinforces():
+    """Backward compatibility: existing callers that only send
+    role_memory_ids/success get the original reinforce-only behavior -
+    learn_from_conversation must NOT be called."""
+    req = MemoryFeedbackRequest(role_memory_ids=["abc-123"], success=True)
+    with patch.object(employee_learning, "record_role_memory_outcome", return_value=1) as mock_reinforce, \
+         patch.object(employee_learning, "learn_from_conversation") as mock_learn:
+        result = chat_feedback(req)
+    assert result == {"updated": 1}
+    mock_reinforce.assert_called_once_with(["abc-123"], success=True)
+    mock_learn.assert_not_called()
+
+
+def test_feedback_with_conversation_fields_also_learns():
+    req = MemoryFeedbackRequest(
+        role_memory_ids=["abc-123"], success=True,
+        channel="whatsapp", user_message="What are your hours?",
+        ai_reply="We're open 9-5 Mon-Fri.",
+    )
+    with patch.object(employee_learning, "record_role_memory_outcome", return_value=1), \
+         patch.object(employee_learning, "learn_from_conversation") as mock_learn:
+        chat_feedback(req)
+    mock_learn.assert_called_once_with(
+        "whatsapp", "What are your hours?", "We're open 9-5 Mon-Fri.",
+        resolved=True, score=0.85,
+    )
+
+
+def test_feedback_failure_still_calls_learn_with_resolved_false():
+    """A failed outcome still calls learn_from_conversation (with
+    resolved=False) rather than skipping it - learn_from_conversation's
+    own internal guard (resolved and score>=0.5) is what decides
+    whether anything actually gets written, not the endpoint."""
+    req = MemoryFeedbackRequest(
+        role_memory_ids=["abc-123"], success=False,
+        channel="email", user_message="Can you process my refund?",
+        ai_reply="I'm not able to help with that.",
+    )
+    with patch.object(employee_learning, "record_role_memory_outcome", return_value=0), \
+         patch.object(employee_learning, "learn_from_conversation") as mock_learn:
+        chat_feedback(req)
+    mock_learn.assert_called_once_with(
+        "email", "Can you process my refund?", "I'm not able to help with that.",
+        resolved=False, score=0.3,
+    )
+
+
+def test_feedback_partial_conversation_fields_skips_learning():
+    """All three of channel/user_message/ai_reply are required together -
+    a partial set (e.g. only channel) should NOT trigger a call, since
+    learn_from_conversation needs all three to write meaningful text."""
+    req = MemoryFeedbackRequest(
+        role_memory_ids=["abc-123"], success=True, channel="whatsapp",
+    )
+    with patch.object(employee_learning, "record_role_memory_outcome", return_value=1), \
+         patch.object(employee_learning, "learn_from_conversation") as mock_learn:
+        chat_feedback(req)
+    mock_learn.assert_not_called()


### PR DESCRIPTION
## Context
Second learning trigger wired this session (after `learn_from_owner_approval` in #314). `learn_from_conversation` needed a "resolved" signal that didn't exist anywhere in the request path - turned out `/chat/feedback` already has exactly that: a real `success: bool`, currently only used to reinforce/decay existing memories.

## What this does
Extended `MemoryFeedbackRequest` with three **optional** fields - `channel`, `user_message`, `ai_reply`. When all three are supplied alongside the existing `role_memory_ids`/`success`, the exchange is also recorded as a new learned skill via `learn_from_conversation`. Omitting them keeps the original reinforce-only behavior exactly as before - fully backward compatible, no existing caller's request body needs to change.

`learn_from_conversation`'s own internal guard (`resolved` and `score >= 0.5`) still decides whether anything actually gets written - the endpoint just passes real values through, including a failed outcome (`resolved=False`) rather than special-casing it.

## Tests
New `tests/test_chat_feedback.py`, 4 tests, `chat_feedback()` called directly (plain function under `@app.post`, no TestClient/HTTP needed), `employee_learning` mocked. Covers backward-compat when new fields absent, learning fires when all three present, failure case, and a partial field set correctly skipping learning.

Full suite: 223 -> 227 passing.
