### PR TITLE
ci: add Java test job for the ragleap-rag port

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,3 +206,16 @@ jobs:
           NEO4J_PASSWORD: testpassword123
         run: |
           python -m pytest tests/ -v
+
+  ragleap-rag-java-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+      - name: Run ragleap-rag Java test suite
+        working-directory: java/ragleap-rag
+        run: mvn -B test


### PR DESCRIPTION
Adds ragleap-rag-java-tests to .github/workflows/ci.yml, running mvn test on java/ragleap-rag via actions/setup-java (Temurin 21). This is the first PR where the Java suite actually runs in CI rather than only being verified manually and pasted back - closes the CI gap the handover doc flagged. Pure append to the workflow file, no existing job touched.