### PR TITLE
feat(ragleap-app-chart): add multi-environment values pattern

### DIFF
--- a/packages/ragleap-app-chart/CHANGELOG.md
+++ b/packages/ragleap-app-chart/CHANGELOG.md
@@ -5,6 +5,10 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Multi-environment values pattern (`values-dev.yaml`, `values-staging.yaml`, `values-prod.yaml`), porting the proven approach from `ragleap-ops` into this generic chart. Because this chart's `services:` field is a list (not a scalar), and Helm does not merge list entries by key, each environment file is a full override, not a partial one -- a genuine structural difference from `ragleap-ops`'s scalar-field overrides, documented inline in each file. Verified via `helm lint` (clean) and `helm template -f values-{env}.yaml` for all three environments: dev renders 1 replica + ingress disabled, staging renders 1 replica + ingress enabled with a staging hostname, prod renders 3 replicas for the stateless example service and correctly keeps the stateful example service at 1 replica, matching the same stateful-service-does-not-scale-via-replicaCount principle already established in `ragleap-ops`.
+
 ### Fixed
 
 - First live cluster deploy (helm install against a real kind cluster) found 2 real bugs in the default example config, neither previously caught by helm lint/helm template alone:

--- a/packages/ragleap-app-chart/README.md
+++ b/packages/ragleap-app-chart/README.md
@@ -27,3 +27,23 @@ rationale.
 - Proven against a non-RagLeap toy app before calling any feature done
   — genericity is only real once demonstrated against something that
   isn't RagLeap itself
+
+## Multi-environment values
+
+`values-dev.yaml`, `values-staging.yaml`, and `values-prod.yaml` are
+available, ported from the same pattern proven in `ragleap-ops`:
+
+```bash
+helm install my-release ./ragleap-app-chart -f values-dev.yaml
+```
+
+**This works differently from `ragleap-ops`'s version.** `ragleap-ops`
+overrides simple scalar fields (`app.replicaCount: 3`), which Helm
+deep-merges cleanly. This chart's `services:` field is a *list*, and
+Helm does not merge list entries by key — an environment file that
+redefines `services:` **replaces the entire list**, not just the
+fields that differ. Each `values-{env}.yaml` here is therefore a full
+override of the example `services:` list, not a partial one. If you
+add or change services in your own `values.yaml`, you'll need to keep
+your own `values-{env}.yaml` files' `services:` lists in sync manually
+— this chart does not (yet) merge list entries automatically.

--- a/packages/ragleap-app-chart/helm/ragleap-app-chart/values-dev.yaml
+++ b/packages/ragleap-app-chart/helm/ragleap-app-chart/values-dev.yaml
@@ -1,0 +1,56 @@
+# Dev environment overrides — apply with:
+#   helm install ragleap-app-chart ./ragleap-app-chart -f values-dev.yaml
+#
+# Full override, not a partial merge — Helm does not merge list entries
+# by key, so services: here must be complete, not just the fields that
+# differ. See ragleap-app-chart's README for why this differs from
+# ragleap-ops's scalar-field override pattern.
+#
+# Single replicas, ingress disabled (use port-forward for local access
+# instead). Not suitable for anything but local testing.
+
+services:
+  - name: web
+    image: myorg/myapp:latest
+    port: 3000
+    replicaCount: 1
+    persistent: false
+    dependsOn:
+      - postgres
+    expose: false
+    env:
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: app-secrets
+            key: db-url
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+  - name: postgres
+    image: postgres:16
+    port: 5432
+    replicaCount: 1
+    persistent: true
+    storage: 10Gi
+    dependsOn: []
+    expose: false
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 999
+      allowPrivilegeEscalation: false
+    initChown: true
+    env:
+      - name: PGDATA
+        value: /data/pgdata
+      - name: POSTGRES_PASSWORD
+        value: test-password-not-for-production
+
+ingress:
+  clusterIssuer: letsencrypt-prod
+  ingressClassName: nginx

--- a/packages/ragleap-app-chart/helm/ragleap-app-chart/values-prod.yaml
+++ b/packages/ragleap-app-chart/helm/ragleap-app-chart/values-prod.yaml
@@ -1,0 +1,62 @@
+# Production environment overrides — apply with:
+#   helm install ragleap-app-chart ./ragleap-app-chart -f values-prod.yaml
+#
+# Full override, not a partial merge — see values-dev.yaml's comment
+# for why (Helm does not merge list entries by key).
+#
+# Higher replica counts for real traffic. Stateful services (like the
+# example postgres entry) stay at a single replica regardless of
+# environment — they're single-writer with a ReadWriteOnce PVC;
+# horizontal scaling needs a different storage/clustering architecture,
+# not a values.yaml change. Same principle as ragleap-ops's db/neo4j.
+#
+# IMPORTANT: never commit real production credentials here. Override
+# env values via --set or a proper secrets workflow (Sealed Secrets,
+# external-secrets, etc.) instead of values.yaml for anything secret.
+
+services:
+  - name: web
+    image: myorg/myapp:latest
+    port: 3000
+    replicaCount: 3
+    persistent: false
+    dependsOn:
+      - postgres
+    expose: true
+    hostname: myapp.example.com   # REPLACE with your real production domain
+    env:
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: app-secrets
+            key: db-url
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+  - name: postgres
+    image: postgres:16
+    port: 5432
+    replicaCount: 1   # stateful — do not scale via this field, see note above
+    persistent: true
+    storage: 10Gi
+    dependsOn: []
+    expose: false
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 999
+      allowPrivilegeEscalation: false
+    initChown: true
+    env:
+      - name: PGDATA
+        value: /data/pgdata
+      - name: POSTGRES_PASSWORD
+        value: REPLACE-VIA-SECRET-NOT-HERE
+
+ingress:
+  clusterIssuer: letsencrypt-prod   # REPLACE with your own ClusterIssuer name
+  ingressClassName: nginx

--- a/packages/ragleap-app-chart/helm/ragleap-app-chart/values-staging.yaml
+++ b/packages/ragleap-app-chart/helm/ragleap-app-chart/values-staging.yaml
@@ -1,0 +1,56 @@
+# Staging environment overrides — apply with:
+#   helm install ragleap-app-chart ./ragleap-app-chart -f values-staging.yaml
+#
+# Full override, not a partial merge — see values-dev.yaml's comment
+# for why (Helm does not merge list entries by key).
+#
+# Mirrors production shape (Ingress enabled, real hostname/issuer) but
+# at lower replica counts, to catch integration issues before they
+# reach production without paying full production resource cost.
+
+services:
+  - name: web
+    image: myorg/myapp:latest
+    port: 3000
+    replicaCount: 1
+    persistent: false
+    dependsOn:
+      - postgres
+    expose: true
+    hostname: staging.myapp.example.com   # REPLACE with your real staging domain
+    env:
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: app-secrets
+            key: db-url
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+  - name: postgres
+    image: postgres:16
+    port: 5432
+    replicaCount: 1
+    persistent: true
+    storage: 10Gi
+    dependsOn: []
+    expose: false
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 999
+      allowPrivilegeEscalation: false
+    initChown: true
+    env:
+      - name: PGDATA
+        value: /data/pgdata
+      - name: POSTGRES_PASSWORD
+        value: test-password-not-for-production   # REPLACE via --set or Sealed Secrets before real use
+
+ingress:
+  clusterIssuer: letsencrypt-prod   # REPLACE with your own ClusterIssuer name
+  ingressClassName: nginx


### PR DESCRIPTION
Adds values-dev.yaml, values-staging.yaml, values-prod.yaml, porting the pattern already proven in ragleap-ops.

Real structural difference from ragleap-ops's version, documented in both the README and inline in each file: ragleap-ops overrides simple scalar fields (app.replicaCount), which Helm deep-merges cleanly. This chart's services: field is a list, and Helm does not merge list entries by key -- an environment file redefining services: replaces the entire list, not just the fields that differ. Each values-{env} file here is therefore a full override of the example services: list, not a partial one, chosen deliberately over template-side merge logic to keep this correct and verifiable rather than clever and untested.

Verified via helm lint (clean) and helm template -f values-{env}.yaml for all three: dev renders 1 replica + ingress disabled, staging renders 1 replica + ingress enabled with a staging hostname, prod renders 3 replicas for the stateless example service while correctly keeping the stateful example service at 1 replica (same stateful-services-don't-scale-via-replicaCount principle already established in ragleap-ops).

CHANGELOG.md and README.md updated.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
