### PR TITLE
fix: surface silent embedding failures in AI Employee memory system

### DIFF
--- a/core/employees/memory.py
+++ b/core/employees/memory.py
@@ -64,6 +64,12 @@ def write_learned_skill(text, tags, importance=0.7, source="interaction",
             cur.execute("DELETE FROM employee_memory WHERE source = %s", (source,))
         embed_service = EmbeddingService()
         embedding = embed_service.embed_text(text)
+        if embedding is None:
+            logger.warning(
+                f"Embedding failed for learned skill (source={source!r}) — "
+                "storing with embedding=NULL; this skill will not surface via "
+                "semantic_search() until re-embedded. Check GEMINI_API_KEY."
+            )
         embedding_literal = (
             "[" + ",".join(str(float(x)) for x in embedding) + "]" if embedding else None
         )
@@ -158,9 +164,10 @@ def semantic_search(query: str, top_k: int = 8, tags: Optional[List[str]] = None
         embed_service = EmbeddingService()
         query_embedding = embed_service.embed_text(query)
     except Exception as e:
-        logger.debug(f"Embedding unavailable for semantic search: {e}")
+        logger.warning(f"Embedding unavailable for semantic search, returning no results: {e}")
         return []
     if not query_embedding:
+        logger.warning("Embedding returned empty for semantic search query, returning no results")
         return []
     literal = "[" + ",".join(str(float(x)) for x in query_embedding) + "]"
     conn = get_connection()


### PR DESCRIPTION
## Context
Investigated the "embedding cross-provider fallback gap" noted in the prior
session handoff. Found that was already correctly resolved by PR #310 -
cross-provider fallback was deliberately rejected (different embedding
models produce incompatible vector spaces, would silently corrupt
similarity search).

The real, narrower gap: two spots in `core/employees/memory.py` where a
persistent embedding failure (exhausted quota, revoked key) had zero or
near-zero visibility:

- `write_learned_skill()` — stored `embedding=NULL` on failure with no log
  line at all
- `semantic_search()` — logged failures at `debug` level only, invisible
  in typical production logging config

`core/ingest.py` and `core/chat.py` were already handled correctly (clear
`ValueError` on total ingestion failure; a visible "couldn't process your
question" answer on chat embedding failure) - confirmed via trace before
concluding anything needed fixing there.

## Fix
Both spots now log at `warning` level with actionable detail. No behavior
change - same values returned/stored either way, just visible now.

## Tested
Full suite: 235 passing, no logic changed.
