### PR TITLE
feat(java-port): port cost.py to Java

### DIFF
--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/cost/CostCalculator.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/cost/CostCalculator.java
@@ -1,0 +1,98 @@
+package com.ragleap.rag.cost;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Cost tracking for ragleap-rag - computes real USD cost per ask() call
+ * from actual provider-reported token usage. Java port of ragleap-rag's
+ * cost.py (the stateless lookup/calculation half - see CostTracker for
+ * the stateful cumulative-spend half).
+ *
+ * Honest limitation, same as the Python source: LLM API pricing changes
+ * frequently. The seed table below covers only Gemini, Anthropic, and
+ * OpenAI as verified on PRICING_TABLE_VERIFIED_DATE, and WILL go stale.
+ * Pass an override table to CostTracker's constructor to keep costs
+ * accurate - this is the expected, normal way to use it, not an edge
+ * case. Unknown provider/model combinations return null rather than
+ * guessing.
+ */
+public final class CostCalculator {
+
+    private CostCalculator() {
+    }
+
+    public static final String PRICING_TABLE_VERIFIED_DATE = "2026-07-28";
+
+    // USD per 1 million tokens. Verified against provider pricing pages/
+    // documentation on PRICING_TABLE_VERIFIED_DATE above - see the
+    // ragleap-rag README for sourcing notes. Ollama is $0 by design
+    // (fully local inference, no per-token API cost).
+    public static final Map<String, Map<String, Rate>> SEED_PRICING_TABLE = buildSeedTable();
+
+    private static Map<String, Map<String, Rate>> buildSeedTable() {
+        Map<String, Map<String, Rate>> table = new HashMap<>();
+
+        Map<String, Rate> gemini = new HashMap<>();
+        gemini.put("gemini-3.6-flash", new Rate(1.50, 7.50));
+        gemini.put("gemini-3.1-pro", new Rate(2.00, 12.00));
+        gemini.put("gemini-2.5-flash-lite", new Rate(0.10, 0.40));
+        table.put("gemini", gemini);
+
+        Map<String, Rate> anthropic = new HashMap<>();
+        anthropic.put("claude-haiku-4-5-20251001", new Rate(1.00, 5.00));
+        anthropic.put("claude-sonnet-5", new Rate(2.00, 10.00));
+        anthropic.put("claude-opus-5", new Rate(5.00, 25.00));
+        anthropic.put("claude-fable-5", new Rate(10.00, 50.00));
+        table.put("anthropic", anthropic);
+
+        Map<String, Rate> openai = new HashMap<>();
+        openai.put("gpt-5.6-luna", new Rate(1.00, 6.00));
+        openai.put("gpt-5.6-terra", new Rate(2.50, 15.00));
+        openai.put("gpt-5.6-sol", new Rate(5.00, 30.00));
+        table.put("openai", openai);
+
+        Map<String, Rate> ollama = new HashMap<>();
+        ollama.put("*", new Rate(0.0, 0.0)); // wildcard entry: any local model, $0
+        table.put("ollama", ollama);
+
+        return table;
+    }
+
+    static Rate lookupRate(Map<String, Map<String, Rate>> pricingTable, String provider, String model) {
+        Map<String, Rate> providerTable = pricingTable.get(provider);
+        if (providerTable == null || providerTable.isEmpty()) {
+            return null;
+        }
+        if (model != null && providerTable.containsKey(model)) {
+            return providerTable.get(model);
+        }
+        if (providerTable.containsKey("*")) { // wildcard entry, e.g. Ollama
+            return providerTable.get("*");
+        }
+        return null;
+    }
+
+    /**
+     * Return USD cost for this call, or null if the provider/model isn't
+     * in the pricing table (never guesses) or usage data is unavailable.
+     *
+     * usage may be null OR empty - both mean "no usage data", matching
+     * Python's `if not usage` truthiness check on an empty dict.
+     */
+    public static Double computeCost(Map<String, Map<String, Rate>> pricingTable, String provider, String model, Map<String, Integer> usage) {
+        if (provider == null || usage == null || usage.isEmpty()) {
+            return null;
+        }
+        Rate rate = lookupRate(pricingTable, provider, model);
+        if (rate == null) {
+            return null;
+        }
+
+        int promptTokens = usage.getOrDefault("prompt_tokens", 0);
+        int completionTokens = usage.getOrDefault("completion_tokens", 0);
+
+        double cost = (promptTokens / 1_000_000.0) * rate.input() + (completionTokens / 1_000_000.0) * rate.output();
+        return Math.round(cost * 1_000_000.0) / 1_000_000.0; // round to 6 decimal places
+    }
+}

--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/cost/CostTracker.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/cost/CostTracker.java
@@ -1,0 +1,66 @@
+package com.ragleap.rag.cost;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tracks cumulative spend and pricing table for a RagLeap instance.
+ * Java port of ragleap-rag's cost.py — CostTracker.
+ *
+ * Not thread-safe by itself for the cumulative counter under heavy
+ * concurrent use - acceptable for the common case (a single process
+ * tracking its own approximate spend), not a precise multi-worker
+ * ledger. For that, aggregate cost from on_answer hook events
+ * externally instead (see com.ragleap.rag.observability.ObservabilityHooks).
+ */
+public class CostTracker {
+
+    private final Map<String, Map<String, Rate>> pricingTable;
+    private final Double budgetUsdPerMonth;
+    private double cumulativeCostUsd = 0.0;
+
+    public CostTracker() {
+        this(null, null);
+    }
+
+    public CostTracker(Map<String, Map<String, Rate>> pricingTableOverride, Double budgetUsdPerMonth) {
+        this.pricingTable = mergePricingTables(CostCalculator.SEED_PRICING_TABLE,
+                pricingTableOverride != null ? pricingTableOverride : Map.of());
+        this.budgetUsdPerMonth = budgetUsdPerMonth;
+    }
+
+    static Map<String, Map<String, Rate>> mergePricingTables(Map<String, Map<String, Rate>> base, Map<String, Map<String, Rate>> override) {
+        Map<String, Map<String, Rate>> merged = new HashMap<>();
+        for (Map.Entry<String, Map<String, Rate>> entry : base.entrySet()) {
+            merged.put(entry.getKey(), new HashMap<>(entry.getValue()));
+        }
+        for (Map.Entry<String, Map<String, Rate>> entry : override.entrySet()) {
+            Map<String, Rate> providerModels = merged.computeIfAbsent(entry.getKey(), k -> new HashMap<>());
+            providerModels.putAll(entry.getValue());
+        }
+        return merged;
+    }
+
+    public Double record(String provider, String model, Map<String, Integer> usage) {
+        Double cost = CostCalculator.computeCost(pricingTable, provider, model, usage);
+        if (cost != null) {
+            cumulativeCostUsd += cost;
+        }
+        return cost;
+    }
+
+    public boolean isOverBudget() {
+        if (budgetUsdPerMonth == null) {
+            return false;
+        }
+        return cumulativeCostUsd >= budgetUsdPerMonth;
+    }
+
+    public double getCumulativeCostUsd() {
+        return cumulativeCostUsd;
+    }
+
+    public Map<String, Map<String, Rate>> getPricingTable() {
+        return pricingTable;
+    }
+}

--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/cost/Rate.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/cost/Rate.java
@@ -1,0 +1,9 @@
+package com.ragleap.rag.cost;
+
+/**
+ * USD price per 1 million tokens for one provider/model pair.
+ * Java equivalent of the {"input": ..., "output": ...} dict values in
+ * cost.py's pricing tables.
+ */
+public record Rate(double input, double output) {
+}

--- a/java/ragleap-rag/src/test/java/com/ragleap/rag/cost/CostCalculatorTest.java
+++ b/java/ragleap-rag/src/test/java/com/ragleap/rag/cost/CostCalculatorTest.java
@@ -1,0 +1,64 @@
+package com.ragleap.rag.cost;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CostCalculatorTest {
+
+    @Test
+    void computesKnownProviderModelCost() {
+        // claude-sonnet-5: input $2.00/1M, output $10.00/1M
+        Map<String, Integer> usage = Map.of("prompt_tokens", 1_000_000, "completion_tokens", 500_000);
+        Double cost = CostCalculator.computeCost(CostCalculator.SEED_PRICING_TABLE, "anthropic", "claude-sonnet-5", usage);
+        assertNotNull(cost);
+        assertEquals(2.00 + 5.00, cost, 0.000001);
+    }
+
+    @Test
+    void unknownProviderReturnsNullNotZero() {
+        Map<String, Integer> usage = Map.of("prompt_tokens", 100, "completion_tokens", 50);
+        assertNull(CostCalculator.computeCost(CostCalculator.SEED_PRICING_TABLE, "unknown-provider", "some-model", usage));
+    }
+
+    @Test
+    void unknownModelWithNoWildcardReturnsNull() {
+        Map<String, Integer> usage = Map.of("prompt_tokens", 100, "completion_tokens", 50);
+        assertNull(CostCalculator.computeCost(CostCalculator.SEED_PRICING_TABLE, "anthropic", "claude-nonexistent", usage));
+    }
+
+    @Test
+    void ollamaWildcardMatchesAnyModel() {
+        Map<String, Integer> usage = Map.of("prompt_tokens", 1_000_000, "completion_tokens", 1_000_000);
+        Double cost = CostCalculator.computeCost(CostCalculator.SEED_PRICING_TABLE, "ollama", "any-local-model-name", usage);
+        assertNotNull(cost);
+        assertEquals(0.0, cost);
+    }
+
+    @Test
+    void nullProviderReturnsNull() {
+        Map<String, Integer> usage = Map.of("prompt_tokens", 100, "completion_tokens", 50);
+        assertNull(CostCalculator.computeCost(CostCalculator.SEED_PRICING_TABLE, null, "claude-sonnet-5", usage));
+    }
+
+    @Test
+    void nullUsageReturnsNull() {
+        assertNull(CostCalculator.computeCost(CostCalculator.SEED_PRICING_TABLE, "anthropic", "claude-sonnet-5", null));
+    }
+
+    @Test
+    void emptyUsageMapReturnsNull() {
+        // Matches Python's `if not usage` - an empty dict is falsy too,
+        // not just None/null.
+        assertNull(CostCalculator.computeCost(CostCalculator.SEED_PRICING_TABLE, "anthropic", "claude-sonnet-5", Map.of()));
+    }
+
+    @Test
+    void missingTokenKeysDefaultToZero() {
+        Double cost = CostCalculator.computeCost(CostCalculator.SEED_PRICING_TABLE, "anthropic", "claude-sonnet-5",
+                Map.of("prompt_tokens", 1_000_000));
+        assertEquals(2.00, cost, 0.000001);
+    }
+}

--- a/java/ragleap-rag/src/test/java/com/ragleap/rag/cost/CostTrackerTest.java
+++ b/java/ragleap-rag/src/test/java/com/ragleap/rag/cost/CostTrackerTest.java
@@ -1,0 +1,88 @@
+package com.ragleap.rag.cost;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CostTrackerTest {
+
+    @Test
+    void recordReturnsAndAccumulatesCost() {
+        CostTracker tracker = new CostTracker();
+        Double cost1 = tracker.record("anthropic", "claude-sonnet-5", Map.of("prompt_tokens", 1_000_000, "completion_tokens", 0));
+        Double cost2 = tracker.record("anthropic", "claude-sonnet-5", Map.of("prompt_tokens", 1_000_000, "completion_tokens", 0));
+
+        assertEquals(2.00, cost1, 0.000001);
+        assertEquals(2.00, cost2, 0.000001);
+        assertEquals(4.00, tracker.getCumulativeCostUsd(), 0.000001);
+    }
+
+    @Test
+    void unrecordableCallDoesNotAffectCumulative() {
+        CostTracker tracker = new CostTracker();
+        Double cost = tracker.record("unknown-provider", "model", Map.of("prompt_tokens", 100, "completion_tokens", 50));
+
+        assertNull(cost);
+        assertEquals(0.0, tracker.getCumulativeCostUsd());
+    }
+
+    @Test
+    void isOverBudgetFalseWhenNoBudgetSet() {
+        CostTracker tracker = new CostTracker();
+        tracker.record("anthropic", "claude-opus-5", Map.of("prompt_tokens", 10_000_000, "completion_tokens", 10_000_000));
+        assertFalse(tracker.isOverBudget());
+    }
+
+    @Test
+    void isOverBudgetTrueWhenCumulativeMeetsOrExceedsBudget() {
+        CostTracker tracker = new CostTracker(null, 1.00);
+        tracker.record("anthropic", "claude-sonnet-5", Map.of("prompt_tokens", 1_000_000, "completion_tokens", 0)); // $2.00
+
+        assertTrue(tracker.isOverBudget());
+    }
+
+    @Test
+    void isOverBudgetFalseWhenBelowBudget() {
+        CostTracker tracker = new CostTracker(null, 100.00);
+        tracker.record("anthropic", "claude-sonnet-5", Map.of("prompt_tokens", 1_000_000, "completion_tokens", 0)); // $2.00
+
+        assertFalse(tracker.isOverBudget());
+    }
+
+    @Test
+    void overrideTableAddsNewModelWithoutRemovingSeedModels() {
+        Map<String, Map<String, Rate>> override = Map.of(
+                "anthropic", Map.of("claude-future-model", new Rate(3.00, 15.00))
+        );
+        CostTracker tracker = new CostTracker(override, null);
+
+        Double newModelCost = tracker.record("anthropic", "claude-future-model", Map.of("prompt_tokens", 1_000_000, "completion_tokens", 0));
+        Double existingModelCost = tracker.record("anthropic", "claude-sonnet-5", Map.of("prompt_tokens", 1_000_000, "completion_tokens", 0));
+
+        assertEquals(3.00, newModelCost, 0.000001);
+        assertEquals(2.00, existingModelCost, 0.000001); // seed model still present
+    }
+
+    @Test
+    void overrideTableCanReplaceExistingRate() {
+        Map<String, Map<String, Rate>> override = Map.of(
+                "anthropic", Map.of("claude-sonnet-5", new Rate(1.00, 1.00))
+        );
+        CostTracker tracker = new CostTracker(override, null);
+
+        Double cost = tracker.record("anthropic", "claude-sonnet-5", Map.of("prompt_tokens", 1_000_000, "completion_tokens", 1_000_000));
+        assertEquals(2.00, cost, 0.000001); // 1.00 input + 1.00 output, not the seed 2.00+10.00
+    }
+
+    @Test
+    void seedPricingTableUnaffectedByTrackerInstances() {
+        // The merge must not mutate CostCalculator.SEED_PRICING_TABLE itself
+        new CostTracker(Map.of("anthropic", Map.of("claude-sonnet-5", new Rate(999.0, 999.0))), null);
+
+        Rate seedRate = CostCalculator.SEED_PRICING_TABLE.get("anthropic").get("claude-sonnet-5");
+        assertEquals(2.00, seedRate.input());
+        assertEquals(10.00, seedRate.output());
+    }
+}


### PR DESCRIPTION
Sixth module of the Java port (see java/HANDOVER.md, PRs #318-324 for prior context). Ports the seed pricing table + CostCalculator.computeCost + CostTracker (cumulative spend, budget check, pricing-table override/merge). 16 new JUnit tests, 62/62 passing overall. Touches only java/.