### PR TITLE
feat(java-port): port db.py to Java, first real-Postgres integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,20 @@ jobs:
 
   ragleap-rag-java-tests:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ragleap_java_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v4
@@ -218,4 +232,6 @@ jobs:
           cache: 'maven'
       - name: Run ragleap-rag Java test suite
         working-directory: java/ragleap-rag
+        env:
+          RAGLEAP_JAVA_TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ragleap_java_test
         run: mvn -B test

--- a/java/ragleap-rag/pom.xml
+++ b/java/ragleap-rag/pom.xml
@@ -48,28 +48,33 @@
         <junit.version>5.10.2</junit.version>
         <jtokkit.version>1.1.0</jtokkit.version>
         <json-schema-validator.version>1.5.5</json-schema-validator.version>
+        <hikaricp.version>7.1.0</hikaricp.version>
+        <postgresql.version>42.7.13</postgresql.version>
     </properties>
 
     <dependencies>
-        <!-- Real Java implementation of OpenAI's tiktoken encodings
-             (including cl100k_base) - the genuine equivalent of Python's
-             tiktoken, used here for the same purpose: real LLM token
-             counts, not an estimate. -->
         <dependency>
             <groupId>com.knuddels</groupId>
             <artifactId>jtokkit</artifactId>
             <version>${jtokkit.version}</version>
         </dependency>
 
-        <!-- Real JSON Schema validation (drafts v4 through 2020-12) -
-             the Java equivalent of Python's jsonschema library, used
-             for the same purpose: validating structured LLM output
-             against a user-supplied schema. Pulls in jackson-databind
-             transitively, which we also use directly for JSON parsing. -->
         <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
             <version>${json-schema-validator.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>${hikaricp.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${postgresql.version}</version>
         </dependency>
 
         <dependency>

--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/db/ConnectionPool.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/db/ConnectionPool.java
@@ -1,0 +1,116 @@
+package com.ragleap.rag.db;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.logging.Logger;
+
+/**
+ * Shared connection pooling for ragleap-rag. Java port of ragleap-rag's
+ * db.py — ConnectionPool.
+ *
+ * Every service class (retrieval, memory) shares one pool instead of
+ * opening a new connection per call — a fresh TCP handshake + Postgres
+ * auth on every single method call is a real, avoidable latency cost,
+ * especially under any concurrent load.
+ *
+ * Uses HikariCP - the Java equivalent of psycopg2's ThreadedConnectionPool.
+ *
+ * Usage maps directly onto the Python source's context-manager pattern:
+ *   try (Connection conn = pool.getConnection()) {
+ *       ...
+ *       conn.commit(); // or conn.rollback() - autoCommit is off, matching
+ *                       // "the pool does not auto-commit" in the Python docstring
+ *   }
+ * try-with-resources calling Connection.close() is HikariCP's equivalent
+ * of psycopg2's putconn() - it returns the connection to the pool rather
+ * than actually closing the underlying socket, and runs even on
+ * exception, same as Python's try/finally.
+ */
+public class ConnectionPool implements AutoCloseable {
+
+    private static final Logger logger = Logger.getLogger(ConnectionPool.class.getName());
+
+    public static final int DEFAULT_MIN_CONN = 1;
+    public static final int DEFAULT_MAX_CONN = 10;
+
+    private final HikariDataSource dataSource;
+
+    public ConnectionPool(String databaseUrl) {
+        this(databaseUrl, DEFAULT_MIN_CONN, DEFAULT_MAX_CONN);
+    }
+
+    public ConnectionPool(String databaseUrl, int minConn, int maxConn) {
+        ParsedUrl parsed = parseDatabaseUrl(databaseUrl);
+
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl(parsed.jdbcUrl());
+        config.setUsername(parsed.username());
+        config.setPassword(parsed.password());
+        config.setMinimumIdle(minConn);
+        config.setMaximumPoolSize(maxConn);
+        // Caller is responsible for commit()/rollback(), matching the
+        // Python source's documented "the pool does not auto-commit".
+        config.setAutoCommit(false);
+
+        this.dataSource = new HikariDataSource(config);
+        logger.info(() -> String.format("Connection pool created (min=%d, max=%d)", minConn, maxConn));
+    }
+
+    /**
+     * Get a connection from the pool. Use in try-with-resources -
+     * closing it returns the connection to the pool, it does not close
+     * the underlying socket. See class javadoc for the Python
+     * context-manager equivalence.
+     */
+    public Connection getConnection() throws SQLException {
+        return dataSource.getConnection();
+    }
+
+    /** Close all connections in the pool. Call on shutdown if needed. */
+    @Override
+    public void close() {
+        dataSource.close();
+        logger.info("Connection pool closed");
+    }
+
+    record ParsedUrl(String jdbcUrl, String username, String password) {
+    }
+
+    /**
+     * Parses a postgresql://user:pass@host:port/dbname URL (psycopg2's
+     * accepted format) into a JDBC URL plus separate username/password,
+     * since the JDBC PostgreSQL driver doesn't accept credentials
+     * embedded in the URL the way psycopg2 does.
+     */
+    static ParsedUrl parseDatabaseUrl(String databaseUrl) {
+        URI uri;
+        try {
+            uri = new URI(databaseUrl);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Invalid database URL: " + databaseUrl, e);
+        }
+
+        String userInfo = uri.getUserInfo();
+        if (userInfo == null) {
+            throw new IllegalArgumentException("Database URL must include user:password - got: " + databaseUrl);
+        }
+        String[] credentials = userInfo.split(":", 2);
+        String username = credentials[0];
+        String password = credentials.length > 1 ? credentials[1] : "";
+
+        String host = uri.getHost();
+        int port = uri.getPort();
+        String database = uri.getPath();
+        if (database != null && database.startsWith("/")) {
+            database = database.substring(1);
+        }
+
+        String jdbcUrl = String.format("jdbc:postgresql://%s:%d/%s", host, port, database);
+        return new ParsedUrl(jdbcUrl, username, password);
+    }
+}

--- a/java/ragleap-rag/src/test/java/com/ragleap/rag/db/ConnectionPoolTest.java
+++ b/java/ragleap-rag/src/test/java/com/ragleap/rag/db/ConnectionPoolTest.java
@@ -1,0 +1,116 @@
+package com.ragleap.rag.db;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Real integration test against a live Postgres instance - NOT mocked.
+ * Connects to a throwaway database (ragleap_java_test), never the
+ * production ragleap_core database.
+ *
+ * Connection URL comes from the RAGLEAP_JAVA_TEST_DATABASE_URL
+ * environment variable when set (used in CI), falling back to the
+ * VPS's local throwaway database for manual/local runs.
+ */
+class ConnectionPoolTest {
+
+    private static final String DATABASE_URL = System.getenv().getOrDefault(
+            "RAGLEAP_JAVA_TEST_DATABASE_URL",
+            "postgresql://ragleap:ragleap@localhost:5433/ragleap_java_test"
+    );
+
+    private static ConnectionPool pool;
+
+    @BeforeAll
+    static void setUpPool() {
+        pool = new ConnectionPool(DATABASE_URL, 1, 5);
+    }
+
+    @AfterAll
+    static void tearDownPool() {
+        pool.close();
+    }
+
+    @Test
+    void parseDatabaseUrlExtractsCredentialsHostPortAndDatabase() {
+        ConnectionPool.ParsedUrl parsed = ConnectionPool.parseDatabaseUrl(
+                "postgresql://ragleap:ragleap@localhost:5433/ragleap_java_test");
+
+        assertEquals("jdbc:postgresql://localhost:5433/ragleap_java_test", parsed.jdbcUrl());
+        assertEquals("ragleap", parsed.username());
+        assertEquals("ragleap", parsed.password());
+    }
+
+    @Test
+    void parseDatabaseUrlRejectsMissingCredentials() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ConnectionPool.parseDatabaseUrl("postgresql://localhost:5433/db"));
+    }
+
+    @Test
+    void getConnectionActuallyConnectsToRealPostgres() throws SQLException {
+        try (Connection conn = pool.getConnection()) {
+            assertFalse(conn.isClosed());
+            assertTrue(conn.isValid(5));
+        }
+    }
+
+    @Test
+    void connectionAutoCommitIsOffMatchingPythonSource() throws SQLException {
+        try (Connection conn = pool.getConnection()) {
+            assertFalse(conn.getAutoCommit());
+        }
+    }
+
+    @Test
+    void fullRoundTripCreateInsertSelectDropOnRealDatabase() throws SQLException {
+        try (Connection conn = pool.getConnection()) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("CREATE TABLE IF NOT EXISTS java_port_scratch_test (id SERIAL PRIMARY KEY, val TEXT)");
+            }
+            conn.commit();
+
+            try (PreparedStatement insert = conn.prepareStatement(
+                    "INSERT INTO java_port_scratch_test (val) VALUES (?)")) {
+                insert.setString(1, "hello from the java port");
+                insert.executeUpdate();
+            }
+            conn.commit();
+
+            try (Statement select = conn.createStatement();
+                 ResultSet rs = select.executeQuery("SELECT val FROM java_port_scratch_test ORDER BY id DESC LIMIT 1")) {
+                assertTrue(rs.next());
+                assertEquals("hello from the java port", rs.getString("val"));
+            }
+
+            try (Statement drop = conn.createStatement()) {
+                drop.execute("DROP TABLE java_port_scratch_test");
+            }
+            conn.commit();
+        }
+    }
+
+    @Test
+    void connectionIsReturnedToPoolNotActuallyClosedByTryWithResources() throws SQLException {
+        // Get and release a connection twice in a row - if close() actually
+        // closed the underlying socket instead of returning it to the pool,
+        // repeated fast acquisition would still work (HikariCP would just
+        // open a new one), but this at least proves no exception occurs
+        // across repeated get/close cycles, matching the pattern the real
+        // service classes (retrieval, memory) will use.
+        for (int i = 0; i < 3; i++) {
+            try (Connection conn = pool.getConnection()) {
+                assertTrue(conn.isValid(5));
+            }
+        }
+    }
+}


### PR DESCRIPTION
First core-pipeline module of the Java port (db.py -> embedding.py -> pgvector -> retrieval.py -> generation.py roadmap - see java/HANDOVER.md and PRs #318-327 for prior context). Ports ConnectionPool using HikariCP + the PostgreSQL JDBC driver. First module tested against a real live Postgres instance (a dedicated ragleap_java_test database, isolated from production ragleap_core) rather than pure unit tests. Also adds a postgres service container to CI/ragleap-rag-java-tests so this coverage is automatic going forward. 6 new JUnit tests, 87/87 passing overall.