### PR TITLE
feat(java-port): port evaluation.py scoring logic to Java

### DIFF
--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/evaluation/CaseResult.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/evaluation/CaseResult.java
@@ -1,0 +1,22 @@
+package com.ragleap.rag.evaluation;
+
+import java.util.List;
+
+/**
+ * Per-case scoring detail. Java equivalent of the dict returned by
+ * evaluate_case() in evaluation.py.
+ *
+ * Boolean/Double (boxed) fields use null the same way Python uses None -
+ * to mean "not applicable to this case" (e.g. retrievalHit is null when
+ * the case had no expectedDocument), not "false"/"0.0".
+ */
+public record CaseResult(
+        String query,
+        String answer,
+        List<String> sources,
+        Boolean retrievalHit,
+        Double keywordCoverage,
+        List<String> keywordsFound,
+        Double groundedness
+) {
+}

--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/evaluation/EvalCase.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/evaluation/EvalCase.java
@@ -1,0 +1,13 @@
+package com.ragleap.rag.evaluation;
+
+import java.util.List;
+
+/**
+ * A single evaluation test case, mirroring cost.py's EvalCase TypedDict
+ * from ragleap-rag's evaluation.py.
+ */
+public record EvalCase(String query, String expectedDocument, List<String> expectedKeywords) {
+    public EvalCase(String query) {
+        this(query, null, List.of());
+    }
+}

--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/evaluation/EvalScorer.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/evaluation/EvalScorer.java
@@ -1,0 +1,118 @@
+package com.ragleap.rag.evaluation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * Lightweight, deterministic evaluation scoring for ragleap-rag. Java
+ * port of the scoring half of evaluation.py — NOT the rag.ask()-calling
+ * half (see RagAnswer's javadoc for why that part is deliberately not
+ * ported yet).
+ *
+ * Honest scope, same as the Python source: this is NOT an LLM-as-judge
+ * framework - it does three deterministic, measurable checks instead:
+ * retrieval hit rate, keyword coverage, and citation groundedness
+ * (substring matching, not semantic understanding - a heuristic signal,
+ * not proof).
+ */
+public final class EvalScorer {
+
+    private static final Logger logger = Logger.getLogger(EvalScorer.class.getName());
+
+    private EvalScorer() {
+    }
+
+    static List<String> keywordHits(String text, List<String> keywords) {
+        String textLower = text.toLowerCase();
+        List<String> hits = new ArrayList<>();
+        for (String kw : keywords) {
+            if (textLower.contains(kw.toLowerCase())) {
+                hits.add(kw);
+            }
+        }
+        return hits;
+    }
+
+    /**
+     * Score a single already-produced RagAnswer against its EvalCase
+     * expectations. Java equivalent of evaluate_case()'s scoring logic,
+     * given the answer rag.ask() would have produced.
+     */
+    public static CaseResult scoreCase(EvalCase evalCase, RagAnswer answer) {
+        List<String> expectedKeywords = evalCase.expectedKeywords() != null ? evalCase.expectedKeywords() : List.of();
+
+        Boolean retrievalHit = null;
+        if (evalCase.expectedDocument() != null) {
+            List<String> sources = answer.sources() != null ? answer.sources() : List.of();
+            retrievalHit = sources.contains(evalCase.expectedDocument());
+        }
+
+        List<String> keywordHits = keywordHits(answer.answer() != null ? answer.answer() : "", expectedKeywords);
+        Double keywordCoverage = expectedKeywords.isEmpty() ? null : (double) keywordHits.size() / expectedKeywords.size();
+
+        Double groundedness = null;
+        if (!keywordHits.isEmpty()) {
+            List<RagAnswer.CitationPreview> citations = answer.citations() != null ? answer.citations() : List.of();
+            StringBuilder citedText = new StringBuilder();
+            for (RagAnswer.CitationPreview c : citations) {
+                if (citedText.length() > 0) {
+                    citedText.append(" ");
+                }
+                citedText.append(c.textPreview() != null ? c.textPreview() : "");
+            }
+            List<String> groundedHits = keywordHits(citedText.toString(), keywordHits);
+            groundedness = (double) groundedHits.size() / keywordHits.size();
+        }
+
+        return new CaseResult(
+                evalCase.query(),
+                answer.answer(),
+                answer.sources() != null ? answer.sources() : List.of(),
+                retrievalHit,
+                keywordCoverage,
+                keywordHits,
+                groundedness
+        );
+    }
+
+    /**
+     * Aggregate a set of already-scored CaseResults into overall rates.
+     * Java equivalent of evaluate()'s aggregation logic, given the
+     * per-case results (produced by calling scoreCase() once per case
+     * after obtaining each answer from rag.ask() - not implemented here).
+     */
+    public static EvaluationResult aggregate(List<CaseResult> results) {
+        if (results == null || results.isEmpty()) {
+            throw new IllegalArgumentException("evaluate() requires at least one test case.");
+        }
+
+        Double retrievalHitRate = average(
+                results.stream().map(CaseResult::retrievalHit).filter(java.util.Objects::nonNull)
+                        .map(b -> b ? 1.0 : 0.0).toList()
+        );
+        Double keywordCoverageRate = average(
+                results.stream().map(CaseResult::keywordCoverage).filter(java.util.Objects::nonNull).toList()
+        );
+        Double groundednessRate = average(
+                results.stream().map(CaseResult::groundedness).filter(java.util.Objects::nonNull).toList()
+        );
+
+        logger.info(() -> String.format(
+                "Evaluation complete: %d cases, retrieval_hit_rate=%s, keyword_coverage_rate=%s, groundedness_rate=%s",
+                results.size(), retrievalHitRate, keywordCoverageRate, groundednessRate));
+
+        return new EvaluationResult(retrievalHitRate, keywordCoverageRate, groundednessRate, results);
+    }
+
+    private static Double average(List<Double> values) {
+        if (values.isEmpty()) {
+            return null;
+        }
+        double sum = 0.0;
+        for (double v : values) {
+            sum += v;
+        }
+        return sum / values.size();
+    }
+}

--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/evaluation/EvaluationResult.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/evaluation/EvaluationResult.java
@@ -1,0 +1,16 @@
+package com.ragleap.rag.evaluation;
+
+import java.util.List;
+
+/**
+ * Aggregated evaluation result. Java equivalent of evaluate()'s return
+ * dict in evaluation.py. The three rate fields are null when no case
+ * contributed a value for that metric - matching Python's None, not 0.0.
+ */
+public record EvaluationResult(
+        Double retrievalHitRate,
+        Double keywordCoverageRate,
+        Double groundednessRate,
+        List<CaseResult> results
+) {
+}

--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/evaluation/RagAnswer.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/evaluation/RagAnswer.java
@@ -1,0 +1,22 @@
+package com.ragleap.rag.evaluation;
+
+import java.util.List;
+
+/**
+ * An already-produced answer from a RAG pipeline - the Java equivalent
+ * of the dict returned by rag.ask() in the Python source, which
+ * evaluation.py's evaluate_case()/evaluate() call directly.
+ *
+ * NOT PORTED HERE: the actual rag.ask() call itself. That requires the
+ * not-yet-ported retrieval + generation pipeline (real LLM API calls),
+ * same category of external dependency as db.py's ConnectionPool. This
+ * class exists so the deterministic scoring logic below (EvalScorer)
+ * can be ported and genuinely unit-tested now, decoupled from producing
+ * the answer - once rag.ask() exists in Java, its result maps to this
+ * record and scoreCase()/evaluate() work unchanged.
+ */
+public record RagAnswer(String answer, List<String> sources, List<CitationPreview> citations) {
+
+    public record CitationPreview(String textPreview) {
+    }
+}

--- a/java/ragleap-rag/src/test/java/com/ragleap/rag/evaluation/EvalScorerTest.java
+++ b/java/ragleap-rag/src/test/java/com/ragleap/rag/evaluation/EvalScorerTest.java
@@ -1,0 +1,105 @@
+package com.ragleap.rag.evaluation;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EvalScorerTest {
+
+    @Test
+    void retrievalHitTrueWhenExpectedDocumentInSources() {
+        EvalCase evalCase = new EvalCase("who founded ragleap?", "founders.md", List.of());
+        RagAnswer answer = new RagAnswer("Antony founded RagLeap.", List.of("founders.md", "about.md"), List.of());
+
+        CaseResult result = EvalScorer.scoreCase(evalCase, answer);
+        assertEquals(Boolean.TRUE, result.retrievalHit());
+    }
+
+    @Test
+    void retrievalHitFalseWhenExpectedDocumentMissing() {
+        EvalCase evalCase = new EvalCase("who founded ragleap?", "founders.md", List.of());
+        RagAnswer answer = new RagAnswer("Antony founded RagLeap.", List.of("about.md"), List.of());
+
+        CaseResult result = EvalScorer.scoreCase(evalCase, answer);
+        assertEquals(Boolean.FALSE, result.retrievalHit());
+    }
+
+    @Test
+    void retrievalHitNullWhenNoExpectedDocument() {
+        EvalCase evalCase = new EvalCase("what is ragleap?", null, List.of());
+        RagAnswer answer = new RagAnswer("A RAG platform.", List.of("about.md"), List.of());
+
+        assertNull(EvalScorer.scoreCase(evalCase, answer).retrievalHit());
+    }
+
+    @Test
+    void keywordCoveragePartialMatch() {
+        EvalCase evalCase = new EvalCase("what channels?", null, List.of("whatsapp", "telegram", "fax"));
+        RagAnswer answer = new RagAnswer("We support WhatsApp and Telegram.", List.of(), List.of());
+
+        CaseResult result = EvalScorer.scoreCase(evalCase, answer);
+        assertEquals(2.0 / 3.0, result.keywordCoverage(), 0.000001);
+        assertEquals(List.of("whatsapp", "telegram"), result.keywordsFound());
+    }
+
+    @Test
+    void keywordCoverageNullWhenNoExpectedKeywords() {
+        EvalCase evalCase = new EvalCase("hello", null, List.of());
+        RagAnswer answer = new RagAnswer("hi there", List.of(), List.of());
+
+        assertNull(EvalScorer.scoreCase(evalCase, answer).keywordCoverage());
+    }
+
+    @Test
+    void groundednessComputedFromCitedText() {
+        EvalCase evalCase = new EvalCase("q", null, List.of("gemini", "openai"));
+        RagAnswer answer = new RagAnswer(
+                "We support Gemini and OpenAI.",
+                List.of(),
+                List.of(new RagAnswer.CitationPreview("RagLeap integrates with Gemini for embeddings."))
+        );
+
+        CaseResult result = EvalScorer.scoreCase(evalCase, answer);
+        // "gemini" found in cited text, "openai" found in answer but not cited
+        assertEquals(0.5, result.groundedness(), 0.000001);
+    }
+
+    @Test
+    void groundednessNullWhenNoKeywordHits() {
+        EvalCase evalCase = new EvalCase("q", null, List.of("nonexistent"));
+        RagAnswer answer = new RagAnswer("unrelated answer", List.of(), List.of());
+
+        assertNull(EvalScorer.scoreCase(evalCase, answer).groundedness());
+    }
+
+    @Test
+    void aggregateComputesRatesAcrossCases() {
+        CaseResult r1 = new CaseResult("q1", "a1", List.of(), true, 1.0, List.of("k1"), 1.0);
+        CaseResult r2 = new CaseResult("q2", "a2", List.of(), false, 0.5, List.of("k1"), 0.0);
+
+        EvaluationResult result = EvalScorer.aggregate(List.of(r1, r2));
+
+        assertEquals(0.5, result.retrievalHitRate(), 0.000001);
+        assertEquals(0.75, result.keywordCoverageRate(), 0.000001);
+        assertEquals(0.5, result.groundednessRate(), 0.000001);
+        assertEquals(2, result.results().size());
+    }
+
+    @Test
+    void aggregateRatesNullWhenNoCaseContributesThatMetric() {
+        CaseResult r1 = new CaseResult("q1", "a1", List.of(), null, null, List.of(), null);
+
+        EvaluationResult result = EvalScorer.aggregate(List.of(r1));
+
+        assertNull(result.retrievalHitRate());
+        assertNull(result.keywordCoverageRate());
+        assertNull(result.groundednessRate());
+    }
+
+    @Test
+    void aggregateThrowsOnEmptyResults() {
+        assertThrows(IllegalArgumentException.class, () -> EvalScorer.aggregate(List.of()));
+    }
+}


### PR DESCRIPTION
Seventh module of the Java port (see java/HANDOVER.md, PRs #318-325 for prior context). Ports the deterministic scoring half of evaluation.py: EvalScorer.scoreCase (retrieval hit, keyword coverage, groundedness) and aggregate(). Deliberately does NOT port evaluate_case()/evaluate()'s rag.ask() call - that's the not-yet-ported retrieval+generation pipeline, same external-dependency category as db.py. RagAnswer models what rag.ask() would produce so this scoring logic is unit-testable now and will work unchanged once rag.ask() is ported. 10 new JUnit tests, 72/72 passing overall. Touches only java/.