### PR TITLE
feat(ragleap-ops): readOnlyRootFilesystem hardening (db/app/voice full, neo4j partial)

### DIFF
--- a/packages/ragleap-ops/helm/ragleap-ops/templates/app-deployment.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/app-deployment.yaml
@@ -20,9 +20,16 @@ spec:
         - name: wait-for-db
           image: postgres:16-alpine
           command: ["sh", "-c", "until pg_isready -h ragleap-db -p 5432 -U {{ .Values.db.credentials.user }}; do sleep 2; done"]
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
       containers:
         - name: app
           image: {{ .Values.app.image }}
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
           ports:
             - containerPort: {{ .Values.app.port }}
           envFrom:
@@ -31,6 +38,9 @@ spec:
           env:
             - name: DATABASE_URL
               value: "postgresql://{{ .Values.db.credentials.user }}:{{ .Values.db.credentials.password }}@ragleap-db:5432/{{ .Values.db.credentials.database }}"
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           readinessProbe:
             tcpSocket:
               port: {{ .Values.app.port }}
@@ -39,3 +49,6 @@ spec:
             tcpSocket:
               port: {{ .Values.app.port }}
             initialDelaySeconds: {{ .Values.app.probes.liveness.initialDelaySeconds }}
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/packages/ragleap-ops/helm/ragleap-ops/templates/db-deployment.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/db-deployment.yaml
@@ -33,6 +33,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 999
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
           envFrom:
             - secretRef:
                 name: ragleap-db-secret
@@ -44,6 +45,10 @@ spec:
             - name: db-schema
               mountPath: /docker-entrypoint-initdb.d/01-schema.sql
               subPath: schema.sql
+            - name: db-run
+              mountPath: /var/run/postgresql
+            - name: tmp
+              mountPath: /tmp
           readinessProbe:
             exec:
               command: ["pg_isready", "-U", {{ .Values.db.credentials.user | quote }}]
@@ -64,3 +69,7 @@ spec:
         - name: db-schema
           configMap:
             name: ragleap-db-schema
+        - name: db-run
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/packages/ragleap-ops/helm/ragleap-ops/templates/neo4j-deployment.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/neo4j-deployment.yaml
@@ -33,6 +33,11 @@ spec:
             runAsNonRoot: true
             runAsUser: 7474
             allowPrivilegeEscalation: false
+            # readOnlyRootFilesystem intentionally NOT enabled --
+            # /logs, /var/lib/neo4j/run, /tmp are now writable emptyDirs,
+            # but the Neo4j Docker entrypoint rewrites /var/lib/neo4j/conf
+            # on every startup, which has NOT been verified to tolerate
+            # a read-only root. Needs investigation before enabling.
           envFrom:
             - secretRef:
                 name: ragleap-neo4j-secret
@@ -51,6 +56,12 @@ spec:
           volumeMounts:
             - name: neo4j-data
               mountPath: /data
+            - name: neo4j-logs
+              mountPath: /logs
+            - name: neo4j-run
+              mountPath: /var/lib/neo4j/run
+            - name: tmp
+              mountPath: /tmp
           readinessProbe:
             httpGet:
               path: /
@@ -69,3 +80,9 @@ spec:
         - name: neo4j-data
           persistentVolumeClaim:
             claimName: ragleap-neo4j-data
+        - name: neo4j-logs
+          emptyDir: {}
+        - name: neo4j-run
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/packages/ragleap-ops/helm/ragleap-ops/templates/voice-deployment.yaml
+++ b/packages/ragleap-ops/helm/ragleap-ops/templates/voice-deployment.yaml
@@ -20,9 +20,16 @@ spec:
         - name: wait-for-db
           image: postgres:16-alpine
           command: ["sh", "-c", "until pg_isready -h ragleap-db -p 5432 -U {{ .Values.db.credentials.user }}; do sleep 2; done"]
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
       containers:
         - name: voice
           image: {{ .Values.voice.image }}
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
           command: {{ .Values.voice.command | toJson }}
           ports:
             - containerPort: {{ .Values.voice.port }}
@@ -32,3 +39,9 @@ spec:
           env:
             - name: DATABASE_URL
               value: "postgresql://{{ .Values.db.credentials.user }}:{{ .Values.db.credentials.password }}@ragleap-db:5432/{{ .Values.db.credentials.database }}"
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/packages/ragleap-ops/k8s/app-deployment.yaml
+++ b/packages/ragleap-ops/k8s/app-deployment.yaml
@@ -32,10 +32,7 @@ spec:
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false
-            # readOnlyRootFilesystem intentionally NOT enabled yet --
-            # this container may write outside its declared volume
-            # mounts (e.g. /tmp, /var/run) and this has not been
-            # live-tested. Enabling it blind risks breaking startup.
+            readOnlyRootFilesystem: true
           ports:
             - containerPort: 8000
           envFrom:
@@ -44,6 +41,9 @@ spec:
           env:
             - name: DATABASE_URL
               value: "postgresql://ragleap:ragleap@ragleap-db:5432/ragleap_core"
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           readinessProbe:
             tcpSocket:
               port: 8000
@@ -52,3 +52,6 @@ spec:
             tcpSocket:
               port: 8000
             initialDelaySeconds: 15
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/packages/ragleap-ops/k8s/db-deployment.yaml
+++ b/packages/ragleap-ops/k8s/db-deployment.yaml
@@ -38,10 +38,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 999
             allowPrivilegeEscalation: false
-            # readOnlyRootFilesystem intentionally NOT enabled yet --
-            # this container may write outside its declared volume
-            # mounts (e.g. /tmp, /var/run) and this has not been
-            # live-tested. Enabling it blind risks breaking startup.
+            readOnlyRootFilesystem: true
           envFrom:
             - secretRef:
                 name: ragleap-db-secret
@@ -53,6 +50,10 @@ spec:
             - name: db-schema
               mountPath: /docker-entrypoint-initdb.d/01-schema.sql
               subPath: schema.sql
+            - name: db-run
+              mountPath: /var/run/postgresql
+            - name: tmp
+              mountPath: /tmp
           readinessProbe:
             exec:
               command: ["pg_isready", "-U", "ragleap"]
@@ -73,3 +74,7 @@ spec:
         - name: db-schema
           configMap:
             name: ragleap-db-schema
+        - name: db-run
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/packages/ragleap-ops/k8s/neo4j-deployment.yaml
+++ b/packages/ragleap-ops/k8s/neo4j-deployment.yaml
@@ -38,10 +38,11 @@ spec:
             runAsNonRoot: true
             runAsUser: 7474
             allowPrivilegeEscalation: false
-            # readOnlyRootFilesystem intentionally NOT enabled yet --
-            # this container may write outside its declared volume
-            # mounts (e.g. /tmp, /var/run) and this has not been
-            # live-tested. Enabling it blind risks breaking startup.
+            # readOnlyRootFilesystem intentionally NOT enabled --
+            # /logs, /var/lib/neo4j/run, /tmp are now writable emptyDirs,
+            # but the Neo4j Docker entrypoint rewrites /var/lib/neo4j/conf
+            # on every startup, which has NOT been verified to tolerate
+            # a read-only root. Needs investigation before enabling.
           envFrom:
             - secretRef:
                 name: ragleap-neo4j-secret
@@ -54,6 +55,12 @@ spec:
           volumeMounts:
             - name: neo4j-data
               mountPath: /data
+            - name: neo4j-logs
+              mountPath: /logs
+            - name: neo4j-run
+              mountPath: /var/lib/neo4j/run
+            - name: tmp
+              mountPath: /tmp
           readinessProbe:
             httpGet:
               path: /
@@ -72,3 +79,9 @@ spec:
         - name: neo4j-data
           persistentVolumeClaim:
             claimName: ragleap-neo4j-data
+        - name: neo4j-logs
+          emptyDir: {}
+        - name: neo4j-run
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/packages/ragleap-ops/k8s/voice-deployment.yaml
+++ b/packages/ragleap-ops/k8s/voice-deployment.yaml
@@ -32,10 +32,7 @@ spec:
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false
-            # readOnlyRootFilesystem intentionally NOT enabled yet --
-            # this container may write outside its declared volume
-            # mounts (e.g. /tmp, /var/run) and this has not been
-            # live-tested. Enabling it blind risks breaking startup.
+            readOnlyRootFilesystem: true
           command: ["python3", "-m", "channels.voice.server"]
           ports:
             - containerPort: 8765
@@ -45,3 +42,9 @@ spec:
           env:
             - name: DATABASE_URL
               value: "postgresql://ragleap:ragleap@ragleap-db:5432/ragleap_core"
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}


### PR DESCRIPTION
## Summary
Adds `readOnlyRootFilesystem: true` across ragleap-ops services, both raw k8s/ manifests and Helm chart templates.

## Per-service status
- **db**: enabled, added emptyDir mounts for /var/run/postgresql and /tmp
- **app**: enabled, added emptyDir mount for /tmp
- **voice**: enabled, added emptyDir mount for /tmp
- **neo4j**: writable mounts added (/logs, /var/lib/neo4j/run, /tmp) but flag deliberately left disabled -- Neo4j's entrypoint rewrites /var/lib/neo4j/conf on every startup, not yet verified safe under read-only root. Documented inline.

## Bonus fix
Helm app/voice templates were missing securityContext entirely (runAsNonRoot, allowPrivilegeEscalation) -- closed as part of this change, now matches raw manifests.

## Verification so far
- helm lint: pass
- helm template: renders correctly, spot-checked voice output
- yaml.safe_load: valid on all 4 raw manifests

## NOT yet done
- Live cluster testing (kind) -- pending, will update CHANGELOG.md once confirmed
- neo4j conf-directory investigation for full readOnlyRootFilesystem