### PR TITLE
feat(java-port): port guardrails.py to Java

### DIFF
--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/guardrails/GuardrailRunner.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/guardrails/GuardrailRunner.java
@@ -1,0 +1,43 @@
+package com.ragleap.rag.guardrails;
+
+import java.util.List;
+import java.util.function.UnaryOperator;
+
+/**
+ * Guardrail hooks for ragleap-rag - user-supplied validation callbacks
+ * for ingested content (input guardrails) and generated answers
+ * (output guardrails). Java port of ragleap-rag's guardrails.py.
+ *
+ * This extends the existing sanitization module (see
+ * com.ragleap.rag.sanitization.ContentSanitizer for null-byte
+ * stripping and injection-risk heuristics) rather than replacing it -
+ * guardrails run in addition to, after, that baseline.
+ *
+ * Unlike ObservabilityHooks, guardrails are NOT fire-and-forget: no
+ * exception is caught here. A guardrail throwing (whether
+ * GuardrailViolation or anything else) propagates straight through to
+ * the caller - matching the Python source exactly, which has no
+ * try/except around the guardrail call.
+ */
+public final class GuardrailRunner {
+
+    private GuardrailRunner() {
+    }
+
+    /**
+     * Run each guardrail in order, threading the (possibly modified)
+     * text through each one. A guardrail can either return a (possibly
+     * transformed) string, or throw GuardrailViolation to reject the
+     * content outright.
+     */
+    public static String runGuardrails(String text, List<UnaryOperator<String>> guardrails) {
+        if (guardrails == null || guardrails.isEmpty()) {
+            return text;
+        }
+        String result = text;
+        for (UnaryOperator<String> guardrail : guardrails) {
+            result = guardrail.apply(result);
+        }
+        return result;
+    }
+}

--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/guardrails/GuardrailViolation.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/guardrails/GuardrailViolation.java
@@ -1,0 +1,19 @@
+package com.ragleap.rag.guardrails;
+
+/**
+ * Throw this from a guardrail function to reject content.
+ * Java port of ragleap-rag's guardrails.py — GuardrailViolation.
+ *
+ * For input guardrails, this aborts ingestion - nothing is stored.
+ * For output guardrails on the (not yet ported) non-streaming ask(),
+ * this replaces the answer with a refusal message before it's
+ * returned. For the (not yet ported) streaming ask_stream(), by the
+ * time this fires, individual tokens may have already been yielded to
+ * the caller — that streaming-vs-non-streaming enforcement distinction
+ * lives in the caller, not in this class or in GuardrailRunner below.
+ */
+public class GuardrailViolation extends RuntimeException {
+    public GuardrailViolation(String message) {
+        super(message);
+    }
+}

--- a/java/ragleap-rag/src/test/java/com/ragleap/rag/guardrails/GuardrailRunnerTest.java
+++ b/java/ragleap-rag/src/test/java/com/ragleap/rag/guardrails/GuardrailRunnerTest.java
@@ -1,0 +1,71 @@
+package com.ragleap.rag.guardrails;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.function.UnaryOperator;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GuardrailRunnerTest {
+
+    @Test
+    void nullGuardrailsReturnsTextUnchanged() {
+        assertEquals("hello world", GuardrailRunner.runGuardrails("hello world", null));
+    }
+
+    @Test
+    void emptyGuardrailsReturnsTextUnchanged() {
+        assertEquals("hello world", GuardrailRunner.runGuardrails("hello world", List.of()));
+    }
+
+    @Test
+    void singleGuardrailTransformsText() {
+        UnaryOperator<String> upper = String::toUpperCase;
+        assertEquals("HELLO", GuardrailRunner.runGuardrails("hello", List.of(upper)));
+    }
+
+    @Test
+    void multipleGuardrailsThreadTextInOrder() {
+        UnaryOperator<String> upper = String::toUpperCase;
+        UnaryOperator<String> exclaim = s -> s + "!";
+        assertEquals("HELLO!", GuardrailRunner.runGuardrails("hello", List.of(upper, exclaim)));
+    }
+
+    @Test
+    void guardrailViolationPropagatesNotSwallowed() {
+        UnaryOperator<String> rejecting = s -> {
+            throw new GuardrailViolation("contains banned phrase");
+        };
+        GuardrailViolation ex = assertThrows(GuardrailViolation.class,
+                () -> GuardrailRunner.runGuardrails("bad text", List.of(rejecting)));
+        assertEquals("contains banned phrase", ex.getMessage());
+    }
+
+    @Test
+    void nonGuardrailExceptionAlsoPropagates() {
+        // The Python source has no try/except at all - ANY exception
+        // propagates, not just GuardrailViolation. Confirm that holds here too.
+        UnaryOperator<String> buggy = s -> {
+            throw new IllegalStateException("unrelated bug");
+        };
+        assertThrows(IllegalStateException.class,
+                () -> GuardrailRunner.runGuardrails("text", List.of(buggy)));
+    }
+
+    @Test
+    void laterGuardrailNeverRunsAfterEarlierOneThrows() {
+        boolean[] secondRan = {false};
+        UnaryOperator<String> throwsFirst = s -> {
+            throw new GuardrailViolation("rejected");
+        };
+        UnaryOperator<String> second = s -> {
+            secondRan[0] = true;
+            return s;
+        };
+
+        assertThrows(GuardrailViolation.class,
+                () -> GuardrailRunner.runGuardrails("text", List.of(throwsFirst, second)));
+        assertFalse(secondRan[0]);
+    }
+}


### PR DESCRIPTION
Fifth module of the Java port (see java/HANDOVER.md, PRs #318-323 for prior context). Ports GuardrailViolation + GuardrailRunner.runGuardrails. Key distinction from ObservabilityHooks: no exception catching here - guardrails intentionally propagate, matching the Python source's lack of try/except. 7 new JUnit tests, 46/46 passing overall. Touches only java/.