### PR TITLE
docs: fix README table overclaiming 2 hosted-only features as Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ Most open-source RAG projects give you a toolkit — you still have to build the
 |---|---|
 | ❌ A different bot for your website, WhatsApp, and Telegram — none of them share memory | ✅ One AI across every channel, with memory that persists between them |
 | ❌ Your RAG chatbot forgets everything the moment a session ends | ✅ Persistent memory — facts and preferences carry across sessions and channels |
-| ❌ You're a developer, so you can wire up LangChain — but your team can't manage it | ✅ A real dashboard for non-technical owners: settings, analytics, team, billing |
-| ❌ Answering customer questions and running the business are two separate systems | ✅ Manager AI — an executive assistant that can see analytics, send emails, and manage settings by conversation |
+| ❌ You're a developer, so you can wire up LangChain — but your team can't manage it | ✅ Single-tenant, self-hosted, .env config — the full multi-tenant dashboard (settings, analytics, team, billing) is in the hosted platform |
+| ❌ Answering customer questions and running the business are two separate systems | ✅ The hosted platform adds an executive-assistant layer (Manager AI) on top of this same engine |
 | ❌ Adding a phone line means integrating Twilio, STT, and TTS yourself | ✅ Voice AI is built in — real inbound calls, answered and routed automatically |
 | ❌ Automating a workflow means writing custom code per integration | ✅ n8n workflow automation triggered directly from any conversation |
 


### PR DESCRIPTION
## Why
The comparison table near the top of the README uses an unlabeled "With
RagLeap" column, which let 2 rows read as describing `ragleap-core` itself
when they actually describe the hosted platform only - verified via
full-repo grep (zero `billing`/`team`/"Manager AI" references anywhere in
this codebase).

This also resolves an internal contradiction: the README's own later
section ("What RagLeap Core is") already correctly scopes Manager AI as
hosted-only - the comparison table was the one place out of sync with the
rest of the document's stated positioning.

## What's unchanged (confirmed real, left as-is)
- Voice AI row - genuine, verified (`channels/voice/` is a real Twilio
  Media Streams handler with Whisper STT + OpenAI TTS, not a stub)
- n8n row - confirmed real (`core/workflows.py`)
- Multi-channel + persistent memory rows - confirmed real

## What changed
2 rows reworded to accurately describe what ragleap-core provides
(single-tenant, self-hosted, .env config) vs. what requires the hosted
platform (multi-tenant dashboard, Manager AI layer).
