### PR TITLE
vectorstores: add UpstashBackend (managed serverless vector DB)

### DIFF
--- a/packages/ragleap-vectorstores/CHANGELOG.md
+++ b/packages/ragleap-vectorstores/CHANGELOG.md
@@ -5,6 +5,42 @@ loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-09-09
+### Added
+- `UpstashBackend` - fourth vector backend, via Upstash Vector's managed
+  serverless REST API. Available via the `upstash` optional extra
+  (`pip install ragleap-vectorstores[upstash]`).
+- Unlike Chroma/LanceDB (embedded) and Redis (self-hostable), Upstash
+  Vector has no local mode at all - the index (including its fixed
+  dimension and dense-vs-hybrid type) must already exist, created via
+  the Upstash console. `init_schema()` cannot create anything; it
+  verifies the real index's dimension and type via `info()` and raises
+  a clear error on mismatch, live-verified against a real index rather
+  than assumed.
+- LIVE-VERIFIED GOTCHA: an Upstash index can be created as "dense" or
+  "hybrid" (requiring sparse vectors on every upsert) - a hybrid index
+  rejects dense-only upserts with a confusing error. `init_schema()`
+  checks this via `info()` and fails clearly up front instead.
+- Metadata filtering is a genuine strength here versus the other
+  backends: Upstash's `filter=` is a real SQL-like string over an
+  actual JSON metadata dict, so arbitrary multi-key filters work
+  natively - closer to Chroma's flexibility than Redis's
+  document_id-only limitation, without Chroma's `$and` wrapping either.
+- `similarity_score` is used directly from Upstash's `query()` - its
+  score is already a normalized similarity in [0, 1] (live-verified: an
+  exact match returns 1.0), unlike Chroma/Redis which return a distance
+  requiring `1 - distance` conversion.
+- `delete_document()` and chunk-counting use Upstash's native `prefix=`
+  parameter on `delete()`/`range()` - a genuine prefix-scan, simpler
+  than Redis's manual scan-then-delete-by-key-list pattern.
+- `supports_sparse()` reports `False` - Upstash Vector does support
+  real hybrid dense+sparse search, but that requires a hybrid-type
+  index and sparse embeddings this package doesn't generate, so it's
+  honestly reported as unsupported.
+- 14 new tests, all against a real Upstash Vector index (no mocks).
+  Tests skip cleanly (not fail) if `UPSTASH_VECTOR_REST_URL`/`TOKEN`
+  aren't set in the environment.
+
 ## [0.3.3] - 2026-09-06
 ### Fixed
 - REAL BUG, live-verified: RedisBackend's key_prefix used to default to

--- a/packages/ragleap-vectorstores/README.md
+++ b/packages/ragleap-vectorstores/README.md
@@ -14,6 +14,7 @@ over time. See the
 | Chroma | `chroma` | Embedded/local via chromadb's PersistentClient - no server required. No native sparse/keyword search (`supports_sparse()` is `False`); hybrid search falls back to dense-only. |
 | LanceDB | `lancedb` | Embedded/local via a directory path - no server required. Real upsert semantics via `merge_insert()`. No native sparse/keyword search enabled yet (`supports_sparse()` is `False`); hybrid search falls back to dense-only. |
 | Redis | `redis` | Requires a real running server - Redis Stack, or plain Redis with the RediSearch module loaded (no embedded/local mode). `init_schema()` checks for the module and raises a clear error if it's missing. Metadata filtering only supports `document_id` (RediSearch requires predeclared schema fields). No native sparse/keyword search enabled yet (`supports_sparse()` is `False`); hybrid search falls back to dense-only. |
+| Upstash Vector | `upstash` | Managed serverless REST API - no embedded/local mode at all, and the index (fixed dimension, dense-vs-hybrid type) must already exist, created via the Upstash console; `init_schema()` verifies compatibility via `info()` rather than creating anything. Metadata filtering supports arbitrary multi-key filters natively (real SQL-like `filter=` string over a genuine JSON dict) - more flexible than Redis here. No native sparse/keyword search enabled yet (`supports_sparse()` is `False`); hybrid search falls back to dense-only. |
 
 ## Design
 
@@ -54,4 +55,12 @@ from ragleap_vectorstores import RedisBackend
 # Requires a real Redis Stack instance (or plain Redis + the RediSearch
 # module) - plain Redis alone has no vector search.
 backend = RedisBackend(redis_url="redis://localhost:6379/0")
+```
+
+```python
+from ragleap_vectorstores import UpstashBackend
+
+# Requires a real Upstash Vector index, created via the Upstash console
+# (console.upstash.com) as a pure DENSE index - no embedded/local mode.
+backend = UpstashBackend(url="https://...upstash.io", token="...")
 ```

--- a/packages/ragleap-vectorstores/pyproject.toml
+++ b/packages/ragleap-vectorstores/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-vectorstores"
-version = "0.3.3"
+version = "0.4.0"
 description = "Pluggable vector backends beyond ragleap-rag core's 6 (PgVector, FAISS, Pinecone, Weaviate, Qdrant, Milvus) - additional VectorBackend implementations as optional extras, no vendor lock-in, no bloated core dependency footprint."
 readme = "README.md"
 license = "MIT"
@@ -12,7 +12,7 @@ requires-python = ">=3.10"
 authors = [
     { name = "Antony", email = "antony@ragleap.com" }
 ]
-keywords = ["rag", "vector-search", "vector-database", "ragleap", "chroma", "chromadb", "lancedb", "redis", "redisearch", "embeddings", "similarity-search"]
+keywords = ["rag", "vector-search", "vector-database", "ragleap", "chroma", "chromadb", "lancedb", "redis", "redisearch", "upstash", "embeddings", "similarity-search"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
@@ -32,6 +32,7 @@ test = ["pytest>=8.0.0", "pytest-asyncio>=0.24.0"]
 chroma = ["chromadb>=1.0.0"]
 lancedb = ["lancedb>=0.15.0", "pyarrow>=14.0.0"]
 redis = ["redis>=5.0.0", "numpy>=1.24.0"]
+upstash = ["upstash-vector>=0.8.0"]
 
 [project.urls]
 Homepage = "https://github.com/antonyrag/ragleap-core"

--- a/packages/ragleap-vectorstores/src/ragleap_vectorstores/__init__.py
+++ b/packages/ragleap-vectorstores/src/ragleap_vectorstores/__init__.py
@@ -8,7 +8,7 @@ the package.
 """
 from ragleap.vectorstores.base import VectorBackend
 
-__version__ = "0.3.3"
+__version__ = "0.4.0"
 
 __all__ = ["VectorBackend", "__version__"]
 
@@ -29,3 +29,9 @@ try:
     __all__.append("RedisBackend")
 except ImportError:
     pass  # redis extra not installed - RedisBackend simply unavailable, not an error
+
+try:
+    from ragleap_vectorstores.upstash_backend import UpstashBackend
+    __all__.append("UpstashBackend")
+except ImportError:
+    pass  # upstash extra not installed - UpstashBackend simply unavailable, not an error

--- a/packages/ragleap-vectorstores/src/ragleap_vectorstores/upstash_backend.py
+++ b/packages/ragleap-vectorstores/src/ragleap_vectorstores/upstash_backend.py
@@ -1,0 +1,266 @@
+"""
+Upstash Vector-backed vector storage for ragleap-vectorstores.
+
+Live-verified against the actually installed upstash-vector==0.8.0 package
+and a real Upstash Vector index (dimension 1536, COSINE) - every method
+signature, filter syntax, and score convention below was introspected and
+exercised for real before being written here, not assumed from docs.
+
+Design notes:
+- url= and token= are REQUIRED. Unlike Chroma/LanceDB (embedded) or even
+  Redis (self-hostable), Upstash Vector is a managed serverless service -
+  there is no local/embedded mode at all. The index itself (including its
+  fixed dimension and dense-vs-hybrid type) must already exist, created
+  via the Upstash console - the SDK has no create-index call. Because of
+  this, init_schema() cannot create anything; it can only verify the real
+  index's dimension matches what the caller expects, via info(), and
+  raise a clear error on mismatch rather than a confusing one at query
+  time.
+- LIVE-VERIFIED GOTCHA: an Upstash Vector index can be created as either
+  "dense" or "hybrid" (requiring sparse vectors on every upsert). This is
+  an index-level setting from creation, not something the SDK controls.
+  A hybrid-configured index rejects dense-only upserts with
+  UpstashError("This index requires sparse vectors"). init_schema()
+  checks dense_index/sparse_index from info() and raises a clear error
+  if the index isn't a pure dense index, rather than failing confusingly
+  on the first insert_chunk() call.
+- Metadata filtering is a REAL differentiator from Chroma/LanceDB/Redis:
+  Upstash's filter= is a SQL-like string ("key = 'value' AND key2 >= 5"),
+  and since metadata is stored as a genuine JSON dict (not predeclared
+  schema fields like Redis requires), arbitrary multi-key filters work
+  natively - closer to Chroma's flexibility than Redis's document_id-only
+  limitation, without needing Chroma's $and wrapping either.
+- similarity_score: Upstash's query() score is ALREADY a normalized
+  similarity in [0, 1] where 1 = identical (live-verified: an exact-match
+  query returned score 1.0) - unlike Chroma/Redis, which return a
+  distance requiring `1 - distance` conversion. Used directly here, no
+  conversion needed.
+- Chunk data (text, document_id, document_name, chunk_index, token_count)
+  is stored natively in Upstash's metadata dict per vector - no SQLite
+  sidecar needed for chunks, same "no sidecar needed" pattern as
+  Chroma/LanceDB. A small SQLite sidecar is still used, but only for the
+  document registry (filename, uploaded_at), same as every other backend.
+- Chunk IDs use the deterministic f"{document_id}:{chunk_index}" format.
+  delete_document() and chunk-counting both use Upstash's native prefix=
+  parameter on delete()/range() - a real prefix-scan delete/list, more
+  convenient than Redis's manual scan-then-delete-by-key-list pattern.
+- supports_sparse() returns False. Upstash Vector *does* support real
+  hybrid dense+sparse search, but that surface requires a hybrid-type
+  index and sparse embeddings this package doesn't generate, so it's
+  honestly reported as unsupported rather than assumed to work.
+"""
+import datetime
+import json
+import logging
+import os
+import re
+import sqlite3
+import threading
+from typing import Dict, List, Optional
+
+from ragleap.vectorstores.base import VectorBackend
+
+logger = logging.getLogger(__name__)
+
+
+def _escape_filter_value(value) -> str:
+    """Build one side of an Upstash filter= clause for a single value.
+    Live-verified filter syntax is SQL-like: string values need single
+    quotes, with any embedded single quote doubled (standard SQL escaping);
+    numbers and booleans are written bare."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    escaped = str(value).replace("'", "''")
+    return f"'{escaped}'"
+
+
+class UpstashBackend(VectorBackend):
+    def __init__(
+        self,
+        url: str,
+        token: str,
+        namespace: str = "",
+        registry_path: Optional[str] = None,
+    ):
+        try:
+            from upstash_vector import Index  # noqa: F401
+        except ImportError as e:
+            raise ImportError(
+                "UpstashBackend requires the 'upstash' extra: "
+                "pip install ragleap-vectorstores[upstash]"
+            ) from e
+
+        if not url or not token:
+            raise ValueError(
+                "UpstashBackend requires both url= and token= - get these "
+                "from the Upstash console (Vector > your index > REST API). "
+                "The index itself must already exist (created via the "
+                "console) as a pure dense index; UpstashBackend cannot "
+                "create one."
+            )
+
+        self.url = url
+        self.token = token
+        # Isolation note, learned from a real RedisBackend bug this
+        # project fixed: if you share ONE Upstash index across multiple
+        # logically separate RagLeap deployments, always pass a distinct
+        # namespace= for each - the default "" namespace is shared by
+        # everyone who doesn't set one, same footgun shape as Redis's
+        # key_prefix collision, just one level up (index vs namespace).
+        self.namespace = namespace
+        self._index = None
+        self._dimensions = None
+        self._lock = threading.Lock()
+
+        registry_path = registry_path or os.path.join(
+            os.path.expanduser("~"), ".ragleap_vectorstores", "upstash_documents.sqlite3"
+        )
+        os.makedirs(os.path.dirname(registry_path), exist_ok=True)
+        self._sqlite_path = registry_path
+        self._conn = sqlite3.connect(self._sqlite_path, check_same_thread=False)
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS documents (
+                id TEXT PRIMARY KEY, filename TEXT NOT NULL,
+                metadata TEXT NOT NULL, uploaded_at TEXT NOT NULL
+            )"""
+        )
+        self._conn.commit()
+
+    def _vector_id(self, document_id: str, chunk_index: int) -> str:
+        return f"{document_id}:{chunk_index}"
+
+    def _build_filter(self, metadata_filter: Optional[Dict]) -> str:
+        """Upstash's filter= is a real SQL-like string over the actual
+        metadata dict - unlike Redis, arbitrary keys work natively since
+        there's no predeclared schema. Multi-key filters join with AND,
+        same native-AND convenience as LanceDB, no $and wrapping needed."""
+        if not metadata_filter:
+            return ""
+        clauses = [f"{key} = {_escape_filter_value(value)}" for key, value in metadata_filter.items()]
+        return " AND ".join(clauses)
+
+    def init_schema(self, dimensions: int) -> None:
+        from upstash_vector import Index
+
+        self._dimensions = dimensions
+        self._index = Index(url=self.url, token=self.token)
+
+        info = self._index.info()
+        if info.sparse_index is not None or info.dense_index is None:
+            raise RuntimeError(
+                f"UpstashBackend: index at {self.url} is not a pure dense "
+                "index (it's configured for hybrid/sparse vectors) - "
+                "live-verified via info(), not assumed. Create a new "
+                "index in the Upstash console with type 'Dense' instead."
+            )
+        if info.dimension != dimensions:
+            raise RuntimeError(
+                f"UpstashBackend: index at {self.url} has dimension "
+                f"{info.dimension}, but {dimensions} was requested. The "
+                "index's dimension is fixed at creation time in the "
+                "Upstash console and cannot be changed by this backend."
+            )
+        logger.info(
+            f"UpstashBackend: connected to existing index "
+            f"(dimensions={dimensions}, namespace={self.namespace!r}) at {self.url}"
+        )
+
+    def insert_document(self, document_id: str, filename: str, metadata: Dict) -> None:
+        with self._lock:
+            self._conn.execute(
+                "INSERT INTO documents (id, filename, metadata, uploaded_at) VALUES (?, ?, ?, ?)",
+                (document_id, filename, json.dumps(metadata or {}), datetime.datetime.utcnow().isoformat()),
+            )
+            self._conn.commit()
+
+    def insert_chunk(
+        self, document_id: str, document_name: str, chunk_index: int,
+        text: str, token_count: int, embedding: List[float], metadata: Dict,
+    ) -> None:
+        vec_id = self._vector_id(document_id, chunk_index)
+        payload_metadata = {
+            "document_id": document_id,
+            "document_name": document_name,
+            "chunk_index": chunk_index,
+            "token_count": token_count or 0,
+            "text": text,
+            **(metadata or {}),
+        }
+        with self._lock:
+            self._index.upsert(
+                vectors=[{"id": vec_id, "vector": embedding, "metadata": payload_metadata}],
+                namespace=self.namespace,
+            )
+
+    def search_dense(self, embedding: List[float], top_k: int, metadata_filter: Optional[Dict] = None) -> List[Dict]:
+        if not embedding or self._index is None:
+            return []
+
+        results = self._index.query(
+            vector=embedding,
+            top_k=top_k,
+            include_metadata=True,
+            filter=self._build_filter(metadata_filter),
+            namespace=self.namespace,
+        )
+
+        out = []
+        for r in results:
+            meta = r.metadata or {}
+            out.append({
+                "chunk_id": r.id,
+                "text": meta.get("text"),
+                # Upstash's score is ALREADY a normalized similarity in
+                # [0, 1] (1 = identical) - live-verified, unlike
+                # Chroma/Redis's distance-based score. Used directly.
+                "similarity_score": round(float(r.score), 4),
+                "document_id": meta.get("document_id"),
+                "document_name": meta.get("document_name"),
+                "chunk_index": meta.get("chunk_index"),
+            })
+        return out
+
+    def supports_sparse(self) -> bool:
+        return False
+
+    def list_documents(self, limit: int, offset: int) -> List[Dict]:
+        rows = self._conn.execute(
+            "SELECT id, filename, uploaded_at, metadata FROM documents "
+            "ORDER BY uploaded_at DESC LIMIT ? OFFSET ?",
+            (limit, offset),
+        ).fetchall()
+
+        results = []
+        for doc_id, filename, uploaded_at, metadata_json in rows:
+            chunk_count = 0
+            if self._index is not None:
+                # Native prefix-scan via range() - no predeclared schema
+                # or manual key-listing needed, unlike Redis's approach.
+                range_result = self._index.range(
+                    prefix=f"{doc_id}:", limit=1000, namespace=self.namespace,
+                )
+                chunk_count = len(range_result.vectors)
+            results.append({
+                "document_id": doc_id, "filename": filename, "uploaded_at": uploaded_at,
+                "metadata": json.loads(metadata_json), "chunk_count": chunk_count,
+            })
+        return results
+
+    def delete_document(self, document_id: str) -> bool:
+        with self._lock:
+            if self._index is not None:
+                # Native prefix-scan delete - single call, unlike Redis's
+                # scan-then-delete-by-key-list pattern.
+                self._index.delete(prefix=f"{document_id}:", namespace=self.namespace)
+            cur = self._conn.execute("DELETE FROM documents WHERE id = ?", (document_id,))
+            deleted = cur.rowcount > 0
+            self._conn.commit()
+        return deleted
+
+    def get_document_filename(self, document_id: str) -> Optional[str]:
+        row = self._conn.execute(
+            "SELECT filename FROM documents WHERE id = ?", (document_id,)
+        ).fetchone()
+        return row[0] if row else None

--- a/packages/ragleap-vectorstores/tests/test_upstash_backend.py
+++ b/packages/ragleap-vectorstores/tests/test_upstash_backend.py
@@ -1,0 +1,191 @@
+"""
+Tests for UpstashBackend. Uses a real Upstash Vector index (managed
+cloud service - no local/embedded mode exists, so unlike Chroma/LanceDB
+this needs real credentials). Reads UPSTASH_VECTOR_REST_URL and
+UPSTASH_VECTOR_REST_TOKEN from the environment - tests skip cleanly if
+these aren't set, rather than failing confusingly.
+
+The real index must be a pure DENSE index (not hybrid/sparse) with
+dimension 1536 - live-verified: a hybrid-configured index rejects
+dense-only upserts with "This index requires sparse vectors". Each test
+uses a random namespace to avoid colliding with other test runs or with
+concurrent CI jobs sharing the same index.
+"""
+import os
+import time
+import uuid
+
+import pytest
+
+from ragleap_vectorstores.upstash_backend import UpstashBackend
+
+UPSTASH_URL = os.environ.get("UPSTASH_VECTOR_REST_URL")
+UPSTASH_TOKEN = os.environ.get("UPSTASH_VECTOR_REST_TOKEN")
+DIMENSIONS = 1536
+
+pytestmark = pytest.mark.skipif(
+    not (UPSTASH_URL and UPSTASH_TOKEN),
+    reason="UPSTASH_VECTOR_REST_URL/TOKEN not set - skipping live Upstash tests",
+)
+
+
+def _vec(seed: int, dim: int = DIMENSIONS) -> list:
+    """Random vector seeded per 'topic', NOT a uniform-fill vector.
+    Live-verified bug in an earlier version of this fixture: uniform
+    vectors like [0.1]*dim and [0.9]*dim are perfectly co-linear (same
+    direction, different magnitude only) - cosine similarity between
+    them is 1.0 regardless of the fill values, making them
+    indistinguishable to a cosine-similarity search. Random vectors with
+    different seeds have genuinely different directions in high-dim
+    space, giving real separation; the same seed reproduces the same
+    vector for exact-match assertions."""
+    import random
+    rng = random.Random(seed)
+    return [rng.uniform(-1, 1) for _ in range(dim)]
+
+
+@pytest.fixture
+def backend(tmp_path):
+    ns = "test_" + uuid.uuid4().hex[:10]
+    b = UpstashBackend(
+        url=UPSTASH_URL,
+        token=UPSTASH_TOKEN,
+        namespace=ns,
+        registry_path=str(tmp_path / "registry.sqlite3"),
+    )
+    b.init_schema(dimensions=DIMENSIONS)
+    yield b
+    try:
+        b._index.reset(namespace=ns)
+    except Exception:
+        pass
+
+
+def _seed(backend):
+    backend.insert_document("doc1", "report.pdf", {"source": "upload"})
+    backend.insert_chunk("doc1", "report.pdf", 0, "The cat sat on the mat.", 6, _vec(1), {})
+    backend.insert_chunk("doc1", "report.pdf", 1, "Dogs bark loudly outside.", 5, _vec(2), {})
+    backend.insert_document("doc2", "notes.txt", {"source": "manual"})
+    backend.insert_chunk("doc2", "notes.txt", 0, "Unrelated content here.", 4, _vec(3), {})
+    time.sleep(1.5)  # Upstash writes are eventually consistent - live-verified need for a short wait
+
+
+def test_requires_url_and_token():
+    with pytest.raises(ValueError):
+        UpstashBackend(url="", token="")
+    with pytest.raises(ValueError):
+        UpstashBackend(url="https://example.upstash.io", token="")
+
+
+def test_init_schema_rejects_dimension_mismatch(tmp_path):
+    b = UpstashBackend(
+        url=UPSTASH_URL, token=UPSTASH_TOKEN,
+        namespace="test_" + uuid.uuid4().hex[:10],
+        registry_path=str(tmp_path / "registry.sqlite3"),
+    )
+    with pytest.raises(RuntimeError, match="dimension"):
+        b.init_schema(dimensions=DIMENSIONS + 1)
+
+
+def test_insert_and_search_dense_shape(backend):
+    _seed(backend)
+    results = backend.search_dense(_vec(1), top_k=5)
+    assert results, "expected at least one result"
+    assert set(results[0].keys()) == {
+        "chunk_id", "text", "similarity_score", "document_id", "document_name", "chunk_index",
+    }
+    assert results[0]["document_id"] == "doc1"
+    assert results[0]["chunk_index"] == 0
+    assert results[0]["text"] == "The cat sat on the mat."
+    assert results[0]["similarity_score"] == 1.0
+
+
+def test_search_dense_single_key_filter(backend):
+    _seed(backend)
+    results = backend.search_dense(_vec(1), top_k=5, metadata_filter={"document_id": "doc2"})
+    assert results
+    assert all(r["document_id"] == "doc2" for r in results)
+
+
+def test_search_dense_multi_key_filter(backend):
+    """Upstash's filter= is a real SQL-like string, so multi-key filters
+    combine natively with AND - live-verified, no $and wrapping needed
+    unlike Chroma."""
+    _seed(backend)
+    results = backend.search_dense(_vec(1), top_k=5, metadata_filter={"document_id": "doc1", "chunk_index": 1})
+    assert len(results) == 1
+    assert results[0]["chunk_id"] == "doc1:1"
+
+
+def test_search_dense_empty_embedding_returns_empty(backend):
+    assert backend.search_dense([], top_k=5) == []
+
+
+def test_search_sparse_not_supported(backend):
+    _seed(backend)
+    assert backend.search_sparse("cat", top_k=5) == []
+
+
+def test_search_hybrid_falls_back_to_dense(backend):
+    _seed(backend)
+    hybrid = backend.search_hybrid("cat", _vec(1), top_k=5)
+    dense = backend.search_dense(_vec(1), top_k=5)
+    assert [r["chunk_id"] for r in hybrid] == [r["chunk_id"] for r in dense]
+
+
+def test_supports_sparse_is_false(backend):
+    assert backend.supports_sparse() is False
+
+
+def test_list_documents(backend):
+    _seed(backend)
+    docs = backend.list_documents(limit=10, offset=0)
+    assert len(docs) == 2
+    by_id = {d["document_id"]: d for d in docs}
+    assert by_id["doc1"]["chunk_count"] == 2
+    assert by_id["doc2"]["chunk_count"] == 1
+    assert by_id["doc1"]["filename"] == "report.pdf"
+    assert by_id["doc1"]["metadata"] == {"source": "upload"}
+
+
+def test_get_document_filename(backend):
+    _seed(backend)
+    assert backend.get_document_filename("doc1") == "report.pdf"
+    assert backend.get_document_filename("nonexistent") is None
+
+
+def test_delete_document_removes_registry_entry_and_vectors(backend):
+    _seed(backend)
+    assert backend.delete_document("doc1") is True
+    assert backend.delete_document("doc1") is False  # already gone
+
+    docs = backend.list_documents(limit=10, offset=0)
+    assert [d["document_id"] for d in docs] == ["doc2"]
+
+    time.sleep(1)
+    remaining = backend.search_dense(_vec(1), top_k=5)
+    assert all(r["document_id"] != "doc1" for r in remaining)
+
+
+def test_insert_chunk_upserts_not_duplicates(backend):
+    """Regression guard: re-inserting the same document_id/chunk_index
+    (same deterministic vector id) overwrites in place via Upstash's
+    native upsert semantics - no duplicate, same pattern as Redis's HSET."""
+    _seed(backend)
+    backend.insert_chunk("doc2", "notes.txt", 0, "UPDATED TEXT", 2, _vec(3), {})
+    time.sleep(1)
+    results = backend.search_dense(_vec(3), top_k=5)
+    assert results[0]["text"] == "UPDATED TEXT"
+    docs = backend.list_documents(limit=10, offset=0)
+    by_id = {d["document_id"]: d for d in docs}
+    assert by_id["doc2"]["chunk_count"] == 1
+
+
+def test_init_schema_idempotent(backend):
+    """Calling init_schema again should reconnect and re-verify
+    dimension/type, not error - there's nothing to "reset" since Upstash
+    has no create-index call, but it must be safe to call twice."""
+    _seed(backend)
+    backend.init_schema(dimensions=DIMENSIONS)
+    results = backend.search_dense(_vec(1), top_k=5)
+    assert len(results) == 3


### PR DESCRIPTION
Adds a fourth ragleap-vectorstores backend using Upstash Vector's managed serverless REST API.

Key differences from the other three backends:
- No local/embedded mode at all - the index (fixed dimension, dense-vs-hybrid type) must already exist, created via the Upstash console
- Metadata filtering is a real SQL-like string over a genuine JSON dict, so arbitrary multi-key filters work natively - more flexible than Redis's document_id-only limitation
- similarity_score is used directly (Upstash's query score is already normalized [0,1], unlike Chroma/Redis's distance-based score)

Live-tested against a real Upstash Vector index (dimension 1536, COSINE), 14 new tests (skip cleanly without credentials rather than failing). README's backends table AND usage section both updated in this same release, learning from the earlier pattern where these lagged in separate patches.

Note: CI won't be able to run the Upstash-specific tests since they need real UPSTASH_VECTOR_REST_URL/TOKEN credentials not available in the CI environment - they'll skip cleanly there, same as locally without credentials. All 41 non-Upstash tests + 14 Upstash tests pass locally with credentials set.