### PR TITLE
docs(ragleap-observability): update README to reflect live-verified status

### DIFF
--- a/packages/ragleap-observability/README.md
+++ b/packages/ragleap-observability/README.md
@@ -6,16 +6,23 @@ services.
 
 ## Status
 
-Design/scaffold only. No Helm chart content yet. This is the
-prerequisite for AIOps per the project's own DevOps maturity roadmap --
-building anomaly detection before a metrics pipeline exists would be
-"a dashboard for data that doesn't exist."
+Prometheus + `postgres_exporter` are built and live-verified end-to-end
+against a real cluster: the exporter connects to `ragleap-db` using a
+read-only monitoring role, and `/metrics` returns real, non-zero
+PostgreSQL statistics (`pg_up 1`, live `pg_stat_database` values). This
+is the prerequisite for AIOps per the project's own DevOps maturity
+roadmap -- building anomaly detection before a metrics pipeline exists
+would be "a dashboard for data that doesn't exist."
+
+Grafana, Loki, and AlertManager are not yet built -- correctly
+sequenced after Prometheus has proven real metrics flowing, per the
+build order below.
 
 ## Planned build order
 
-1. Prometheus + exporters (postgres_exporter for db; verify neo4j's
-   Prometheus endpoint exists in Community Edition before assuming --
-   same discipline as the backup-command check in ragleap-ops)
+1. ✅ Prometheus + exporters (postgres_exporter for db) -- done,
+   live-verified this session. neo4j's exporter remains disabled
+   pending independent verification, see "Known open items".
 2. Grafana, provisioned dashboards-as-code, verified against real
    flowing data
 3. Loki + log shipping (can parallel step 2)
@@ -41,7 +48,8 @@ building anomaly detection before a metrics pipeline exists would be
   specific collector. `neo4jExporter.enabled` defaults to `false` in
   `values.yaml` until this is live-verified against the real
   `neo4j:5-community` image in this repo's own `kind` cluster.
-- `ragleap-db`'s schema does not yet have a read-only monitoring role
-  for `postgres_exporter` to connect as — needs adding in `ragleap-ops`
-  first; this package assumes it exists via
-  `ragleap-db-exporter-secret`.
+- ~~`ragleap-db`'s schema does not yet have a read-only monitoring role~~
+  **Resolved and live-verified this session.** The `ragleap_monitor`
+  role exists in `ragleap-ops`'s schema and `ragleap-db-exporter-secret`
+  connects successfully -- confirmed via real `/metrics` output showing
+  `pg_up 1` and live PostgreSQL statistics, not just a running pod.


### PR DESCRIPTION
## Summary
README described the package as 'design/scaffold only' with an unresolved monitoring-role dependency -- both stale as of this session's live testing. Since PyPI uses this README as the package description page, publishing to real PyPI with stale content would mislead real users.

## Changes
- Status section: now accurately reflects postgres_exporter is built and live-verified end-to-end
- Known open items: monitoring-role dependency marked resolved with real verification evidence (pg_up 1, live metrics)
- neo4j exporter section unchanged -- still correctly flagged unverified/disabled

Full evidence in packages/ragleap-observability/CHANGELOG.md.