### PR TITLE
feat(java-port): port chunker.py to Java

### DIFF
--- a/java/ragleap-rag/pom.xml
+++ b/java/ragleap-rag/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.ragleap</groupId>
+    <artifactId>ragleap-rag</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>ragleap-rag (Java port)</name>
+    <description>
+        Java port of packages/ragleap-rag (Python). Ported module by
+        module, starting with chunker.py -&gt; TextChunker. Lives outside
+        packages/ entirely - that directory is other employees' territory
+        and is never touched, per the repo's standing rule.
+    </description>
+
+    <properties>
+        <maven.compiler.release>21</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit.version>5.10.2</junit.version>
+        <jtokkit.version>1.1.0</jtokkit.version>
+    </properties>
+
+    <dependencies>
+        <!-- Real Java implementation of OpenAI's tiktoken encodings
+             (including cl100k_base) - the genuine equivalent of Python's
+             tiktoken, used here for the same purpose: real LLM token
+             counts, not an estimate. -->
+        <dependency>
+            <groupId>com.knuddels</groupId>
+            <artifactId>jtokkit</artifactId>
+            <version>${jtokkit.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/chunker/Chunk.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/chunker/Chunk.java
@@ -1,0 +1,8 @@
+package com.ragleap.rag.chunker;
+
+/**
+ * A single text chunk produced by TextChunker, with token-count metadata.
+ * Java equivalent of the dict returned per-chunk by chunker.py's chunk_text().
+ */
+public record Chunk(String text, int chunkIndex, int tokenCount, boolean tokenCountIsExact) {
+}

--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/chunker/TextChunker.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/chunker/TextChunker.java
@@ -1,0 +1,141 @@
+package com.ragleap.rag.chunker;
+
+import com.knuddels.jtokkit.Encodings;
+import com.knuddels.jtokkit.api.Encoding;
+import com.knuddels.jtokkit.api.EncodingRegistry;
+import com.knuddels.jtokkit.api.EncodingType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * Splits documents into overlapping chunks for embedding and retrieval.
+ * Java port of ragleap-rag's chunker.py — TextChunker.
+ */
+public class TextChunker {
+
+    private static final Logger logger = Logger.getLogger(TextChunker.class.getName());
+
+    public static final int DEFAULT_CHUNK_SIZE = 512;
+    public static final int DEFAULT_CHUNK_OVERLAP = 50;
+
+    // Mirrors the Python module's _encoding_cache: resolve cl100k_base once,
+    // reuse it. jtokkit's registry/encoding objects are safe to share.
+    private static final EncodingRegistry REGISTRY = Encodings.newDefaultEncodingRegistry();
+    private static volatile Encoding cl100kEncoding;
+
+    private final int chunkSize;
+    private final int chunkOverlap;
+
+    public TextChunker() {
+        this(DEFAULT_CHUNK_SIZE, DEFAULT_CHUNK_OVERLAP);
+    }
+
+    public TextChunker(int chunkSize, int chunkOverlap) {
+        this.chunkSize = chunkSize;
+        this.chunkOverlap = chunkOverlap;
+
+        if (this.chunkOverlap >= this.chunkSize) {
+            throw new IllegalArgumentException("Chunk overlap must be less than chunk size");
+        }
+
+        logger.info(() -> String.format(
+                "Initialized TextChunker: size=%d, overlap=%d", this.chunkSize, this.chunkOverlap));
+    }
+
+    public int getChunkSize() {
+        return chunkSize;
+    }
+
+    public int getChunkOverlap() {
+        return chunkOverlap;
+    }
+
+    /** Simple whitespace tokenization — mirrors Python's str.split(). */
+    private List<String> tokenize(String text) {
+        List<String> tokens = new ArrayList<>();
+        for (String t : text.trim().split("\\s+")) {
+            if (!t.isEmpty()) {
+                tokens.add(t);
+            }
+        }
+        return tokens;
+    }
+
+    /**
+     * Split text into overlapping chunks with metadata.
+     * Slides a window of chunkSize tokens with step (chunkSize - chunkOverlap),
+     * breaking once a window reaches the end of the token list — matching
+     * chunker.py's for/break boundary exactly (not after, to keep chunk-count parity).
+     */
+    public List<Chunk> chunkText(String text) {
+        if (text == null || text.strip().isEmpty()) {
+            logger.warning("Empty text provided for chunking");
+            return List.of();
+        }
+
+        List<String> tokens = tokenize(text);
+        if (tokens.isEmpty()) {
+            logger.warning("No tokens extracted from text");
+            return List.of();
+        }
+
+        List<Chunk> chunks = new ArrayList<>();
+        int step = chunkSize - chunkOverlap;
+        int chunkIndex = 0;
+
+        for (int start = 0; start < tokens.size(); start += step) {
+            int end = Math.min(start + chunkSize, tokens.size());
+            String chunkTextContent = String.join(" ", tokens.subList(start, end));
+
+            TokenCount tc = realTokenCount(chunkTextContent);
+            chunks.add(new Chunk(chunkTextContent, chunkIndex, tc.count(), tc.isExact()));
+            chunkIndex++;
+
+            if (end == tokens.size()) {
+                break;
+            }
+        }
+
+        logger.info(() -> String.format("Chunked text into %d chunks", chunks.size()));
+        return chunks;
+    }
+
+    private record TokenCount(int count, boolean isExact) {}
+
+    /**
+     * Real LLM token count via jtokkit's cl100k_base encoding — the Java
+     * equivalent of tiktoken. Falls back to a whitespace word count with
+     * isExact=false only if the encoding genuinely can't be obtained —
+     * the fallback is never reported as exact.
+     */
+    private TokenCount realTokenCount(String text) {
+        try {
+            Encoding encoding = cl100kEncoding;
+            if (encoding == null) {
+                synchronized (TextChunker.class) {
+                    encoding = cl100kEncoding;
+                    if (encoding == null) {
+                        encoding = REGISTRY.getEncoding(EncodingType.CL100K_BASE);
+                        cl100kEncoding = encoding;
+                    }
+                }
+            }
+            return new TokenCount(encoding.countTokens(text), true);
+        } catch (Exception e) {
+            logger.warning("jtokkit encoding unavailable (" + e.getMessage()
+                    + "); falling back to word count");
+            int wordCount = text.isBlank() ? 0 : text.trim().split("\\s+").length;
+            return new TokenCount(wordCount, false);
+        }
+    }
+
+    public static TextChunker createChunker() {
+        return new TextChunker();
+    }
+
+    public static TextChunker createChunker(int chunkSize, int chunkOverlap) {
+        return new TextChunker(chunkSize, chunkOverlap);
+    }
+}

--- a/java/ragleap-rag/src/test/java/com/ragleap/rag/chunker/TextChunkerTest.java
+++ b/java/ragleap-rag/src/test/java/com/ragleap/rag/chunker/TextChunkerTest.java
@@ -1,0 +1,87 @@
+package com.ragleap.rag.chunker;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TextChunkerTest {
+
+    @Test
+    void constructorRejectsOverlapGreaterThanOrEqualToChunkSize() {
+        assertThrows(IllegalArgumentException.class, () -> new TextChunker(10, 10));
+        assertThrows(IllegalArgumentException.class, () -> new TextChunker(10, 15));
+    }
+
+    @Test
+    void defaultConstructorUsesStandardDefaults() {
+        TextChunker chunker = new TextChunker();
+        assertEquals(512, chunker.getChunkSize());
+        assertEquals(50, chunker.getChunkOverlap());
+    }
+
+    @Test
+    void emptyTextReturnsNoChunks() {
+        TextChunker chunker = new TextChunker();
+        assertTrue(chunker.chunkText("").isEmpty());
+        assertTrue(chunker.chunkText("   \n  ").isEmpty());
+    }
+
+    @Test
+    void nullTextReturnsNoChunks() {
+        TextChunker chunker = new TextChunker();
+        assertTrue(chunker.chunkText(null).isEmpty());
+    }
+
+    @Test
+    void chunkCountMatchesSlidingWindowBoundaryCondition() {
+        // 25 whitespace tokens, chunkSize=10, overlap=2 -> step=8
+        // starts: 0 (end=10), 8 (end=18), 16 (end=25, break) -> 3 chunks
+        StringBuilder sb = new StringBuilder();
+        for (int i = 1; i <= 25; i++) {
+            sb.append("word").append(i).append(" ");
+        }
+        TextChunker chunker = new TextChunker(10, 2);
+        List<Chunk> chunks = chunker.chunkText(sb.toString().trim());
+
+        assertEquals(3, chunks.size());
+        assertEquals(0, chunks.get(0).chunkIndex());
+        assertEquals("word1 word2 word3 word4 word5 word6 word7 word8 word9 word10",
+                chunks.get(0).text());
+        assertEquals("word9 word10 word11 word12 word13 word14 word15 word16 word17 word18",
+                chunks.get(1).text());
+        // last chunk: tokens[16:25] -> word17..word25 (9 tokens, since end==size triggers break)
+        assertEquals("word17 word18 word19 word20 word21 word22 word23 word24 word25",
+                chunks.get(2).text());
+    }
+
+    @Test
+    void singleChunkWhenTextShorterThanChunkSize() {
+        TextChunker chunker = new TextChunker();
+        List<Chunk> chunks = chunker.chunkText("just a few words here");
+        assertEquals(1, chunks.size());
+        assertEquals("just a few words here", chunks.get(0).text());
+    }
+
+    @Test
+    void tokenCountIsRealAndMarkedExact() {
+        TextChunker chunker = new TextChunker();
+        List<Chunk> chunks = chunker.chunkText("The quick brown fox jumps over the lazy dog");
+        assertEquals(1, chunks.size());
+        Chunk chunk = chunks.get(0);
+        assertTrue(chunk.tokenCountIsExact());
+        assertTrue(chunk.tokenCount() > 0);
+        // cl100k_base tokenizes this classic pangram fragment to more than
+        // the 9 whitespace words due to subword splitting — sanity bound only.
+        assertTrue(chunk.tokenCount() >= 9);
+    }
+
+    @Test
+    void factoryMethodsWork() {
+        assertNotNull(TextChunker.createChunker());
+        TextChunker custom = TextChunker.createChunker(20, 5);
+        assertEquals(20, custom.getChunkSize());
+        assertEquals(5, custom.getChunkOverlap());
+    }
+}


### PR DESCRIPTION
First module of the Java port of ragleap-rag (see java/HANDOVER.md for full scope/plan). Ports chunker.py -> TextChunker.java faithfully, including the sliding-window boundary condition and the tiktoken/jtokkit exact-vs-fallback token-count distinction. 8 JUnit tests passing locally (mvn test). Touches only java/ — nothing under packages/. Note: no Java CI job exists yet, so PR checks below are the existing Python-only jobs and don't cover this change.