### PR TITLE
feat: wire learn_from_integration_action into sync_integration

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -474,6 +474,14 @@ def sync_integration(data_source_id: str):
     result = integrations_service.sync_data_source(data_source_id)
     if not result.get("success") and result.get("error") == "Data source not found":
         raise HTTPException(status_code=404, detail="Data source not found")
+    data_source = integrations_service.get_data_source(data_source_id)
+    if data_source:
+        result_summary = (
+            f"success: {result.get('records_synced', 0)} records synced"
+            if result.get("success")
+            else f"failed: {result.get('error', 'unknown error')}"
+        )
+        employee_learning.learn_from_integration_action(data_source.name, "sync", result_summary)
     return result
 
 

--- a/tests/test_sync_integration_learning.py
+++ b/tests/test_sync_integration_learning.py
@@ -1,0 +1,56 @@
+"""
+Tests for core/api.py's sync_integration() endpoint - covers the new
+learn_from_integration_action() call added after a successful/failed
+sync, using integrations_service.sync_data_source()'s and
+get_data_source()'s real return shapes. Called directly (plain
+function under @app.post), integrations_service and employee_learning
+mocked, no live DB/API needed.
+"""
+import os
+import sys
+from unittest.mock import patch
+
+os.environ.setdefault("DATABASE_URL", "postgresql://ragleap:ragleap@localhost:5433/ragleap_core")
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from core.api import sync_integration, integrations_service, employee_learning
+from core.integrations.base import DataSource
+
+
+def _make_data_source(name="My CRM"):
+    return DataSource(id="ds-1", name=name, source_type="rest_api")
+
+
+def test_successful_sync_records_learned_skill():
+    with patch.object(integrations_service, "sync_data_source",
+                       return_value={"success": True, "records_synced": 42}), \
+         patch.object(integrations_service, "get_data_source",
+                       return_value=_make_data_source("Salesforce")), \
+         patch.object(employee_learning, "learn_from_integration_action") as mock_learn:
+        result = sync_integration("ds-1")
+    assert result == {"success": True, "records_synced": 42}
+    mock_learn.assert_called_once_with("Salesforce", "sync", "success: 42 records synced")
+
+
+def test_failed_sync_records_learned_skill_with_error():
+    with patch.object(integrations_service, "sync_data_source",
+                       return_value={"success": False, "error": "connection timeout"}), \
+         patch.object(integrations_service, "get_data_source",
+                       return_value=_make_data_source("HubSpot")), \
+         patch.object(employee_learning, "learn_from_integration_action") as mock_learn:
+        result = sync_integration("ds-1")
+    assert result == {"success": False, "error": "connection timeout"}
+    mock_learn.assert_called_once_with("HubSpot", "sync", "failed: connection timeout")
+
+
+def test_data_source_not_found_raises_404_and_does_not_learn():
+    from fastapi import HTTPException
+    with patch.object(integrations_service, "sync_data_source",
+                       return_value={"success": False, "error": "Data source not found"}), \
+         patch.object(employee_learning, "learn_from_integration_action") as mock_learn:
+        try:
+            sync_integration("nonexistent")
+            assert False, "expected HTTPException"
+        except HTTPException as e:
+            assert e.status_code == 404
+    mock_learn.assert_not_called()


### PR DESCRIPTION
## Context
Third learning trigger wired this session (after #314, #315). `integrations_service.sync_data_source()` already returns a real success/records-synced-or-error result - no new signal needed.

## What this does
`sync_integration()` (`POST /integrations/{id}/sync`) now also fetches the data source's name and calls `learn_from_integration_action` with a human-readable result summary. Scoped to `sync` only, not `test_integration` - test is a connectivity check, sync is the meaningful recurring operation.

## Tests
New `tests/test_sync_integration_learning.py`, 3 tests, `sync_integration()` called directly, both dependencies mocked. Covers success, failure, and the not-found case (no learning call for something that didn't actually happen).

Full suite: 227 -> 230 passing.
