### PR TITLE
release(ragleap-app-chart): bump to v0.2.0

### DIFF
--- a/packages/ragleap-app-chart/CHANGELOG.md
+++ b/packages/ragleap-app-chart/CHANGELOG.md
@@ -5,6 +5,8 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.2.0]
+
 ### Added
 
 - `command`/`args` support per service in `deployment.yaml` -- a real, structural gap found while building the worked example below (not previously supported at all, for any reason, on any service). Discovered live: a worked example using `hashicorp/http-echo` set its message via `env:`, deployed successfully, but returned the image's baked-in default text instead -- because `http-echo` is configured via a command-line flag (`-text=...`), not an environment variable, and the chart had no way to override the container's command/args at all. Fixed by mirroring the exact pattern already used in `ragleap-ops` (`command: {{ .Values.voice.command | toJson }}`). Re-deployed live against the same real kind cluster after the fix and confirmed the correct response (`hello from ragleap-app-chart`) via a live port-forward and curl -- not just `helm template` output.

--- a/packages/ragleap-app-chart/helm/ragleap-app-chart/Chart.yaml
+++ b/packages/ragleap-app-chart/helm/ragleap-app-chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ragleap-app-chart
 description: Generic, reusable Helm chart for deploying arbitrary services to Kubernetes — not RagLeap-specific
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"

--- a/packages/ragleap-app-chart/pyproject.toml
+++ b/packages/ragleap-app-chart/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragleap-app-chart"
-version = "0.1.0"
+version = "0.2.0"
 description = "Generic, reusable Helm chart for deploying arbitrary services to Kubernetes — not RagLeap-specific"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/ragleap-app-chart/src/ragleap_app_chart/__init__.py
+++ b/packages/ragleap-app-chart/src/ragleap_app_chart/__init__.py
@@ -12,4 +12,4 @@ chart alongside this src/ tree, matching the release discipline of
 ragleap-ops, ragleap-rag, ragleap-graph, and ragleap-vectorstores.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"


### PR DESCRIPTION
Version bump for the multi-env values pattern, worked example, and command/args support shipped this session -- real new features warrant a minor version bump per semver, not a patch release.

Bumped consistently across pyproject.toml, __init__.py, and Chart.yaml (both version and appVersion). helm lint confirmed clean post-bump.

CHANGELOG.md's [Unreleased] section moved to [0.2.0], per project convention.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
