### PR TITLE
feat(java-port): port cache.py (in-memory half) to Java

### DIFF
--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/cache/CacheStats.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/cache/CacheStats.java
@@ -1,0 +1,8 @@
+package com.ragleap.rag.cache;
+
+/**
+ * Snapshot of cache hit/miss/size stats.
+ * Java equivalent of the dict returned by QueryEmbeddingCache.stats() in cache.py.
+ */
+public record CacheStats(long hits, long misses, double hitRate, int size) {
+}

--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/cache/QueryEmbeddingCache.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/cache/QueryEmbeddingCache.java
@@ -1,0 +1,88 @@
+package com.ragleap.rag.cache;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+/**
+ * Simple in-memory LRU cache for query embeddings.
+ * Java port of ragleap-rag's cache.py — QueryEmbeddingCache.
+ *
+ * Does NOT cache full answers, only embeddings — an embedding is a pure
+ * function of (text, model), so caching it is always safe, unlike
+ * answer-level caching which could go stale with conversation memory.
+ *
+ * Note: this is the in-memory half of cache.py only. The Redis-backed
+ * RedisQueryEmbeddingCache class in the Python source is NOT ported here —
+ * it needs a live Redis client and real integration testing, scoped out
+ * for now the same way db.py's ConnectionPool was.
+ */
+public class QueryEmbeddingCache {
+
+    private static final Logger logger = Logger.getLogger(QueryEmbeddingCache.class.getName());
+
+    private final int maxSize;
+    private final LinkedHashMap<String, List<Double>> store;
+    private long hits = 0;
+    private long misses = 0;
+
+    public QueryEmbeddingCache() {
+        this(1000);
+    }
+
+    public QueryEmbeddingCache(int maxSize) {
+        this.maxSize = maxSize;
+        // accessOrder=true: both get() and put() move an entry to the end,
+        // matching Python's explicit move_to_end() calls on hit and on set.
+        this.store = new LinkedHashMap<>(16, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<String, List<Double>> eldest) {
+                boolean evict = size() > QueryEmbeddingCache.this.maxSize;
+                if (evict) {
+                    String key = eldest.getKey();
+                    logger.fine(() -> "Cache full, evicted: "
+                            + key.substring(0, Math.min(50, key.length())) + "...");
+                }
+                return evict;
+            }
+        };
+    }
+
+    private String key(String query, String model) {
+        return model + ":" + query;
+    }
+
+    public Optional<List<Double>> get(String query, String model) {
+        String k = key(query, model);
+        List<Double> value = store.get(k); // accessOrder=true already moves it to MRU position
+        if (value != null) {
+            hits++;
+            return Optional.of(value);
+        }
+        misses++;
+        return Optional.empty();
+    }
+
+    public void set(String query, String model, List<Double> embedding) {
+        String k = key(query, model);
+        store.put(k, embedding); // accessOrder=true moves it to MRU; removeEldestEntry evicts LRU if over max
+    }
+
+    public void clear() {
+        store.clear();
+        hits = 0;
+        misses = 0;
+    }
+
+    public CacheStats stats() {
+        long total = hits + misses;
+        double hitRate = total > 0 ? Math.round((double) hits / total * 10000.0) / 10000.0 : 0.0;
+        return new CacheStats(hits, misses, hitRate, store.size());
+    }
+
+    public int getMaxSize() {
+        return maxSize;
+    }
+}

--- a/java/ragleap-rag/src/test/java/com/ragleap/rag/cache/QueryEmbeddingCacheTest.java
+++ b/java/ragleap-rag/src/test/java/com/ragleap/rag/cache/QueryEmbeddingCacheTest.java
@@ -1,0 +1,115 @@
+package com.ragleap.rag.cache;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class QueryEmbeddingCacheTest {
+
+    @Test
+    void defaultMaxSizeIsOneThousand() {
+        assertEquals(1000, new QueryEmbeddingCache().getMaxSize());
+    }
+
+    @Test
+    void missOnEmptyCache() {
+        QueryEmbeddingCache cache = new QueryEmbeddingCache();
+        assertTrue(cache.get("hello", "text-embedding-3-small").isEmpty());
+        assertEquals(1, cache.stats().misses());
+        assertEquals(0, cache.stats().hits());
+    }
+
+    @Test
+    void hitAfterSet() {
+        QueryEmbeddingCache cache = new QueryEmbeddingCache();
+        List<Double> embedding = List.of(0.1, 0.2, 0.3);
+        cache.set("hello", "text-embedding-3-small", embedding);
+
+        Optional<List<Double>> result = cache.get("hello", "text-embedding-3-small");
+        assertTrue(result.isPresent());
+        assertEquals(embedding, result.get());
+        assertEquals(1, cache.stats().hits());
+        assertEquals(0, cache.stats().misses());
+    }
+
+    @Test
+    void sameQueryDifferentModelsAreDistinctKeys() {
+        QueryEmbeddingCache cache = new QueryEmbeddingCache();
+        cache.set("hello", "model-a", List.of(1.0));
+        assertTrue(cache.get("hello", "model-b").isEmpty());
+    }
+
+    @Test
+    void evictsLeastRecentlyUsedWhenOverCapacity() {
+        QueryEmbeddingCache cache = new QueryEmbeddingCache(2);
+        cache.set("q1", "m", List.of(1.0));
+        cache.set("q2", "m", List.of(2.0));
+        cache.set("q3", "m", List.of(3.0)); // should evict q1 (least recently used)
+
+        assertTrue(cache.get("q1", "m").isEmpty());
+        assertTrue(cache.get("q2", "m").isPresent());
+        assertTrue(cache.get("q3", "m").isPresent());
+        assertEquals(2, cache.stats().size());
+    }
+
+    @Test
+    void getRefreshesRecencyAndProtectsFromEviction() {
+        QueryEmbeddingCache cache = new QueryEmbeddingCache(2);
+        cache.set("q1", "m", List.of(1.0));
+        cache.set("q2", "m", List.of(2.0));
+
+        cache.get("q1", "m"); // q1 becomes most-recently-used; q2 becomes LRU
+
+        cache.set("q3", "m", List.of(3.0)); // should evict q2, not q1
+
+        assertTrue(cache.get("q1", "m").isPresent());
+        assertTrue(cache.get("q2", "m").isEmpty());
+        assertTrue(cache.get("q3", "m").isPresent());
+    }
+
+    @Test
+    void clearResetsStoreAndCounters() {
+        QueryEmbeddingCache cache = new QueryEmbeddingCache();
+        cache.set("q1", "m", List.of(1.0));
+        cache.get("q1", "m");
+        cache.get("missing", "m");
+
+        cache.clear();
+
+        CacheStats stats = cache.stats();
+        assertEquals(0, stats.hits());
+        assertEquals(0, stats.misses());
+        assertEquals(0, stats.size());
+        assertTrue(cache.get("q1", "m").isEmpty());
+    }
+
+    @Test
+    void hitRateIsZeroWithNoRequests() {
+        assertEquals(0.0, new QueryEmbeddingCache().stats().hitRate());
+    }
+
+    @Test
+    void hitRateComputedCorrectly() {
+        QueryEmbeddingCache cache = new QueryEmbeddingCache();
+        cache.set("q1", "m", List.of(1.0));
+        cache.get("q1", "m");  // hit
+        cache.get("q1", "m");  // hit
+        cache.get("q2", "m");  // miss
+
+        CacheStats stats = cache.stats();
+        assertEquals(2, stats.hits());
+        assertEquals(1, stats.misses());
+        assertEquals(0.6667, stats.hitRate());
+    }
+
+    @Test
+    void statsSizeReflectsStoreSize() {
+        QueryEmbeddingCache cache = new QueryEmbeddingCache();
+        cache.set("q1", "m", List.of(1.0));
+        cache.set("q2", "m", List.of(2.0));
+        assertEquals(2, cache.stats().size());
+    }
+}


### PR DESCRIPTION
Second module of the Java port (see java/HANDOVER.md context from PR #318). Ports QueryEmbeddingCache -> Java using LinkedHashMap's native LRU support. Does NOT include RedisQueryEmbeddingCache from the same source file — that requires a live Redis client and real integration testing against the VPS's Redis instance, deliberately deferred rather than half-verified. 10 new JUnit tests, 18/18 passing overall. Touches only java/. As with #318, existing PR checks are Python-only and don't cover this Java change.