### PR TITLE
docs(readme): add ragleap-observability, now live on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![PyPI ragleap-vectorstores](https://img.shields.io/pypi/v/ragleap-vectorstores?label=ragleap-vectorstores)](https://pypi.org/project/ragleap-vectorstores/) [![Downloads](https://img.shields.io/pepy/dt/ragleap-vectorstores?label=downloads)](https://pypi.org/project/ragleap-vectorstores/)
 [![PyPI ragleap-ops](https://img.shields.io/pypi/v/ragleap-ops?label=ragleap-ops)](https://pypi.org/project/ragleap-ops/) [![Downloads](https://img.shields.io/pepy/dt/ragleap-ops?label=downloads)](https://pypi.org/project/ragleap-ops/)
 [![PyPI ragleap-app-chart](https://img.shields.io/pypi/v/ragleap-app-chart?label=ragleap-app-chart)](https://pypi.org/project/ragleap-app-chart/) [![Downloads](https://img.shields.io/pepy/dt/ragleap-app-chart?label=downloads)](https://pypi.org/project/ragleap-app-chart/)
+[![PyPI ragleap-observability](https://img.shields.io/pypi/v/ragleap-observability?label=ragleap-observability)](https://pypi.org/project/ragleap-observability/) [![Downloads](https://img.shields.io/pepy/dt/ragleap-observability?label=downloads)](https://pypi.org/project/ragleap-observability/)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://github.com/antonyrag/ragleap-core) [![Discord](https://img.shields.io/badge/Discord-Join%20us-5865F2?logo=discord&logoColor=white)](https://discord.gg/mQwJuQDVrA)
 
 </div>
@@ -66,6 +67,14 @@ Need a generic, reusable chart for your own app (not RagLeap-specific)? `ragleap
 pip install ragleap-app-chart
 # or, with uv
 uv add ragleap-app-chart
+```
+
+Want metrics for your `ragleap-ops` deployment? `ragleap-observability` ships Prometheus + `postgres_exporter`, live-verified end-to-end against a real cluster:
+
+```bash
+pip install ragleap-observability
+# or, with uv
+uv add ragleap-observability
 ```
 
 Or run the full self-hosted app (channels, web chat UI, Docker Compose) — see [Quickstart](#quickstart) below. Browse every package at [packages.ragleap.com](https://packages.ragleap.com). Try it hands-on with the runnable scripts in [examples/](examples/) — `01_ingest_and_query.py` (upload a document, ask a question via the API) and `02_test_channel_directly.py` (test channel answering logic without real bot credentials).
@@ -513,8 +522,9 @@ pip install --index-url https://packages.ragleap.com/simple/ ragleap-rag
 - **`ragleap-vectorstores`** — pluggable vector backends beyond `ragleap-rag` core's 6. First backend: Chroma, embedded/local via chromadb's `PersistentClient` — no server required. Install with `pip install ragleap-vectorstores[chroma]` or `uv add ragleap-vectorstores[chroma]`.
 - **`ragleap-ops`** — Kubernetes deployment manifests for RagLeap Core, live-tested end-to-end on a real cluster. Install with `pip install ragleap-ops` or `uv add ragleap-ops`.
 - **`ragleap-app-chart`** — generic, reusable Helm chart for deploying arbitrary services to Kubernetes, not RagLeap-specific. Point it at your own app via a `services:` list. Install with `pip install ragleap-app-chart` or `uv add ragleap-app-chart`.
+- **`ragleap-observability`** — Prometheus + `postgres_exporter` for `ragleap-ops`, live-verified end-to-end against a real cluster (real connection confirmed, real non-zero metrics returned). Grafana/Loki/AlertManager not yet built. Install with `pip install ragleap-observability` or `uv add ragleap-observability`.
 
-All five are MIT licensed. Browse the full package index at [packages.ragleap.com](https://packages.ragleap.com).
+All six are MIT licensed. Browse the full package index at [packages.ragleap.com](https://packages.ragleap.com).
 
 ## Supported LLM Providers (BYOK)
 


### PR DESCRIPTION
## Summary
ragleap-observability v0.1.0 published this session -- Prometheus + postgres_exporter for ragleap-ops, live-verified end-to-end (real connection confirmed, real non-zero metrics returned via /metrics).

## Changes (4 locations, per project convention)
- Badge row
- Install snippet, alongside ragleap-ops and ragleap-app-chart in the Kubernetes section
- Package-list bullet
- MIT-licensed count: five -> six