### PR TITLE
feat(java-port): port embedding.py's EmbeddingConfig to Java

### DIFF
--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/embedding/EmbeddingConfig.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/embedding/EmbeddingConfig.java
@@ -1,0 +1,169 @@
+package com.ragleap.rag.embedding;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Explicit embedding provider configuration for ragleap-rag. Java port
+ * of ragleap-rag's embedding.py — EmbeddingConfig.
+ *
+ * No model or dimensions value is ever hardcoded as a silent default -
+ * provider model names, availability, and dimensions all change over
+ * time, so this always requires you to know and specify both, one way
+ * or another (constructor arg or environment variable) - matching the
+ * Python source's documented reasoning exactly.
+ */
+public final class EmbeddingConfig {
+
+    // Providers whose embeddings endpoint is OpenAI-compatible (same
+    // request/response shape as OpenAI's /v1/embeddings).
+    public static final Map<String, String> OPENAI_COMPATIBLE_BASE_URLS = buildOpenAiCompatibleBaseUrls();
+
+    private static Map<String, String> buildOpenAiCompatibleBaseUrls() {
+        Map<String, String> m = new LinkedHashMap<>();
+        m.put("openai", "https://api.openai.com/v1");
+        m.put("mistral", "https://api.mistral.ai/v1");
+        m.put("together", "https://api.together.xyz/v1");
+        m.put("ollama", "http://localhost:11434/v1");
+        return Map.copyOf(m);
+    }
+
+    // Providers with their own (non-OpenAI-compatible) response shape.
+    public static final Set<String> CUSTOM_SHAPE_PROVIDERS = Set.of("cohere", "voyage");
+
+    private static final List<String> ALL_PROVIDERS = buildAllProviders();
+
+    private static List<String> buildAllProviders() {
+        List<String> all = new java.util.ArrayList<>();
+        all.add("gemini");
+        all.addAll(OPENAI_COMPATIBLE_BASE_URLS.keySet());
+        all.addAll(CUSTOM_SHAPE_PROVIDERS);
+        all.add("custom");
+        return List.copyOf(all);
+    }
+
+    private final String provider;
+    private final String apiKey;
+    private final String model;
+    private final Integer dimensions;
+    private final String baseUrl;
+
+    public EmbeddingConfig(String provider, String apiKey, String model, Integer dimensions, String baseUrl) {
+        this(provider, apiKey, model, dimensions, baseUrl, System::getenv);
+    }
+
+    /**
+     * Package-private constructor allowing tests to inject a fake
+     * environment lookup instead of real System.getenv() - the Java
+     * equivalent of monkeypatching os.environ in the Python tests.
+     */
+    EmbeddingConfig(String provider, String apiKey, String model, Integer dimensions, String baseUrl,
+                     Function<String, String> env) {
+        String resolvedProvider = provider.toLowerCase();
+        String resolvedApiKey = apiKey;
+        String resolvedModel = model;
+        Integer resolvedDimensions = dimensions;
+        String resolvedBaseUrl = baseUrl;
+
+        if (resolvedProvider.equals("gemini")) {
+            resolvedApiKey = firstNonNull(resolvedApiKey, env.apply("GEMINI_API_KEY"));
+            resolvedModel = firstNonNull(resolvedModel, env.apply("GEMINI_EMBEDDING_MODEL"));
+            resolvedDimensions = firstNonNull(resolvedDimensions, parseIntOrNull(env.apply("EMBEDDING_DIMENSIONS")));
+        } else if (OPENAI_COMPATIBLE_BASE_URLS.containsKey(resolvedProvider)) {
+            String upper = resolvedProvider.toUpperCase();
+            resolvedApiKey = firstNonNull(resolvedApiKey, env.apply(upper + "_API_KEY"));
+            resolvedModel = firstNonNull(resolvedModel, env.apply(upper + "_EMBEDDING_MODEL"));
+            String envDims = firstNonNull(env.apply(upper + "_EMBEDDING_DIMENSIONS"), env.apply("EMBEDDING_DIMENSIONS"));
+            resolvedDimensions = firstNonNull(resolvedDimensions, parseIntOrNull(envDims));
+            resolvedBaseUrl = firstNonNull(resolvedBaseUrl, OPENAI_COMPATIBLE_BASE_URLS.get(resolvedProvider));
+        } else if (CUSTOM_SHAPE_PROVIDERS.contains(resolvedProvider)) {
+            String upper = resolvedProvider.toUpperCase();
+            resolvedApiKey = firstNonNull(resolvedApiKey, env.apply(upper + "_API_KEY"));
+            resolvedModel = firstNonNull(resolvedModel, env.apply(upper + "_EMBEDDING_MODEL"));
+            String envDims = firstNonNull(env.apply(upper + "_EMBEDDING_DIMENSIONS"), env.apply("EMBEDDING_DIMENSIONS"));
+            resolvedDimensions = firstNonNull(resolvedDimensions, parseIntOrNull(envDims));
+        } else if (resolvedProvider.equals("custom")) {
+            resolvedApiKey = firstNonNull(resolvedApiKey, env.apply("CUSTOM_EMBEDDING_API_KEY"));
+            resolvedModel = firstNonNull(resolvedModel, env.apply("CUSTOM_EMBEDDING_MODEL"));
+            String envDims = firstNonNull(env.apply("CUSTOM_EMBEDDING_DIMENSIONS"), env.apply("EMBEDDING_DIMENSIONS"));
+            resolvedDimensions = firstNonNull(resolvedDimensions, parseIntOrNull(envDims));
+            resolvedBaseUrl = firstNonNull(resolvedBaseUrl, env.apply("CUSTOM_EMBEDDING_BASE_URL"));
+            if (resolvedBaseUrl == null) {
+                throw new IllegalArgumentException(
+                        "No baseUrl for provider 'custom'. Pass baseUrl explicitly to EmbeddingConfig(), " +
+                        "or set CUSTOM_EMBEDDING_BASE_URL in your environment - it must point to an " +
+                        "OpenAI-compatible /embeddings endpoint.");
+            }
+        } else {
+            throw new IllegalArgumentException(
+                    "Unknown embedding provider '" + resolvedProvider + "'. Supported: " +
+                    String.join(", ", ALL_PROVIDERS) + ".");
+        }
+
+        if (resolvedApiKey == null && !resolvedProvider.equals("ollama")) {
+            throw new IllegalArgumentException(
+                    "No API key for embedding provider '" + resolvedProvider + "'. Pass apiKey explicitly " +
+                    "to EmbeddingConfig(), or set " + resolvedProvider.toUpperCase() + "_API_KEY in your environment.");
+        }
+        if (resolvedModel == null) {
+            throw new IllegalArgumentException(
+                    "No embedding model specified for provider '" + resolvedProvider + "'. Pass model " +
+                    "explicitly to EmbeddingConfig(), or set " + resolvedProvider.toUpperCase() +
+                    "_EMBEDDING_MODEL in your environment. ragleap-rag never hardcodes a default embedding " +
+                    "model - provider model availability and dimensions change too frequently for a baked-in " +
+                    "default to stay reliable.");
+        }
+        if (resolvedDimensions == null) {
+            throw new IllegalArgumentException(
+                    "No dimensions specified for embedding provider '" + resolvedProvider + "' model '" +
+                    resolvedModel + "'. Pass dimensions explicitly to EmbeddingConfig(), or set " +
+                    "EMBEDDING_DIMENSIONS (or " + resolvedProvider.toUpperCase() + "_EMBEDDING_DIMENSIONS) " +
+                    "in your environment - dimensions must match your chosen model exactly, and ragleap-rag " +
+                    "can't safely guess it.");
+        }
+
+        this.provider = resolvedProvider;
+        this.apiKey = resolvedApiKey;
+        this.model = resolvedModel;
+        this.dimensions = resolvedDimensions;
+        this.baseUrl = resolvedBaseUrl;
+    }
+
+    private static String firstNonNull(String a, String b) {
+        return a != null ? a : b;
+    }
+
+    private static Integer firstNonNull(Integer a, Integer b) {
+        return a != null ? a : b;
+    }
+
+    private static Integer parseIntOrNull(String s) {
+        if (s == null || s.isEmpty()) {
+            return null;
+        }
+        return Integer.parseInt(s);
+    }
+
+    public String getProvider() {
+        return provider;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public Integer getDimensions() {
+        return dimensions;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+}

--- a/java/ragleap-rag/src/test/java/com/ragleap/rag/embedding/EmbeddingConfigTest.java
+++ b/java/ragleap-rag/src/test/java/com/ragleap/rag/embedding/EmbeddingConfigTest.java
@@ -1,0 +1,127 @@
+package com.ragleap.rag.embedding;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EmbeddingConfigTest {
+
+    // Uses reflection to reach the package-private test constructor from
+    // this same-package test class - no reflection tricks needed
+    // actually, since the test class IS in the same package. Direct call.
+
+    private static Function<String, String> fakeEnv(Map<String, String> vars) {
+        return vars::get;
+    }
+
+    @Test
+    void geminiResolvesFromExplicitArgsOverEnv() {
+        EmbeddingConfig config = new EmbeddingConfig("gemini", "explicit-key", "gemini-embedding-001", 768, null,
+                fakeEnv(Map.of("GEMINI_API_KEY", "env-key")));
+        assertEquals("explicit-key", config.getApiKey());
+        assertEquals("gemini-embedding-001", config.getModel());
+        assertEquals(768, config.getDimensions());
+    }
+
+    @Test
+    void geminiFallsBackToEnvironmentVariables() {
+        EmbeddingConfig config = new EmbeddingConfig("gemini", null, null, null, null,
+                fakeEnv(Map.of(
+                        "GEMINI_API_KEY", "env-key",
+                        "GEMINI_EMBEDDING_MODEL", "gemini-embedding-001",
+                        "EMBEDDING_DIMENSIONS", "3072"
+                )));
+        assertEquals("env-key", config.getApiKey());
+        assertEquals("gemini-embedding-001", config.getModel());
+        assertEquals(3072, config.getDimensions());
+    }
+
+    @Test
+    void openAiCompatibleProviderGetsDefaultBaseUrl() {
+        EmbeddingConfig config = new EmbeddingConfig("mistral", "key", "mistral-embed", 1024, null, fakeEnv(Map.of()));
+        assertEquals("https://api.mistral.ai/v1", config.getBaseUrl());
+    }
+
+    @Test
+    void openAiCompatibleProviderPerProviderEnvVarsOverrideGenericOnes() {
+        EmbeddingConfig config = new EmbeddingConfig("together", null, null, null, null,
+                fakeEnv(Map.of(
+                        "TOGETHER_API_KEY", "tkey",
+                        "TOGETHER_EMBEDDING_MODEL", "togethercomputer/m2-bert",
+                        "TOGETHER_EMBEDDING_DIMENSIONS", "768",
+                        "EMBEDDING_DIMENSIONS", "9999"
+                )));
+        assertEquals(768, config.getDimensions());
+    }
+
+    @Test
+    void ollamaDoesNotRequireApiKey() {
+        assertDoesNotThrow(() -> new EmbeddingConfig("ollama", null, "nomic-embed-text", 768, null, fakeEnv(Map.of())));
+    }
+
+    @Test
+    void nonOllamaProviderWithoutApiKeyThrows() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> new EmbeddingConfig("mistral", null, "mistral-embed", 1024, null, fakeEnv(Map.of())));
+        assertTrue(ex.getMessage().contains("API key"));
+    }
+
+    @Test
+    void missingModelThrows() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> new EmbeddingConfig("ollama", null, null, 768, null, fakeEnv(Map.of())));
+        assertTrue(ex.getMessage().contains("model"));
+    }
+
+    @Test
+    void missingDimensionsThrows() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> new EmbeddingConfig("ollama", null, "nomic-embed-text", null, null, fakeEnv(Map.of())));
+        assertTrue(ex.getMessage().contains("dimensions"));
+    }
+
+    @Test
+    void customProviderRequiresBaseUrl() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> new EmbeddingConfig("custom", "key", "some-model", 512, null, fakeEnv(Map.of())));
+        assertTrue(ex.getMessage().contains("base"));
+    }
+
+    @Test
+    void customProviderWithExplicitBaseUrlWorks() {
+        assertDoesNotThrow(() -> new EmbeddingConfig("custom", "key", "some-model", 512,
+                "http://localhost:8080/v1", fakeEnv(Map.of())));
+    }
+
+    @Test
+    void cohereAndVoyageAreCustomShapeProvidersWithNoBaseUrlAssigned() {
+        EmbeddingConfig cohere = new EmbeddingConfig("cohere", "key", "embed-v3", 1024, null, fakeEnv(Map.of()));
+        assertNull(cohere.getBaseUrl());
+    }
+
+    @Test
+    void unknownProviderThrowsWithSupportedListInMessage() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> new EmbeddingConfig("not-a-real-provider", "key", "model", 100, null, fakeEnv(Map.of())));
+        assertTrue(ex.getMessage().contains("Unknown embedding provider"));
+        assertTrue(ex.getMessage().contains("gemini"));
+    }
+
+    @Test
+    void providerNameIsCaseInsensitive() {
+        EmbeddingConfig config = new EmbeddingConfig("GEMINI", "key", "model", 768, null, fakeEnv(Map.of()));
+        assertEquals("gemini", config.getProvider());
+    }
+
+    @Test
+    void publicConstructorUsesRealSystemGetenvWithoutThrowingOnConstruction() {
+        // Sanity check the public (non-test) constructor path compiles and
+        // runs against real System.getenv - using ollama since it's the
+        // only provider that doesn't require an API key to succeed.
+        assertDoesNotThrow(() -> new EmbeddingConfig("ollama", null, "nomic-embed-text", 768, null));
+    }
+}


### PR DESCRIPTION
Second core-pipeline module (db.py -> embedding.py -> pgvector -> retrieval.py -> generation.py roadmap, see PR #337 for db.py). Ports EmbeddingConfig - the provider configuration/validation half of embedding.py - across all 7 providers (gemini, openai, mistral, together, ollama, cohere, voyage) plus custom. EmbeddingService (actual HTTP calls) is a deliberate follow-up PR, to be live-verified against the Ollama instance already running on this VPS (confirmed working via curl against its OpenAI-compatible /v1/embeddings endpoint with nomic-embed-text). 14 new JUnit tests, 101/101 passing overall.