### PR TITLE
docs: fix stale claims found in ragleap-graph documentation audit

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -71,7 +71,7 @@ RagLeap's production RAG engine originally lived inside a larger private Django 
 
 ## Phase 7 — `ragleap-graph` hardening (in progress)
 
-`ragleap-graph` (the standalone PyPI library, `packages/ragleap-graph/`) went from v0.1.0 to v0.6.5 across this and prior sessions: LLM-based entity/relation extraction, entity deduplication, hybrid vector+graph retrieval, per-document contribution tracking (idempotent re-upserts), lineage lookup (`find_lineage()`), and per-user data isolation (`user_id=`, with a `backfill_user_id_defaults()` migration for pre-upgrade installs). 87 tests, 86 passing, 1 skipped without `GEMINI_API_KEY`.
+`ragleap-graph` (the standalone PyPI library, `packages/ragleap-graph/`) went from v0.1.0 to v0.9.0 across this and prior sessions: LLM-based entity/relation extraction, entity deduplication, hybrid vector+graph retrieval, per-document contribution tracking (idempotent re-upserts), lineage lookup (`find_lineage()`), per-user data isolation (`user_id=`, with a `backfill_user_id_defaults()` migration for pre-upgrade installs), Postgres-backed audit logging, schema migrations, cross-chunk relation extraction, and ontology cross-validation. 108 tests, 92 passing without live credentials, 16 skipped.
 
 - [x] Core graph indexing, regex + LLM entity extraction, co-occurrence graphs
 - [x] Typed relation extraction (`RELATES_AS` edges), hybrid `GraphRetriever`
@@ -79,10 +79,10 @@ RagLeap's production RAG engine originally lived inside a larger private Django 
 - [x] Per-document idempotency for `CONTAINS`/`CO_OCCURS_WITH`/`RELATES_AS` (fixed real weight-doubling and stale-edge bugs)
 - [x] `find_lineage()` — per-document contribution lookup, previously unreachable via any public method
 - [x] `user_id=` for per-user data isolation across `upsert_document()` and all read methods, plus `backfill_user_id_defaults()` migration
-- [ ] Audit logging (Postgres-backed, `database_url=`, writes+reads) — see [#151](../../issues/151)
-- [ ] Ontology cross-validation between relation types and entity types — blocked on a design decision, see [#152](../../issues/152)
-- [ ] Eval framework (graph-RAG vs vector-RAG accuracy) — new engineering, see [#153](../../issues/153)
-- [ ] Cross-chunk relation extraction — see [#154](../../issues/154)
+- [x] Audit logging (Postgres-backed, `database_url=`, writes+reads) — shipped v0.6.6, [#151](../../issues/151) closed (found already implemented during a documentation-claims audit, the issue description had drifted stale)
+- [x] Ontology cross-validation between relation types and entity types — shipped v0.9.0, see [#152](../../issues/152)
+- [ ] Eval framework (graph-RAG vs vector-RAG accuracy) — new engineering, still needs domain-expert-authored labeled test cases, see [#153](../../issues/153)
+- [x] Cross-chunk relation extraction — shipped v0.8.0, see [#154](../../issues/154)
 
 Also open: rotating a previously-exposed `GEMINI_API_KEY` ([#155](../../issues/155)), deciding how a future `ragleap-voice` package should relate to the existing `channels/voice/` code ([#156](../../issues/156)), and confirming the `/simple/` PyPI proxy serves real package data ([#157](../../issues/157)).
 

--- a/packages/ragleap-graph/README.md
+++ b/packages/ragleap-graph/README.md
@@ -28,7 +28,7 @@ related = graph.search_related_entities(["Acme Corp"], max_depth=2)
 ```
 
 <!-- AUTO-STATS:START -->
-**Current: v0.6.5** · 87 tests (86 passed, 1 skipped)
+**Current: v0.9.0** · 108 tests (92 passed without live credentials, 16 skipped)
 <!-- AUTO-STATS:END -->
 
 ## Architecture
@@ -62,6 +62,46 @@ one real-world entity into multiple candidates in the first place — see
 CHANGELOG.md for a real, measured example of this and how `method="llm"`
 avoids it at the source.
 
+## Cross-chunk relation extraction (v0.8.0+)
+
+Relation extraction normally runs per-chunk, so a relation whose evidence
+spans two chunks — e.g. an entity named in chunk 1, referred to only by
+pronoun ("it", "the company") in a later chunk — can be missed. Enable
+`cross_chunk_relations=True` for one additional pass over the full
+document using every entity found across all chunks:
+
+```python
+extraction=ExtractionConfig(
+    method="llm",
+    provider=ProviderConfig(provider="gemini", api_key="...", model="gemini-3.6-flash"),
+    extract_relations=True,
+    cross_chunk_relations=True,
+)
+```
+
+Known limitation: this depends on the provider's reasoning ability to
+resolve the reference correctly. Live-verified working with Gemini;
+small local models (e.g. `qwen2.5:0.5b`) were found, via live testing,
+to produce an incorrect relation rather than none on this task — not
+recommended for this feature without independently verifying its output.
+
+## Ontology cross-validation (v0.9.0+)
+
+Constrain which `relation_type` values are valid between which
+`entity_type` pairs. A relation violating the ontology is dropped (with
+a `WARNING` logged) rather than written to Neo4j; `relation_type` values
+not listed remain unconstrained. Requires `entity_types=` to also be set:
+
+```python
+extraction=ExtractionConfig(
+    method="llm",
+    provider=ProviderConfig(provider="gemini", api_key="...", model="gemini-3.6-flash"),
+    extract_relations=True,
+    entity_types=["ORGANIZATION", "PERSON"],
+    relation_ontology={"FOUNDED_BY": (["ORGANIZATION"], ["PERSON"])},
+)
+```
+
 ## Operations
 
 `ragleap-graph` is a knowledge-graph retrieval library, not a database
@@ -76,7 +116,7 @@ for the reasoning behind this scope decision.
 
 ## Status
 
-v0.6.5. Ported from a real production `GraphService`, adapted for standalone open-source use — see `HANDOFF.md` for the full design history. `ragleap-rag` >=0.12.0 is an optional dependency, required only for `method="llm"`.
+v0.9.0. Ported from a real production `GraphService`, adapted for standalone open-source use — see `HANDOFF.md` for the full design history. `ragleap-rag` >=0.12.0 is an optional dependency, required only for `method="llm"`.
 
 ## License
 

--- a/packages/ragleap-graph/docs/design/cross-chunk-relation-extraction.md
+++ b/packages/ragleap-graph/docs/design/cross-chunk-relation-extraction.md
@@ -1,0 +1,96 @@
+# Design: Cross-Chunk Relation Extraction (#154)
+
+> **Status: Implemented (v0.8.0).**
+> This document was drafted during the same session that implemented
+> the feature and was not committed to the repo at the time - a real
+> process gap caught during a later documentation-claims audit. It's
+> recreated here after the fact, reflecting what was actually decided
+> and shipped, not a pending proposal. See CHANGELOG.md for the full
+> implementation summary.
+
+**Package:** `ragleap-graph`
+**Depends on / precedent:** `docs/design/schema-migrations.md`,
+`docs/adr/0001-backup-restore-ownership.md`
+
+---
+
+## 1. Problem statement
+
+Relation extraction ran per-chunk only: each chunk was sent to the LLM
+independently, so any relation whose evidence spans a chunk boundary -
+e.g. an entity introduced in chunk 1, referred to only by pronoun ("it",
+"the company") in a later chunk - was never extracted. Confirmed via
+source inspection: `entity_counter` already accumulated entity names
+across every chunk (`_upsert_document_once()`, `__init__.py`), but
+`known_entities` passed into each chunk's relation-extraction call was
+chunk-local only - the fix was a threading problem, not a missing
+subsystem.
+
+## 2. What shipped
+
+`ExtractionConfig.cross_chunk_relations` (opt-in, default `False`,
+requires `extract_relations=True`): after the per-chunk loop, one
+additional `LLMRelationExtractor.extract()` call runs over the full
+accumulated document text and every entity found across all chunks,
+feeding the *same* `relation_counter` used by the per-chunk pass - no
+new Neo4j write path was needed, since the existing `RelationWeight`
+aggregation and `RELATES_AS` MERGE already handle whatever lands in
+`relation_counter`.
+
+`LLMRelationExtractor.extract()` gained an optional `resolve_references`
+parameter (default `False`, only set `True` by the cross-chunk call)
+that adds an explicit instruction asking the model to resolve
+pronouns/vague references to a known entity name - the base per-chunk
+prompt gave no such instruction, and without it a 0.5B-parameter model
+had no reason to infer that "it" should map to a specific known entity.
+
+## 3. Real finding from live testing (this is the part worth keeping)
+
+The architecture worked correctly on the first design pass - verified
+by tracing the existing `RelationWeight`/`RELATES_AS` pipeline before
+writing any code, so no parallel write path was ever needed.
+
+What did NOT work on the first attempt was the model itself: `qwen2.5:0.5b`
+failed to resolve a real pronoun-reference test case correctly. It didn't
+just miss the relation - it produced an incorrect one
+(`(Sarah Chen)-[FOUNDED_BY]->(Austin)`, connecting the wrong two
+entities), which is a worse failure mode than returning nothing, since
+it would silently pollute the graph rather than leave an honest gap.
+
+A side-by-side test with Gemini (`gemini-3.5-flash` at the time, since
+superseded) resolved the identical test case correctly
+(`(Acme Corp)-[RELOCATED_TO]->(Austin)`), confirming this was a model
+capability ceiling, not a flaw in the `resolve_references` prompt
+addition or the surrounding architecture.
+
+**Documented limitation, not silently worked around:** cross-chunk
+relation extraction quality depends heavily on the provider's reasoning
+capability. Small local models are not recommended for this feature
+without independently verifying their output - this is stated in the
+CHANGELOG, the README, and the live test's own docstring.
+
+## 4. Non-goals (unchanged from original scope)
+
+- General-purpose coreference resolution - only enough continuity to
+  support relation extraction was implemented, not a full NLP subsystem.
+- Cross-*document* relation extraction (linking entities across separate
+  `upsert_document()` calls) - not attempted.
+- Guaranteeing full recall of cross-chunk relations - the bar was
+  "meaningfully better than zero, live-verified, honestly labeled,"
+  matching this project's existing pattern for other known limitations
+  (`ask_stream()` token usage, `MAX_CONTEXT_CHARS` approximation).
+
+## 5. Verification performed
+
+- Offline: pure-logic tests for the carry-forward/threading behavior,
+  following the existing `LLMRelationExtractor` mock-based test style.
+- Live: a real test document, deliberately constructed so the relation
+  cannot be found by per-chunk extraction alone (chunk 2 has fewer than
+  2 entities without cross-chunk context), run against real Neo4j +
+  Gemini. Confirms both that `cross_chunk_relations=True` recovers the
+  relation AND that `cross_chunk_relations=False` (the default) does
+  not - proving the flag changes real behavior, not just that the test
+  document happened to be easy.
+- Full suite: 88 passed, 15 skipped at ship time (zero regressions -
+  `resolve_references` defaults `False` and the cross-chunk pass is
+  fully gated behind the opt-in flag).

--- a/packages/ragleap-graph/docs/design/ontology-cross-validation.md
+++ b/packages/ragleap-graph/docs/design/ontology-cross-validation.md
@@ -1,6 +1,14 @@
 # Design: Ontology Cross-Validation (#152)
 
-**Status:** Proposed — needs maintainer decision before implementation.
+> **Status: Implemented (v0.9.0).**
+> This document originally proposed ontology cross-validation for
+> `ragleap-graph`. It shipped in v0.9.0 - see CHANGELOG.md for the full
+> implementation summary. Left here as historical design record. The
+> open questions in Section 6 were resolved as: Q1 dict-of-tuples shape
+> (as proposed), Q2 drop-with-warning (not tag-and-keep), Q3 yes -
+> relation_ontology without entity_types raises ValueError at config
+> time, Q4 yes - applies to both the per-chunk and cross-chunk passes.
+
 **Package:** `ragleap-graph`
 **Depends on / precedent:** entity_types= enforcement (v0.6.3, coerces
 out-of-vocabulary entity types to "UNKNOWN" post-hoc rather than relying

--- a/packages/ragleap-graph/docs/design/schema-migrations.md
+++ b/packages/ragleap-graph/docs/design/schema-migrations.md
@@ -1,10 +1,11 @@
 # Schema Migrations — Design Proposal for ragleap-graph
 
-> **Status: Proposal.**
-> This document proposes a lightweight migration framework for
-> `ragleap-graph`'s Neo4j schema. It is a design artifact for maintainer
-> review, not an implemented feature. No code changes are required to
-> ship this document.
+> **Status: Implemented (v0.7.0).**
+> This document originally proposed a lightweight migration framework
+> for `ragleap-graph`'s Neo4j schema. It shipped as `ragleap_graph.migrations`
+> in v0.7.0 - see CHANGELOG.md for the full implementation summary. Left
+> here as historical design record; the reasoning below is why it was
+> built the way it was, not a pending proposal.
 
 ---
 


### PR DESCRIPTION
Full documentation-claims audit (the item flagged as \"not started\" in the original project handoff, only the two PyPI taglines had previously been re-verified).

## Real findings
- README.md and ROADMAP.md both stuck at v0.6.5/87 tests - three releases behind (v0.7.0, v0.8.0, v0.9.0 all missing)
- Two design docs (schema-migrations.md, ontology-cross-validation.md) still marked "Proposal"/"Proposed" despite being fully implemented
- A third design doc (cross-chunk-relation-extraction.md) was drafted but never actually committed - recreated here
- **Issue #151 was claiming audit logging "not built" when it shipped in v0.6.6** - closed on GitHub with an explanatory comment, separate from this PR
- packages.ragleap.com's index.html and both wiki pages (Home.md, Roadmap.md) were also independently stale - fixed directly (not part of this PR, those aren't in this repo/aren't PR'd)

## Also added
README gained short sections for `cross_chunk_relations=` and `relation_ontology=`, which it didn't mention at all before this.

## Process gap worth noting
None of index.html, Roadmap.md, or this kind of broader doc audit were ever part of the 14-step release checklist - worth adding a step for at least the homepage index going forward.