### PR TITLE
feat(java-port): port structured.py to Java

### DIFF
--- a/java/ragleap-rag/pom.xml
+++ b/java/ragleap-rag/pom.xml
@@ -47,6 +47,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
         <jtokkit.version>1.1.0</jtokkit.version>
+        <json-schema-validator.version>1.5.5</json-schema-validator.version>
     </properties>
 
     <dependencies>
@@ -58,6 +59,17 @@
             <groupId>com.knuddels</groupId>
             <artifactId>jtokkit</artifactId>
             <version>${jtokkit.version}</version>
+        </dependency>
+
+        <!-- Real JSON Schema validation (drafts v4 through 2020-12) -
+             the Java equivalent of Python's jsonschema library, used
+             for the same purpose: validating structured LLM output
+             against a user-supplied schema. Pulls in jackson-databind
+             transitively, which we also use directly for JSON parsing. -->
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <version>${json-schema-validator.version}</version>
         </dependency>
 
         <dependency>

--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/structured/StructuredOutputValidator.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/structured/StructuredOutputValidator.java
@@ -1,0 +1,107 @@
+package com.ragleap.rag.structured;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SchemaValidatorsConfig;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+
+import java.util.Set;
+import java.util.logging.Logger;
+
+/**
+ * Structured output support for ragleap-rag - validates model responses
+ * against a user-supplied JSON schema. Java port of ragleap-rag's
+ * structured.py.
+ *
+ * Uses com.networknt:json-schema-validator for real schema validation -
+ * the Java equivalent of Python's jsonschema library, supporting the
+ * same range of JSON Schema drafts (v4 through 2020-12).
+ *
+ * See ValidationMethod's javadoc for why, unlike Python, the "library
+ * not installed" fallback path is not reachable through the normal API
+ * here - it's a hard Maven dependency, always present.
+ */
+public final class StructuredOutputValidator {
+
+    private static final Logger logger = Logger.getLogger(StructuredOutputValidator.class.getName());
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    // Defaults to the 2020-12 draft when a schema doesn't declare its own
+    // $schema - networknt's factory still honors an explicit $schema in
+    // the supplied schema document via getSchema(), this is only the
+    // fallback used when none is present.
+    private static final JsonSchemaFactory SCHEMA_FACTORY =
+            JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012);
+
+    private StructuredOutputValidator() {
+    }
+
+    /**
+     * Parse rawText as JSON and validate against schema. Never throws -
+     * a malformed response results in a ValidationResult with a null
+     * parsed value and valid=false.
+     */
+    public static ValidationResult parseAndValidate(String rawText, JsonNode schema) {
+        JsonNode parsed;
+        try {
+            parsed = MAPPER.readTree(rawText);
+        } catch (JsonProcessingException e) {
+            return new ValidationResult(null, false, ValidationMethod.JSONSCHEMA);
+        }
+        return validateWithJsonSchema(parsed, schema);
+    }
+
+    /**
+     * Same as parseAndValidate(), but for providers (Anthropic tool-use)
+     * that hand back an already-parsed JsonNode instead of a raw JSON
+     * string.
+     */
+    public static ValidationResult parseAndValidateObject(JsonNode obj, JsonNode schema) {
+        return validateWithJsonSchema(obj, schema);
+    }
+
+    private static ValidationResult validateWithJsonSchema(JsonNode instance, JsonNode schema) {
+        JsonSchema jsonSchema;
+        try {
+            jsonSchema = SCHEMA_FACTORY.getSchema(schema);
+        } catch (Exception e) {
+            logger.severe("Invalid JSON schema passed to response_format=: " + e.getMessage());
+            return new ValidationResult(instance, false, ValidationMethod.JSONSCHEMA);
+        }
+
+        Set<ValidationMessage> errors = jsonSchema.validate(instance);
+        if (!errors.isEmpty()) {
+            String messages = errors.stream().map(ValidationMessage::getMessage)
+                    .reduce((a, b) -> a + "; " + b).orElse("");
+            logger.warning("Structured output failed schema validation: " + messages);
+            return new ValidationResult(instance, false, ValidationMethod.JSONSCHEMA);
+        }
+        return new ValidationResult(instance, true, ValidationMethod.JSONSCHEMA);
+    }
+
+    /**
+     * Basic top-level type check only - does NOT verify nested structure.
+     * Ported for documentation parity with the Python source's fallback
+     * path (see ValidationMethod's javadoc); not reachable through
+     * parseAndValidate()/parseAndValidateObject() in the normal Java API,
+     * since the real validator is always available here.
+     */
+    static boolean basicTypeCheckOnly(JsonNode instance, JsonNode schema) {
+        JsonNode typeNode = schema.get("type");
+        if (typeNode == null || !typeNode.isTextual()) {
+            return true;
+        }
+        return switch (typeNode.asText()) {
+            case "object" -> instance.isObject();
+            case "array" -> instance.isArray();
+            case "string" -> instance.isTextual();
+            case "number" -> instance.isNumber();
+            case "boolean" -> instance.isBoolean();
+            default -> true;
+        };
+    }
+}

--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/structured/ValidationMethod.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/structured/ValidationMethod.java
@@ -1,0 +1,20 @@
+package com.ragleap.rag.structured;
+
+/**
+ * Which validation approach actually ran. Java equivalent of the
+ * "jsonschema" / "basic_type_check_only" strings returned by
+ * structured.py's parse_and_validate()/parse_and_validate_object().
+ *
+ * Unlike Python, where BASIC_TYPE_CHECK_ONLY happens when the optional
+ * jsonschema extra isn't installed at runtime, the Java port always
+ * bundles com.networknt:json-schema-validator as a hard Maven
+ * dependency - there's no equivalent "maybe not installed" state. So
+ * StructuredOutputValidator's public methods always return JSONSCHEMA;
+ * BASIC_TYPE_CHECK_ONLY exists here for documentation parity with the
+ * Python source and is reachable only via the explicitly-named
+ * basicTypeCheckOnly() method, not through the normal validation path.
+ */
+public enum ValidationMethod {
+    JSONSCHEMA,
+    BASIC_TYPE_CHECK_ONLY
+}

--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/structured/ValidationResult.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/structured/ValidationResult.java
@@ -1,0 +1,14 @@
+package com.ragleap.rag.structured;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Result of validating structured output against a schema. Java
+ * equivalent of the (parsed_object_or_None, is_valid, validation_method)
+ * tuple returned by structured.py.
+ *
+ * parsed is null when raw_text failed to parse as JSON at all - this
+ * never throws, matching the Python source's "never raises" contract.
+ */
+public record ValidationResult(JsonNode parsed, boolean valid, ValidationMethod method) {
+}

--- a/java/ragleap-rag/src/test/java/com/ragleap/rag/structured/StructuredOutputValidatorTest.java
+++ b/java/ragleap-rag/src/test/java/com/ragleap/rag/structured/StructuredOutputValidatorTest.java
@@ -1,0 +1,113 @@
+package com.ragleap.rag.structured;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StructuredOutputValidatorTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private JsonNode node(String json) throws Exception {
+        return MAPPER.readTree(json);
+    }
+
+    @Test
+    void validObjectPassesSchemaValidation() throws Exception {
+        JsonNode schema = node("""
+            {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}
+            """);
+        ValidationResult result = StructuredOutputValidator.parseAndValidate("{\"name\": \"RagLeap\"}", schema);
+
+        assertTrue(result.valid());
+        assertEquals(ValidationMethod.JSONSCHEMA, result.method());
+        assertEquals("RagLeap", result.parsed().get("name").asText());
+    }
+
+    @Test
+    void objectMissingRequiredFieldFailsValidation() throws Exception {
+        JsonNode schema = node("""
+            {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}
+            """);
+        ValidationResult result = StructuredOutputValidator.parseAndValidate("{}", schema);
+
+        assertFalse(result.valid());
+        // parsed is still returned even when invalid - matches Python's
+        // (parsed, False, method), not (None, False, method)
+        assertNotNull(result.parsed());
+    }
+
+    @Test
+    void malformedJsonReturnsNullParsedAndInvalid() throws Exception {
+        JsonNode schema = node("{\"type\": \"object\"}");
+        ValidationResult result = StructuredOutputValidator.parseAndValidate("{not valid json", schema);
+
+        assertNull(result.parsed());
+        assertFalse(result.valid());
+    }
+
+    @Test
+    void nestedStructureIsGenuinelyValidatedNotJustTopLevelType() throws Exception {
+        // Proves this is real jsonschema-style validation, not the
+        // basic_type_check_only fallback which would only check that
+        // the top-level value is an object.
+        JsonNode schema = node("""
+            {
+              "type": "object",
+              "properties": {
+                "age": {"type": "integer", "minimum": 0}
+              }
+            }
+            """);
+        ValidationResult result = StructuredOutputValidator.parseAndValidate("{\"age\": -5}", schema);
+
+        assertFalse(result.valid());
+    }
+
+    @Test
+    void invalidSchemaItselfHandledGracefullyNotThrown() throws Exception {
+        // A schema with a malformed regex pattern - networknt should
+        // surface this as a schema-level problem, not throw uncaught.
+        JsonNode schema = node("""
+            {"type": "string", "pattern": "[invalid("}
+            """);
+        assertDoesNotThrow(() -> StructuredOutputValidator.parseAndValidate("\"test\"", schema));
+    }
+
+    @Test
+    void parseAndValidateObjectAcceptsAlreadyParsedNode() throws Exception {
+        JsonNode schema = node("{\"type\": \"array\", \"items\": {\"type\": \"number\"}}");
+        JsonNode obj = node("[1, 2, 3]");
+
+        ValidationResult result = StructuredOutputValidator.parseAndValidateObject(obj, schema);
+        assertTrue(result.valid());
+    }
+
+    @Test
+    void basicTypeCheckOnlyMatchesObjectType() throws Exception {
+        JsonNode schema = node("{\"type\": \"object\"}");
+        assertTrue(StructuredOutputValidator.basicTypeCheckOnly(node("{}"), schema));
+        assertFalse(StructuredOutputValidator.basicTypeCheckOnly(node("[]"), schema));
+    }
+
+    @Test
+    void basicTypeCheckOnlyMatchesArrayType() throws Exception {
+        JsonNode schema = node("{\"type\": \"array\"}");
+        assertTrue(StructuredOutputValidator.basicTypeCheckOnly(node("[1,2]"), schema));
+        assertFalse(StructuredOutputValidator.basicTypeCheckOnly(node("\"str\""), schema));
+    }
+
+    @Test
+    void basicTypeCheckOnlyDoesNotCatchNestedViolations() throws Exception {
+        // Demonstrates exactly the documented limitation: a top-level
+        // object "passes" even though a nested field violates the schema
+        // - this is the gap that makes it a fallback, not a substitute.
+        JsonNode schema = node("""
+            {"type": "object", "properties": {"age": {"type": "integer", "minimum": 0}}}
+            """);
+        JsonNode instance = node("{\"age\": -5}");
+        assertTrue(StructuredOutputValidator.basicTypeCheckOnly(instance, schema));
+    }
+}


### PR DESCRIPTION
Eighth module of the Java port (see java/HANDOVER.md, PRs #318-326 for prior context). Ports StructuredOutputValidator using com.networknt:json-schema-validator 1.5.5 (pinned below the newer 3.0.7 due to a Jackson 3.x groupId/namespace break - see commit message for detail). First module needing a new third-party Maven dependency beyond jtokkit. Design note: unlike Python's optional jsonschema extra, the Java dependency is always bundled, so the basic_type_check_only fallback path isn't reachable through the normal API - documented in ValidationMethod. 9 new JUnit tests, 81/81 passing overall. Touches only java/.