### PR TITLE
feat(java-port): port observability.py to Java

### DIFF
--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/observability/ObservabilityHooks.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/observability/ObservabilityHooks.java
@@ -1,0 +1,46 @@
+package com.ragleap.rag.observability;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+
+/**
+ * Lightweight observability hooks for ragleap-rag - fire-and-forget
+ * event emission points that other tools (logging, metrics, tracing)
+ * can consume. Java port of ragleap-rag's observability.py.
+ *
+ * This does NOT implement any dashboard, storage, or analysis itself -
+ * it is purely the instrumentation seam.
+ *
+ * Design philosophy, preserved exactly from the Python source: a broken
+ * or slow hook must never break the actual RAG operation. Every hook
+ * call is wrapped in try/catch - an exception in a hook is logged as a
+ * warning and swallowed, never propagated. This is fire-and-forget, not
+ * a guarantee of delivery.
+ */
+public final class ObservabilityHooks {
+
+    private static final Logger logger = Logger.getLogger(ObservabilityHooks.class.getName());
+
+    private ObservabilityHooks() {
+    }
+
+    /**
+     * Call each handler with the event map, in order. A handler throwing
+     * an exception is logged and swallowed - never propagated, since
+     * observability must never break the actual RAG operation.
+     */
+    public static void fireEvent(Map<String, Object> event, List<Consumer<Map<String, Object>>> handlers, String hookName) {
+        if (handlers == null || handlers.isEmpty()) {
+            return;
+        }
+        for (Consumer<Map<String, Object>> handler : handlers) {
+            try {
+                handler.accept(event);
+            } catch (Exception e) {
+                logger.warning("Observability hook '" + hookName + "' raised an exception (swallowed): " + e);
+            }
+        }
+    }
+}

--- a/java/ragleap-rag/src/test/java/com/ragleap/rag/observability/ObservabilityHooksTest.java
+++ b/java/ragleap-rag/src/test/java/com/ragleap/rag/observability/ObservabilityHooksTest.java
@@ -1,0 +1,84 @@
+package com.ragleap.rag.observability;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ObservabilityHooksTest {
+
+    @Test
+    void nullHandlersListDoesNothing() {
+        assertDoesNotThrow(() -> ObservabilityHooks.fireEvent(Map.of("type", "test"), null, "hook"));
+    }
+
+    @Test
+    void emptyHandlersListDoesNothing() {
+        assertDoesNotThrow(() -> ObservabilityHooks.fireEvent(Map.of("type", "test"), List.of(), "hook"));
+    }
+
+    @Test
+    void singleHandlerReceivesTheEvent() {
+        List<Map<String, Object>> received = new ArrayList<>();
+        Consumer<Map<String, Object>> handler = received::add;
+
+        Map<String, Object> event = Map.of("type", "ask", "latency_ms", 42);
+        ObservabilityHooks.fireEvent(event, List.of(handler), "on_ask");
+
+        assertEquals(1, received.size());
+        assertEquals(event, received.get(0));
+    }
+
+    @Test
+    void allHandlersCalledInOrder() {
+        List<Integer> callOrder = new ArrayList<>();
+        Consumer<Map<String, Object>> first = e -> callOrder.add(1);
+        Consumer<Map<String, Object>> second = e -> callOrder.add(2);
+        Consumer<Map<String, Object>> third = e -> callOrder.add(3);
+
+        ObservabilityHooks.fireEvent(Map.of(), List.of(first, second, third), "hook");
+
+        assertEquals(List.of(1, 2, 3), callOrder);
+    }
+
+    @Test
+    void throwingHandlerIsSwallowedNotPropagated() {
+        Consumer<Map<String, Object>> throwing = e -> {
+            throw new RuntimeException("boom");
+        };
+
+        assertDoesNotThrow(() -> ObservabilityHooks.fireEvent(Map.of(), List.of(throwing), "flaky_hook"));
+    }
+
+    @Test
+    void throwingHandlerDoesNotStopSubsequentHandlers() {
+        List<String> called = new ArrayList<>();
+        Consumer<Map<String, Object>> throwing = e -> {
+            throw new RuntimeException("boom");
+        };
+        Consumer<Map<String, Object>> afterThrow = e -> called.add("ran");
+
+        ObservabilityHooks.fireEvent(Map.of(), List.of(throwing, afterThrow), "hook");
+
+        assertEquals(List.of("ran"), called);
+    }
+
+    @Test
+    void multipleHandlersEachThrowAreAllSwallowed() {
+        List<String> called = new ArrayList<>();
+        Consumer<Map<String, Object>> throwsFirst = e -> {
+            throw new IllegalStateException("first failure");
+        };
+        Consumer<Map<String, Object>> succeeds = e -> called.add("succeeded");
+        Consumer<Map<String, Object>> throwsSecond = e -> {
+            throw new RuntimeException("second failure");
+        };
+
+        assertDoesNotThrow(() -> ObservabilityHooks.fireEvent(Map.of(), List.of(throwsFirst, succeeds, throwsSecond), "hook"));
+        assertEquals(List.of("succeeded"), called);
+    }
+}


### PR DESCRIPTION
Fourth module of the Java port (see java/HANDOVER.md, PRs #318-322 for prior context). Ports ObservabilityHooks.fireEvent - fire-and-forget event dispatch to handler callbacks, with exceptions from any handler logged and swallowed rather than propagated. 7 new JUnit tests, 39/39 passing overall. Touches only java/. First PR where CI/ragleap-rag-java-tests runs against an actual code change rather than just being added.