### PR TITLE
docs(ragleap-app-chart): update README status line to v0.2.0

### DIFF
--- a/packages/ragleap-app-chart/README.md
+++ b/packages/ragleap-app-chart/README.md
@@ -12,7 +12,7 @@ Point it at your own app; it doesn't know or care what RagLeap is.
 
 ## Status
 
-v0.1.0 published on PyPI. Generic `services:` schema and range-loop
+v0.2.0 published on PyPI. Generic `services:` schema and range-loop
 Helm templates are live-tested end-to-end on a real kind cluster (not
 just `helm lint`/`helm template`) -- see CHANGELOG.md for the real
 bugs found and fixed via live testing. See


### PR DESCRIPTION
The README's Status section still said v0.1.0 published on PyPI -- stale after this session's v0.2.0 release (tag ragleap-app-chart-v0.2.0 triggered release.yml automatically, confirmed live on real PyPI). This README is also the published package's description on PyPI itself, so leaving it stale would show an outdated version number on the real package page.

## What does this PR do?

Briefly describe the change.

## Related issue

Closes #

## Checklist

- [ ] I've tested this change locally
- [ ] I've updated documentation if needed
- [ ] My changes follow the existing code style
