### PR TITLE
feat(java-port): port VectorBackend + PgVectorBackend (CRUD + dense search)

### DIFF
--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/vectorstore/DocumentSummary.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/vectorstore/DocumentSummary.java
@@ -1,0 +1,13 @@
+package com.ragleap.rag.vectorstore;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+/**
+ * One row from VectorBackend.list_documents() in base.py.
+ */
+public record DocumentSummary(
+        String documentId, String filename, OffsetDateTime uploadedAt,
+        Map<String, Object> metadata, long chunkCount
+) {
+}

--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/vectorstore/PgVectorBackend.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/vectorstore/PgVectorBackend.java
@@ -1,0 +1,233 @@
+package com.ragleap.rag.vectorstore;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ragleap.rag.db.ConnectionPool;
+import com.ragleap.rag.schema.SchemaManager;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.StringJoiner;
+import java.util.UUID;
+
+/**
+ * Postgres + pgvector backend - the default, battle-tested storage for
+ * ragleap-rag. Java port of ragleap-rag's vectorstores/pgvector.py -
+ * PgVectorBackend.
+ *
+ * This PR ports the CRUD + dense-search half only (initSchema,
+ * insertDocument, insertChunk, searchDense, listDocuments,
+ * deleteDocument, getDocumentFilename). searchSparse and searchHybrid
+ * (RRF fusion) are a deliberate follow-up PR.
+ *
+ * Key technical note: pgvector's halfvec(N) type-modifier position
+ * must be a literal at SQL-parse time, not a JDBC bind parameter -
+ * PreparedStatement can't put a `?` inside `halfvec(?)`. This mirrors
+ * what psycopg2's %s effectively did too (client-side string
+ * substitution before the query is sent), just via a different
+ * mechanism - dimensions is interpolated directly into the SQL text
+ * (safe here: it's an internal int, never user input), while every
+ * actual data value still uses a real bind parameter.
+ *
+ * Metadata (JSONB) is serialized/deserialized explicitly via Jackson's
+ * ObjectMapper - unlike psycopg2, the JDBC PostgreSQL driver doesn't
+ * auto-parse jsonb columns into a Map.
+ *
+ * document_id and chunk id map to java.util.UUID via JDBC's native
+ * support, rather than string-casting the way Python's implicit
+ * str(uuid_obj) coercion does - a deliberate improvement, documented
+ * here rather than silently diverging.
+ */
+public class PgVectorBackend implements VectorBackend {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final ConnectionPool pool;
+    private final double minSimilarity;
+    private Integer dimensions;
+
+    public PgVectorBackend(String databaseUrl) {
+        this(databaseUrl, 0.05);
+    }
+
+    public PgVectorBackend(String databaseUrl, double minSimilarity) {
+        this.pool = new ConnectionPool(databaseUrl);
+        this.minSimilarity = minSimilarity;
+    }
+
+    @Override
+    public void initSchema(int dimensions) throws SQLException {
+        this.dimensions = dimensions;
+        SchemaManager.initCoreSchema(pool, dimensions);
+    }
+
+    @Override
+    public void insertDocument(String documentId, String filename, Map<String, Object> metadata) throws SQLException {
+        try (Connection conn = pool.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(
+                     "INSERT INTO documents (id, filename, metadata) VALUES (?, ?, ?::jsonb)")) {
+            stmt.setObject(1, UUID.fromString(documentId));
+            stmt.setString(2, filename);
+            stmt.setString(3, toJson(metadata));
+            stmt.executeUpdate();
+            conn.commit();
+        }
+    }
+
+    @Override
+    public void insertChunk(String documentId, String documentName, int chunkIndex, String text,
+                              Integer tokenCount, List<Double> embedding, Map<String, Object> metadata) throws SQLException {
+        String embeddingLiteral = toVectorLiteral(embedding);
+        try (Connection conn = pool.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(
+                     "INSERT INTO chunks (document_id, document_name, chunk_index, text, token_count, embedding, metadata) " +
+                     "VALUES (?, ?, ?, ?, ?, ?::vector, ?::jsonb)")) {
+            stmt.setObject(1, UUID.fromString(documentId));
+            stmt.setString(2, documentName);
+            stmt.setInt(3, chunkIndex);
+            stmt.setString(4, text);
+            if (tokenCount != null) {
+                stmt.setInt(5, tokenCount);
+            } else {
+                stmt.setNull(5, java.sql.Types.INTEGER);
+            }
+            stmt.setString(6, embeddingLiteral);
+            stmt.setString(7, toJson(metadata));
+            stmt.executeUpdate();
+            conn.commit();
+        }
+    }
+
+    @Override
+    public List<SearchResult> searchDense(List<Double> embedding, int topK, Map<String, Object> metadataFilter) throws SQLException {
+        if (embedding == null || embedding.isEmpty()) {
+            return List.of();
+        }
+        int dims = this.dimensions != null ? this.dimensions : embedding.size();
+        String literal = toVectorLiteral(embedding);
+
+        StringBuilder sql = new StringBuilder(String.format(
+                "SELECT id, text, document_id, document_name, chunk_index, " +
+                "1 - (embedding::halfvec(%1$d) <=> ?::halfvec(%1$d)) / 2 AS similarity_score " +
+                "FROM chunks", dims));
+
+        boolean hasFilter = metadataFilter != null && !metadataFilter.isEmpty();
+        if (hasFilter) {
+            sql.append(" WHERE metadata @> ?::jsonb");
+        }
+        sql.append(String.format(" ORDER BY embedding::halfvec(%1$d) <=> ?::halfvec(%1$d) LIMIT ?", dims));
+
+        List<SearchResult> results = new ArrayList<>();
+        try (Connection conn = pool.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql.toString())) {
+            int i = 1;
+            stmt.setString(i++, literal);
+            if (hasFilter) {
+                stmt.setString(i++, toJson(metadataFilter));
+            }
+            stmt.setString(i++, literal);
+            stmt.setInt(i, topK);
+
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    double score = rs.getDouble("similarity_score");
+                    if (score < minSimilarity) {
+                        continue;
+                    }
+                    results.add(new SearchResult(
+                            rs.getObject("id", UUID.class).toString(),
+                            rs.getString("text"),
+                            Math.round(score * 10000.0) / 10000.0,
+                            rs.getObject("document_id", UUID.class).toString(),
+                            rs.getString("document_name"),
+                            rs.getInt("chunk_index")
+                    ));
+                }
+            }
+        }
+        return results;
+    }
+
+    @Override
+    public List<DocumentSummary> listDocuments(int limit, int offset) throws SQLException {
+        String sql = "SELECT d.id, d.filename, d.uploaded_at, d.metadata, COUNT(c.id) AS chunk_count " +
+                "FROM documents d LEFT JOIN chunks c ON c.document_id = d.id " +
+                "GROUP BY d.id, d.filename, d.uploaded_at, d.metadata " +
+                "ORDER BY d.uploaded_at DESC LIMIT ? OFFSET ?";
+
+        List<DocumentSummary> results = new ArrayList<>();
+        try (Connection conn = pool.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setInt(1, limit);
+            stmt.setInt(2, offset);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    results.add(new DocumentSummary(
+                            rs.getObject("id", UUID.class).toString(),
+                            rs.getString("filename"),
+                            rs.getObject("uploaded_at", OffsetDateTime.class),
+                            fromJson(rs.getString("metadata")),
+                            rs.getLong("chunk_count")
+                    ));
+                }
+            }
+        }
+        return results;
+    }
+
+    @Override
+    public boolean deleteDocument(String documentId) throws SQLException {
+        try (Connection conn = pool.getConnection();
+             PreparedStatement stmt = conn.prepareStatement("DELETE FROM documents WHERE id = ?")) {
+            stmt.setObject(1, UUID.fromString(documentId));
+            int deleted = stmt.executeUpdate();
+            conn.commit();
+            return deleted > 0;
+        }
+    }
+
+    @Override
+    public Optional<String> getDocumentFilename(String documentId) throws SQLException {
+        try (Connection conn = pool.getConnection();
+             PreparedStatement stmt = conn.prepareStatement("SELECT filename FROM documents WHERE id = ?")) {
+            stmt.setObject(1, UUID.fromString(documentId));
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(rs.getString("filename"));
+                }
+                return Optional.empty();
+            }
+        }
+    }
+
+    private static String toVectorLiteral(List<Double> embedding) {
+        StringJoiner joiner = new StringJoiner(",", "[", "]");
+        for (Double v : embedding) {
+            joiner.add(String.valueOf(v));
+        }
+        return joiner.toString();
+    }
+
+    private static String toJson(Map<String, Object> map) throws SQLException {
+        try {
+            return MAPPER.writeValueAsString(map != null ? map : Map.of());
+        } catch (Exception e) {
+            throw new SQLException("Failed to serialize metadata to JSON", e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> fromJson(String json) throws SQLException {
+        try {
+            return json != null ? MAPPER.readValue(json, Map.class) : Map.of();
+        } catch (Exception e) {
+            throw new SQLException("Failed to parse metadata JSON", e);
+        }
+    }
+}

--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/vectorstore/SearchResult.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/vectorstore/SearchResult.java
@@ -1,0 +1,21 @@
+package com.ragleap.rag.vectorstore;
+
+/**
+ * One search hit. Java equivalent of the dicts returned by
+ * VectorBackend.search_dense()/search_sparse()/search_hybrid() in
+ * base.py - must contain at least chunk_id, text, similarity_score,
+ * document_id, document_name, chunk_index.
+ *
+ * retrievalMethod is null for plain dense/sparse results - only
+ * search_hybrid() sets it, to "hybrid_rrf".
+ */
+public record SearchResult(
+        String chunkId, String text, double similarityScore,
+        String documentId, String documentName, int chunkIndex,
+        String retrievalMethod
+) {
+    public SearchResult(String chunkId, String text, double similarityScore,
+                          String documentId, String documentName, int chunkIndex) {
+        this(chunkId, text, similarityScore, documentId, documentName, chunkIndex, null);
+    }
+}

--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/vectorstore/VectorBackend.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/vectorstore/VectorBackend.java
@@ -1,0 +1,77 @@
+package com.ragleap.rag.vectorstore;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Every vector storage backend must implement this interface. Java
+ * port of ragleap-rag's vectorstores/base.py - VectorBackend.
+ *
+ * RagLeap defaults to PgVectorBackend (Postgres + pgvector) for full
+ * backward compatibility. Other backends (FAISS, Pinecone, ...) can be
+ * swapped in later. Backends differ in what they can do -
+ * supportsSparse() is a real capability flag, not a formality: callers
+ * should check it before assuming hybrid search is meaningful for a
+ * given backend.
+ *
+ * Methods declare `throws SQLException` rather than the Java
+ * equivalent of Python's bare exceptions - JDBC operations are
+ * inherently checked-exception-bearing, and callers need to see that
+ * in the interface, unlike Python where any exception can propagate
+ * silently through an unannotated method signature.
+ */
+public interface VectorBackend {
+
+    /** Create/verify whatever storage structure this backend needs. Idempotent. */
+    void initSchema(int dimensions) throws SQLException;
+
+    /** Register a new document (parent record for its chunks). */
+    void insertDocument(String documentId, String filename, Map<String, Object> metadata) throws SQLException;
+
+    /** Store one chunk with its embedding. */
+    void insertChunk(String documentId, String documentName, int chunkIndex, String text,
+                       Integer tokenCount, List<Double> embedding, Map<String, Object> metadata) throws SQLException;
+
+    /**
+     * Vector similarity search. Must return results with at least
+     * chunkId, text, similarityScore, documentId, documentName, chunkIndex.
+     */
+    List<SearchResult> searchDense(List<Double> embedding, int topK, Map<String, Object> metadataFilter) throws SQLException;
+
+    /** Keyword/full-text search. Default: not supported (see supportsSparse()). */
+    default List<SearchResult> searchSparse(String queryText, int topK, Map<String, Object> metadataFilter) throws SQLException {
+        return List.of();
+    }
+
+    /**
+     * Combined dense+sparse via RRF. Default: falls back to dense-only
+     * if this backend doesn't support sparse search - see supportsSparse().
+     */
+    default List<SearchResult> searchHybrid(String queryText, List<Double> embedding, int topK,
+                                              Map<String, Object> metadataFilter) throws SQLException {
+        return searchDense(embedding, topK, metadataFilter);
+    }
+
+    /**
+     * Whether this backend can do real keyword/full-text search.
+     * Callers should check this rather than assume hybrid search is
+     * doing anything beyond dense search under the hood.
+     */
+    default boolean supportsSparse() {
+        return false;
+    }
+
+    /** List documents, most recent first. */
+    List<DocumentSummary> listDocuments(int limit, int offset) throws SQLException;
+
+    /** Delete a document and its chunks. Returns true if something was deleted. */
+    boolean deleteDocument(String documentId) throws SQLException;
+
+    /**
+     * Return a document's stored filename, or empty if it doesn't exist.
+     * Used when no explicit filename is given for an update.
+     */
+    Optional<String> getDocumentFilename(String documentId) throws SQLException;
+}

--- a/java/ragleap-rag/src/test/java/com/ragleap/rag/vectorstore/PgVectorBackendTest.java
+++ b/java/ragleap-rag/src/test/java/com/ragleap/rag/vectorstore/PgVectorBackendTest.java
@@ -1,0 +1,192 @@
+package com.ragleap.rag.vectorstore;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Real integration test against the live ragleap_java_test database -
+ * NOT mocked. Uses a small dimension count (8) for fast, deterministic
+ * test vectors while still exercising real pgvector similarity math.
+ */
+class PgVectorBackendTest {
+
+    private static final String DATABASE_URL = System.getenv().getOrDefault(
+            "RAGLEAP_JAVA_TEST_DATABASE_URL",
+            "postgresql://ragleap:ragleap@localhost:5433/ragleap_java_test"
+    );
+    private static final int DIMS = 8;
+
+    private static PgVectorBackend backend;
+
+    @BeforeAll
+    static void setUp() throws SQLException {
+        backend = new PgVectorBackend(DATABASE_URL, 0.0); // 0.0 threshold: don't filter results in tests
+        backend.initSchema(DIMS);
+    }
+
+    @AfterEach
+    void cleanUpRows() throws Exception {
+        // Truncate between tests so document/chunk counts don't bleed
+        // across tests - schema itself stays (idempotent CREATE anyway).
+        java.lang.reflect.Field poolField = PgVectorBackend.class.getDeclaredField("pool");
+        poolField.setAccessible(true);
+        var pool = (com.ragleap.rag.db.ConnectionPool) poolField.get(backend);
+        try (Connection conn = pool.getConnection();
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("TRUNCATE documents CASCADE");
+            conn.commit();
+        }
+    }
+
+    @AfterAll
+    static void tearDown() throws SQLException {
+        java.lang.reflect.Field poolField;
+        try {
+            poolField = PgVectorBackend.class.getDeclaredField("pool");
+            poolField.setAccessible(true);
+            var pool = (com.ragleap.rag.db.ConnectionPool) poolField.get(backend);
+            try (Connection conn = pool.getConnection();
+                 Statement stmt = conn.createStatement()) {
+                stmt.execute("DROP TABLE IF EXISTS chunks CASCADE");
+                stmt.execute("DROP TABLE IF EXISTS documents CASCADE");
+                conn.commit();
+            }
+            pool.close();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static List<Double> vec(double... values) {
+        List<Double> list = new java.util.ArrayList<>();
+        for (double v : values) {
+            list.add(v);
+        }
+        return list;
+    }
+
+    @Test
+    void insertAndRetrieveDocumentFilename() throws SQLException {
+        String docId = UUID.randomUUID().toString();
+        backend.insertDocument(docId, "report.pdf", Map.of("source", "upload"));
+
+        Optional<String> filename = backend.getDocumentFilename(docId);
+        assertTrue(filename.isPresent());
+        assertEquals("report.pdf", filename.get());
+    }
+
+    @Test
+    void getDocumentFilenameEmptyForNonexistentDocument() throws SQLException {
+        assertTrue(backend.getDocumentFilename(UUID.randomUUID().toString()).isEmpty());
+    }
+
+    @Test
+    void insertChunkAndSearchDenseFindsExactMatchFirst() throws SQLException {
+        String docId = UUID.randomUUID().toString();
+        backend.insertDocument(docId, "doc.txt", Map.of());
+
+        backend.insertChunk(docId, "doc.txt", 0, "chunk about cats",
+                10, vec(1, 0, 0, 0, 0, 0, 0, 0), Map.of());
+        backend.insertChunk(docId, "doc.txt", 1, "chunk about dogs",
+                10, vec(0, 1, 0, 0, 0, 0, 0, 0), Map.of());
+
+        List<SearchResult> results = backend.searchDense(vec(1, 0, 0, 0, 0, 0, 0, 0), 5, null);
+
+        assertFalse(results.isEmpty());
+        assertEquals("chunk about cats", results.get(0).text());
+        assertTrue(results.get(0).similarityScore() > results.get(results.size() - 1).similarityScore()
+                || results.size() == 1);
+    }
+
+    @Test
+    void searchDenseRespectsTopK() throws SQLException {
+        String docId = UUID.randomUUID().toString();
+        backend.insertDocument(docId, "doc.txt", Map.of());
+        for (int i = 0; i < 5; i++) {
+            backend.insertChunk(docId, "doc.txt", i, "chunk " + i, 5,
+                    vec(1, 0, 0, 0, 0, 0, 0, 0), Map.of());
+        }
+
+        List<SearchResult> results = backend.searchDense(vec(1, 0, 0, 0, 0, 0, 0, 0), 2, null);
+        assertEquals(2, results.size());
+    }
+
+    @Test
+    void searchDenseWithMetadataFilterOnlyReturnsMatchingChunks() throws SQLException {
+        String docId = UUID.randomUUID().toString();
+        backend.insertDocument(docId, "doc.txt", Map.of());
+        backend.insertChunk(docId, "doc.txt", 0, "public chunk", 5,
+                vec(1, 0, 0, 0, 0, 0, 0, 0), Map.of("visibility", "public"));
+        backend.insertChunk(docId, "doc.txt", 1, "private chunk", 5,
+                vec(1, 0, 0, 0, 0, 0, 0, 0), Map.of("visibility", "private"));
+
+        List<SearchResult> results = backend.searchDense(vec(1, 0, 0, 0, 0, 0, 0, 0), 10,
+                Map.of("visibility", "public"));
+
+        assertEquals(1, results.size());
+        assertEquals("public chunk", results.get(0).text());
+    }
+
+    @Test
+    void searchDenseReturnsEmptyForEmptyEmbedding() throws SQLException {
+        assertEquals(List.of(), backend.searchDense(List.of(), 5, null));
+    }
+
+    @Test
+    void listDocumentsReturnsMostRecentFirstWithChunkCounts() throws SQLException, InterruptedException {
+        String doc1 = UUID.randomUUID().toString();
+        String doc2 = UUID.randomUUID().toString();
+        backend.insertDocument(doc1, "first.txt", Map.of());
+        Thread.sleep(10); // ensure distinct uploaded_at ordering
+        backend.insertDocument(doc2, "second.txt", Map.of());
+        backend.insertChunk(doc2, "second.txt", 0, "chunk", 5, vec(1, 0, 0, 0, 0, 0, 0, 0), Map.of());
+
+        List<DocumentSummary> docs = backend.listDocuments(10, 0);
+
+        assertEquals(2, docs.size());
+        assertEquals("second.txt", docs.get(0).filename()); // most recent first
+        assertEquals(1, docs.get(0).chunkCount());
+        assertEquals(0, docs.get(1).chunkCount());
+    }
+
+    @Test
+    void deleteDocumentReturnsTrueAndCascadesChunks() throws SQLException {
+        String docId = UUID.randomUUID().toString();
+        backend.insertDocument(docId, "doc.txt", Map.of());
+        backend.insertChunk(docId, "doc.txt", 0, "chunk", 5, vec(1, 0, 0, 0, 0, 0, 0, 0), Map.of());
+
+        boolean deleted = backend.deleteDocument(docId);
+        assertTrue(deleted);
+        assertTrue(backend.getDocumentFilename(docId).isEmpty());
+
+        List<SearchResult> results = backend.searchDense(vec(1, 0, 0, 0, 0, 0, 0, 0), 10, null);
+        assertTrue(results.isEmpty(), "Chunks should cascade-delete with their parent document");
+    }
+
+    @Test
+    void deleteDocumentReturnsFalseForNonexistentDocument() throws SQLException {
+        assertFalse(backend.deleteDocument(UUID.randomUUID().toString()));
+    }
+
+    @Test
+    void supportsSparseDefaultsFalseUntilPortedInFollowUp() {
+        // PgVectorBackend actually supports sparse search in Python (returns
+        // true) - this Java port hasn't ported searchSparse/searchHybrid
+        // yet, so it currently uses the interface's default (false) rather
+        // than overriding it prematurely. Update this test when that
+        // follow-up PR lands.
+        assertFalse(backend.supportsSparse());
+    }
+}


### PR DESCRIPTION
Core vector store module (see java/HANDOVER.md roadmap, PRs #337/#338/#344/#345 for db.py/embedding.py/schema.py). Ports the VectorBackend interface and PgVectorBackend's CRUD + dense-search half. searchSparse/searchHybrid (RRF fusion) deliberately deferred to a follow-up PR. Key finding documented in the commit: pgvector's halfvec(N) casts require SQL-text interpolation, not JDBC bind params. 10 new JUnit tests against real live Postgres (not mocked) - genuine vector similarity math, cascade deletes, metadata filtering all verified. 127/127 passing overall.