### PR TITLE
feat(ragleap-graph): ontology cross-validation (#152)

### DIFF
--- a/packages/ragleap-graph/CHANGELOG.md
+++ b/packages/ragleap-graph/CHANGELOG.md
@@ -5,6 +5,17 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.9.0]
+### Added
+- Ontology cross-validation (#152). `ExtractionConfig.relation_ontology` (default `None`) lets callers define which `relation_type` values are semantically valid between which `entity_type` pairs, e.g. `{"FOUNDED_BY": (["ORGANIZATION"], ["PERSON"])}`. Requires `entity_types=` to also be set (raises `ValueError` at config time otherwise, matching the fail-fast style already used elsewhere in `ExtractionConfig.__post_init__`) - an ontology is meaningless without typed entities to check it against.
+- `LLMRelationExtractor.extract()` gained an optional `entity_types` parameter (a `{lowercased_name: type}` map) threaded through from the `entity_type_map` already built during `upsert_document()`'s per-chunk loop - the type information existed in scope already, it just never reached relation extraction or validation before this.
+- A relation whose `relation_type` is a key in `relation_ontology`, but whose subject/object entity types are not in that relation_type's allowed lists, is dropped (with a `WARNING` logged, not silently) rather than written to Neo4j. `relation_type` values NOT present in `relation_ontology` remain fully unconstrained - an ontology only needs to cover the relation_types worth constraining, not every possible one, mirroring `entity_types=`'s own "unset means anything goes" precedent one level up.
+- Applies uniformly to both the existing per-chunk extraction pass and the v0.8.0 cross-chunk pass, since both call the same `LLMRelationExtractor.extract()`.
+### Verified
+- 4 new offline tests: config-time `ValueError` when `relation_ontology` is set without `entity_types`, a relation matching allowed types is kept, a relation violating allowed types is dropped, an unlisted relation_type passes through unconstrained.
+- 1 new live end-to-end test, gated on live Neo4j + `GEMINI_API_KEY` (same precedent as the #154 cross-chunk test: ontology validation depends on the underlying relation_type/entity_type extraction being accurate, which is unreliable on small local models). Confirms real Gemini-extracted output: an ontology-valid relation is kept, and a real ontology-violating relation the model actually proposed is genuinely dropped - not just asserted against mocked output.
+- Full offline suite: 91 passed, 16 skipped without credentials (previous baseline 87/16 - 4 new tests added, zero regressions).
+
 ## [0.8.0]
 ### Added
 - Cross-chunk relation extraction (#154). `ExtractionConfig.cross_chunk_relations` (default `False`) enables an opt-in second pass in `upsert_document()`: after all chunks are processed, one additional `LLMRelationExtractor.extract()` call runs over the full accumulated document text using every entity found across all chunks (not just the current chunk's local entities), recovering relations whose subject and object were established in different chunks - e.g. an entity introduced in chunk 1 referenced only by pronoun ("It", "the company") in a later chunk. Requires `extract_relations=True`.

--- a/packages/ragleap-graph/docs/design/ontology-cross-validation.md
+++ b/packages/ragleap-graph/docs/design/ontology-cross-validation.md
@@ -1,0 +1,92 @@
+# Design: Ontology Cross-Validation (#152)
+
+**Status:** Proposed — needs maintainer decision before implementation.
+**Package:** `ragleap-graph`
+**Depends on / precedent:** entity_types= enforcement (v0.6.3, coerces
+out-of-vocabulary entity types to "UNKNOWN" post-hoc rather than relying
+on prompt guidance alone)
+
+## 1. Problem statement
+
+`ExtractedRelation` carries only `subject`, `relation_type`, `object` as
+plain strings - no entity-type information. Meanwhile, `entity_type_map`
+(built in `_upsert_document_once()`, `__init__.py` ~line 519-546) already
+knows each entity's type by the time relations are extracted, but that
+information is never passed into `LLMRelationExtractor.extract()` or used
+to validate the relation afterward. Nothing stops a nonsensical
+combination like `(DATE)-[FOUNDED_BY]->(LOCATION)` from being written to
+Neo4j today.
+
+Confirmed via source inspection this session (not assumed): entity_type_map
+exists in the right scope, before the relation-extraction call sites at
+lines 558 and 585 - so threading it through is a contained change, not a
+new subsystem.
+
+## 2. Goals
+
+- Give callers a way to define which relation_type values make sense
+  between which entity_type pairs.
+- Reject or flag relations that violate the ontology, following the same
+  "enforce, don't just prompt" precedent as entity_types=.
+- Stay opt-in and backward compatible - callers who don't define an
+  ontology get today's unchanged behavior.
+
+## 3. Non-goals
+
+- Inferring an ontology automatically from data (a real, separate,
+  much larger feature - not proposed here).
+- A general-purpose ontology/taxonomy management system. This is scoped
+  to validating relation_type against the two connected entity_types.
+
+## 4. Real open questions - maintainer decision needed
+
+**Q1. What shape does the caller-supplied ontology take?**
+Candidate: a new `ExtractionConfig.relation_ontology` field, e.g.
+```python
+relation_ontology: Optional[dict[str, tuple[list[str], list[str]]]] = None
+# {"FOUNDED_BY": (["ORGANIZATION"], ["PERSON"])}
+```
+mapping each relation_type to its allowed (subject_types, object_types).
+Alternative: a flat list of allowed (subject_type, relation_type,
+object_type) triples - simpler to read, more verbose to define for
+many relation_types sharing the same type pair.
+
+**Q2. What happens on an invalid combination?**
+Entity types coerce silently to "UNKNOWN" (v0.6.3). Relations have no
+"UNKNOWN" equivalent - dropping a relation entirely is a bigger loss
+than downgrading an entity's type. Options: (a) drop the relation
+silently, (b) drop it but log a warning, (c) keep it but tag it
+(e.g. `ontology_valid: false` property on the RELATES_AS edge,
+mirroring how cross-chunk relations got `extraction_scope: "cross_chunk"`
+- actually, checking the v0.8.0 patch, that property was proposed in an
+earlier draft but the shipped version doesn't write it; worth deciding
+consistently for both features if (c) is chosen here).
+
+**Q3. Does this require entity_types= to be set at all?**
+An ontology is meaningless without typed entities - if entity_types= is
+unset, all entities are "UNKNOWN" and no relation_type could ever be
+validated against anything real. Should setting relation_ontology=
+without entity_types= be a config-time ValueError (fail fast, matching
+ExtractionConfig's existing __post_init__ validation style) rather than
+silently validating everything against "UNKNOWN" and passing nothing?
+
+**Q4. Does this apply to the v0.8.0 cross-chunk pass too?**
+The cross-chunk relation-extraction call already reuses the exact same
+LLMRelationExtractor.extract() and the same relation_counter - so yes,
+by construction, unless deliberately excluded. Worth confirming this is
+desired, given cross-chunk relations are already documented as more
+failure-prone on weak models; ontology validation might catch some of
+those failures (a bonus), or might reject cross-chunk relations at a
+different rate than per-chunk ones (worth watching for once live-tested).
+
+## 5. Verification plan (draft)
+
+- Offline tests: valid/invalid combination pairs, dropped vs kept
+  relations, config validation errors, following the same fake-double
+  style as existing extraction.py tests.
+- Live test: real extraction producing at least one relation that
+  violates a caller-supplied ontology, confirming it's correctly
+  excluded (or tagged, depending on Q2's answer) - same
+  Gemini-preferred-over-small-local-model pattern established for #154,
+  since ontology validation depends on the underlying relation_type/
+  entity_type extraction being reasonably accurate in the first place.

--- a/packages/ragleap-graph/pyproject.toml
+++ b/packages/ragleap-graph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-graph"
-version = "0.8.0"
+version = "0.9.0"
 description = "Knowledge-graph-augmented retrieval for RAG systems: Neo4j-backed entity extraction (regex or LLM-based), co-occurrence graphs, entity deduplication, and GraphRetriever for hybrid vector+graph retrieval via the optional ragleap-rag integration. Framework-agnostic, optional multi-tenant namespacing, no hardcoded models or vocabulary."
 readme = "README.md"
 license = "MIT"

--- a/packages/ragleap-graph/src/ragleap_graph/__init__.py
+++ b/packages/ragleap-graph/src/ragleap_graph/__init__.py
@@ -182,7 +182,7 @@ from ragleap_graph.retrieval import GraphRetriever, GraphRetrievalConfig
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 
 # Hard ceiling on traversal depth — prevents both runaway queries and,
 # since max_depth is string-interpolated into Cypher (see note above),
@@ -555,7 +555,10 @@ class GraphIndex:
 
             if self._relation_extractor is not None:
                 relations = self._relation_extractor.extract(
-                    text, known_entities=unique_entities, domain_terms=domain_terms
+                    text,
+                    known_entities=unique_entities,
+                    domain_terms=domain_terms,
+                    entity_types=entity_type_map,
                 )
                 for rel in relations:
                     key = (rel.subject, rel.relation_type, rel.object)
@@ -585,6 +588,7 @@ class GraphIndex:
                     known_entities=all_entities,
                     domain_terms=domain_terms,
                     resolve_references=True,
+                    entity_types=entity_type_map,
                 )
                 for rel in cross_chunk_relations:
                     key = (rel.subject, rel.relation_type, rel.object)

--- a/packages/ragleap-graph/src/ragleap_graph/extraction.py
+++ b/packages/ragleap-graph/src/ragleap_graph/extraction.py
@@ -16,10 +16,13 @@ Design constraints (locked, see CHANGELOG for rationale):
 from __future__ import annotations
 
 import json
+import logging
 import re
 from dataclasses import dataclass, field
 from difflib import SequenceMatcher
 from typing import Any, Literal, Optional
+
+logger = logging.getLogger(__name__)
 
 try:
     # Reuse ragleap-rag's existing provider abstraction rather than
@@ -78,6 +81,7 @@ class ExtractionConfig:
     extract_relations: bool = False
     cross_chunk_relations: bool = False
     entity_types: Optional[list[str]] = None
+    relation_ontology: Optional[dict[str, tuple[list[str], list[str]]]] = None
 
     def __post_init__(self) -> None:
         if self.extract_relations and self.method != "llm":
@@ -89,6 +93,13 @@ class ExtractionConfig:
             raise ValueError(
                 "cross_chunk_relations=True requires extract_relations=True - "
                 "the cross-chunk pass reuses the same LLM relation extractor."
+            )
+        if self.relation_ontology and not self.entity_types:
+            raise ValueError(
+                "relation_ontology=... requires entity_types=... - an ontology "
+                "constrains relation_type against entity types, so without a "
+                "known set of entity types every entity would be 'UNKNOWN' and "
+                "nothing could ever be validated against anything real."
             )
         if self.method == "llm" and self.provider is None:
             raise ValueError(
@@ -418,6 +429,7 @@ class LLMRelationExtractor:
         known_entities: list[str],
         domain_terms: Optional[list[str]] = None,
         resolve_references: bool = False,
+        entity_types: Optional[dict[str, str]] = None,
     ) -> list[ExtractedRelation]:
         """
         Identify relations between known_entities as they appear in text.
@@ -431,6 +443,14 @@ class LLMRelationExtractor:
         per-chunk extraction behavior is unchanged - added for the #154
         cross-chunk pass, where the full document is more likely to
         contain references to entities introduced earlier in the text.
+
+        entity_types: optional {lowercased_entity_name: entity_type} map,
+        used only when self._config.relation_ontology is set (#152). A
+        returned relation is dropped (with a WARNING logged) if its
+        relation_type is a key in relation_ontology and the subject/object
+        entity types are not in that relation_type's allowed
+        (subject_types, object_types). relation_type values NOT present
+        in relation_ontology are unconstrained.
         """
         if not text or not text.strip() or len(known_entities) < 2:
             return []
@@ -450,7 +470,35 @@ class LLMRelationExtractor:
                 f"LLM relation extraction failed on all configured providers: {result.get('answer')}"
             )
 
-        return self._parse_result(result, known_entities)
+        relations = self._parse_result(result, known_entities)
+
+        if self._config.relation_ontology and entity_types:
+            relations = self._filter_by_ontology(relations, entity_types)
+
+        return relations
+
+    def _filter_by_ontology(
+        self, relations: list[ExtractedRelation], entity_types: dict[str, str]
+    ) -> list[ExtractedRelation]:
+        ontology = self._config.relation_ontology
+        kept: list[ExtractedRelation] = []
+        for rel in relations:
+            if rel.relation_type not in ontology:
+                kept.append(rel)
+                continue
+            allowed_subject_types, allowed_object_types = ontology[rel.relation_type]
+            subj_type = entity_types.get(rel.subject.lower(), "UNKNOWN")
+            obj_type = entity_types.get(rel.object.lower(), "UNKNOWN")
+            if subj_type in allowed_subject_types and obj_type in allowed_object_types:
+                kept.append(rel)
+            else:
+                logger.warning(
+                    "Dropping relation violating ontology: (%s: %s) -[%s]-> (%s: %s). "
+                    "Allowed subject types: %s, allowed object types: %s.",
+                    rel.subject, subj_type, rel.relation_type, rel.object, obj_type,
+                    allowed_subject_types, allowed_object_types,
+                )
+        return kept
 
     def _build_instruction(
         self,

--- a/packages/ragleap-graph/tests/test_extraction.py
+++ b/packages/ragleap-graph/tests/test_extraction.py
@@ -462,6 +462,107 @@ def test_relation_extractor_drops_self_relations():
     assert relations == []
 
 
+def test_ontology_requires_entity_types():
+    from ragleap_graph.extraction import ExtractionConfig
+    import pytest
+    with pytest.raises(ValueError, match="requires entity_types"):
+        ExtractionConfig(
+            method="llm",
+            provider=FakeProviderConfig(provider="gemini"),
+            extract_relations=True,
+            relation_ontology={"FOUNDED_BY": (["ORGANIZATION"], ["PERSON"])},
+        )
+
+
+def test_ontology_keeps_relation_matching_allowed_types():
+    from ragleap_graph.extraction import ExtractionConfig, LLMRelationExtractor
+    FakeGenerationService.next_response = {
+        "answer": json.dumps({"relations": [
+            {"subject": "Acme Corp", "relation_type": "FOUNDED_BY", "object": "Sarah Chen"},
+        ]}),
+        "provider_used": "gemini",
+        "structured": {"relations": [
+            {"subject": "Acme Corp", "relation_type": "FOUNDED_BY", "object": "Sarah Chen"},
+        ]},
+        "structured_valid": True,
+        "structured_enforcement": "native",
+    }
+    config = ExtractionConfig(
+        method="llm",
+        provider=FakeProviderConfig(provider="gemini"),
+        extract_relations=True,
+        entity_types=["ORGANIZATION", "PERSON"],
+        relation_ontology={"FOUNDED_BY": (["ORGANIZATION"], ["PERSON"])},
+    )
+    extractor = LLMRelationExtractor(config)
+    relations = extractor.extract(
+        "Acme Corp was founded by Sarah Chen.",
+        known_entities=["Acme Corp", "Sarah Chen"],
+        entity_types={"acme corp": "ORGANIZATION", "sarah chen": "PERSON"},
+    )
+    assert len(relations) == 1
+    assert relations[0].subject == "Acme Corp"
+
+
+def test_ontology_drops_relation_violating_allowed_types():
+    from ragleap_graph.extraction import ExtractionConfig, LLMRelationExtractor
+    FakeGenerationService.next_response = {
+        "answer": json.dumps({"relations": [
+            {"subject": "Sarah Chen", "relation_type": "FOUNDED_BY", "object": "Austin"},
+        ]}),
+        "provider_used": "gemini",
+        "structured": {"relations": [
+            {"subject": "Sarah Chen", "relation_type": "FOUNDED_BY", "object": "Austin"},
+        ]},
+        "structured_valid": True,
+        "structured_enforcement": "native",
+    }
+    config = ExtractionConfig(
+        method="llm",
+        provider=FakeProviderConfig(provider="gemini"),
+        extract_relations=True,
+        entity_types=["ORGANIZATION", "PERSON", "LOCATION"],
+        relation_ontology={"FOUNDED_BY": (["ORGANIZATION"], ["PERSON"])},
+    )
+    extractor = LLMRelationExtractor(config)
+    relations = extractor.extract(
+        "text",
+        known_entities=["Sarah Chen", "Austin"],
+        entity_types={"sarah chen": "PERSON", "austin": "LOCATION"},
+    )
+    assert relations == []
+
+
+def test_ontology_leaves_unlisted_relation_types_unconstrained():
+    from ragleap_graph.extraction import ExtractionConfig, LLMRelationExtractor
+    FakeGenerationService.next_response = {
+        "answer": json.dumps({"relations": [
+            {"subject": "Sarah Chen", "relation_type": "VISITED", "object": "Austin"},
+        ]}),
+        "provider_used": "gemini",
+        "structured": {"relations": [
+            {"subject": "Sarah Chen", "relation_type": "VISITED", "object": "Austin"},
+        ]},
+        "structured_valid": True,
+        "structured_enforcement": "native",
+    }
+    config = ExtractionConfig(
+        method="llm",
+        provider=FakeProviderConfig(provider="gemini"),
+        extract_relations=True,
+        entity_types=["PERSON", "LOCATION"],
+        relation_ontology={"FOUNDED_BY": (["ORGANIZATION"], ["PERSON"])},
+    )
+    extractor = LLMRelationExtractor(config)
+    relations = extractor.extract(
+        "text",
+        known_entities=["Sarah Chen", "Austin"],
+        entity_types={"sarah chen": "PERSON", "austin": "LOCATION"},
+    )
+    assert len(relations) == 1
+    assert relations[0].relation_type == "VISITED"
+
+
 def test_relation_extractor_raises_when_all_providers_failed():
     from ragleap_graph.extraction import ExtractionConfig, LLMRelationExtractor
     FakeGenerationService.next_response = {

--- a/packages/ragleap-graph/tests/test_ragleap_graph.py
+++ b/packages/ragleap-graph/tests/test_ragleap_graph.py
@@ -498,6 +498,80 @@ def test_cross_chunk_relation_recovers_relation_per_chunk_extraction_misses():
         graph.close()
 
 
+@pytest.mark.skipif(
+    not (HAS_LIVE_NEO4J and gemini_available),
+    reason="Needs both live Neo4j credentials and a GEMINI_API_KEY in environment",
+)
+def test_ontology_drops_relation_violating_configured_types():
+    """
+    Real proof-of-value test for #152 (ontology cross-validation). Uses
+    Gemini, same precedent as the #154 cross-chunk test: ontology
+    validation depends on the underlying relation_type/entity_type
+    extraction being accurate, so a weak local model would confound
+    "did the ontology filter work" with "did the model extract sensibly
+    in the first place".
+
+    Document deliberately invites a nonsensical relation: asking the
+    model to relate a PERSON to a DATE using a relation_type ("FOUNDED")
+    that our configured ontology only allows between ORGANIZATION and
+    PERSON. If the model (as expected) proposes something like
+    (Sarah Chen)-[FOUNDED]->(2010), the ontology should drop it - proving
+    real end-to-end filtering, not just the offline mock-based tests.
+    """
+    from ragleap import ProviderConfig
+    from ragleap_graph import ExtractionConfig
+
+    provider = ProviderConfig(provider="gemini")
+    extraction = ExtractionConfig(
+        method="llm",
+        provider=provider,
+        extract_relations=True,
+        entity_types=["ORGANIZATION", "PERSON", "DATE"],
+        relation_ontology={"FOUNDED": (["PERSON"], ["ORGANIZATION"])},
+    )
+    config = GraphConfig(uri=NEO4J_URI, user=NEO4J_USER, password=NEO4J_PASSWORD)
+    graph = GraphIndex(config=config, extraction=extraction)
+    try:
+        graph.upsert_document(
+            "ontology-doc-1", "Test",
+            [{"text": "Sarah Chen founded Acme Corp in 2010."}],
+            namespace=TEST_NAMESPACE,
+        )
+        with graph.driver.session() as session:
+            rows = session.run(
+                "MATCH (a:Entity {namespace: $ns})-[r:RELATES_AS]->(b:Entity {namespace: $ns}) "
+                "WHERE toLower(a.name) CONTAINS 'sarah' AND toLower(b.name) CONTAINS '2010' "
+                "RETURN r.relation_type AS rt",
+                ns=TEST_NAMESPACE,
+            ).data()
+            assert len(rows) == 0, (
+                f"expected the ontology to drop any (PERSON)-[FOUNDED]->(DATE) relation, "
+                f"but found: {rows}"
+            )
+            # Sanity check the ontology-VALID relation still comes through -
+            # otherwise a trivial "the model extracted nothing at all" bug
+            # would also make the assertion above pass for the wrong reason.
+            valid_rows = session.run(
+                "MATCH (a:Entity {namespace: $ns})-[r:RELATES_AS]->(b:Entity {namespace: $ns}) "
+                "WHERE toLower(a.name) CONTAINS 'sarah' AND toLower(b.name) CONTAINS 'acme' "
+                "RETURN r.relation_type AS rt",
+                ns=TEST_NAMESPACE,
+            ).data()
+            assert len(valid_rows) >= 1, (
+                "expected the ontology-valid (PERSON)-[FOUNDED]->(ORGANIZATION) relation "
+                "to still be present - if this fails, the model may not have extracted "
+                "any FOUNDED relation at all, which would make the drop assertion above "
+                "pass for the wrong reason"
+            )
+    finally:
+        with graph.driver.session() as session:
+            session.run(
+                "MATCH (n) WHERE n.namespace = $ns DETACH DELETE n",
+                ns=TEST_NAMESPACE,
+            )
+        graph.close()
+
+
 @pytest.mark.skipif(not HAS_LIVE_NEO4J, reason="No live Neo4j credentials in environment")
 def test_co_occurs_with_per_document_contribution_tracking():
     """


### PR DESCRIPTION
Implements #152 per docs/design/ontology-cross-validation.md.

## What
- `ExtractionConfig.relation_ontology` (opt-in, requires `entity_types=`)
- `LLMRelationExtractor.extract()` gains `entity_types=`, threaded from the existing `entity_type_map`
- Violating relations dropped with a `WARNING`, not silently
- Applies to both the per-chunk pass and the v0.8.0 cross-chunk pass

## Design decisions (see design doc for full reasoning)
- Ontology shape: `{relation_type: (allowed_subject_types, allowed_object_types)}`
- Unlisted relation_types remain fully unconstrained
- `relation_ontology` without `entity_types` is a config-time `ValueError`

## Testing
- 4 new offline tests (mock-based, matching existing `LLMRelationExtractor` test style)
- 1 new live test, gated on `HAS_LIVE_NEO4J and gemini_available`: confirms a real ontology-valid relation is kept AND a real ontology-violating relation the model actually proposed is genuinely dropped
- Full suite: 92 passed, 16 skipped without credentials (zero regressions)