### PR TITLE
feat(java-port): port retrieval.py to Java (VectorRetrievalService)

### DIFF
--- a/java/ragleap-rag/src/main/java/com/ragleap/rag/retrieval/VectorRetrievalService.java
+++ b/java/ragleap-rag/src/main/java/com/ragleap/rag/retrieval/VectorRetrievalService.java
@@ -1,0 +1,280 @@
+package com.ragleap.rag.retrieval;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ragleap.rag.db.ConnectionPool;
+import com.ragleap.rag.vectorstore.SearchResult;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Retrieval for ragleap-rag: dense (pgvector), sparse (Postgres
+ * full-text), and hybrid (Reciprocal Rank Fusion) search. Java port of
+ * ragleap-rag's retrieval.py - VectorRetrievalService.
+ *
+ * Requires a PostgreSQL database with the pgvector extension and the
+ * schema created by com.ragleap.rag.schema.SchemaManager (see that
+ * class for the exact DDL).
+ *
+ * No knowledge-graph coupling here by design - ragleap-graph (a
+ * separate package, not yet ported) extends retrieval with
+ * graph-boosted ranking on top of this.
+ *
+ * Deliberate overlap with com.ragleap.rag.vectorstore.PgVectorBackend,
+ * documented rather than silently duplicated or refactored away: this
+ * class predates/parallels the VectorBackend abstraction in the Python
+ * source (operates on a raw pool directly, not through an interface)
+ * and has real behavioral differences from PgVectorBackend worth
+ * preserving faithfully:
+ *   - Validates query embedding dimensions match the configured
+ *     embeddingDimensions exactly, warning and returning empty rather
+ *     than proceeding on mismatch - PgVectorBackend has no such check.
+ *   - Supports filtering to a single documentId - PgVectorBackend only
+ *     supports metadata filtering, not a document_id filter.
+ *   - Logs and RE-THROWS on error (via SEVERE + rethrow) rather than
+ *     letting the checked exception propagate unlogged.
+ */
+public class VectorRetrievalService {
+
+    private static final Logger logger = Logger.getLogger(VectorRetrievalService.class.getName());
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final int RRF_K = 60; // Reciprocal Rank Fusion constant - 60 is the standard default.
+
+    private final ConnectionPool pool;
+    private final int embeddingDimensions;
+    private final double minSimilarity;
+
+    public VectorRetrievalService(ConnectionPool pool) {
+        this(pool, 3072, 0.05);
+    }
+
+    public VectorRetrievalService(ConnectionPool pool, int embeddingDimensions, double minSimilarity) {
+        this.pool = pool;
+        this.embeddingDimensions = embeddingDimensions;
+        this.minSimilarity = minSimilarity;
+    }
+
+    /** Dense retrieval via pgvector cosine distance. */
+    public List<SearchResult> searchSimilarChunks(List<Double> queryEmbedding, int topK,
+                                                     String documentId, Map<String, Object> metadataFilter) throws SQLException {
+        if (queryEmbedding == null || queryEmbedding.isEmpty()) {
+            return List.of();
+        }
+        if (queryEmbedding.size() != embeddingDimensions) {
+            logger.warning(() -> String.format(
+                    "Query embedding dim=%d != expected %d; skipping search",
+                    queryEmbedding.size(), embeddingDimensions));
+            return List.of();
+        }
+
+        String literal = toVectorLiteral(queryEmbedding);
+
+        StringBuilder sql = new StringBuilder(String.format(
+                "SELECT id, text, document_id, document_name, chunk_index, " +
+                "1 - (embedding::halfvec(%1$d) <=> ?::halfvec(%1$d)) / 2 AS similarity_score " +
+                "FROM chunks", embeddingDimensions));
+
+        List<String> whereClauses = new ArrayList<>();
+        if (documentId != null) {
+            whereClauses.add("document_id = ?");
+        }
+        boolean hasMetadataFilter = metadataFilter != null && !metadataFilter.isEmpty();
+        if (hasMetadataFilter) {
+            whereClauses.add("metadata @> ?::jsonb");
+        }
+        if (!whereClauses.isEmpty()) {
+            sql.append(" WHERE ").append(String.join(" AND ", whereClauses));
+        }
+        sql.append(String.format(" ORDER BY embedding::halfvec(%1$d) <=> ?::halfvec(%1$d) LIMIT ?", embeddingDimensions));
+
+        try (Connection conn = pool.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql.toString())) {
+            int i = 1;
+            stmt.setString(i++, literal);
+            if (documentId != null) {
+                stmt.setObject(i++, UUID.fromString(documentId));
+            }
+            if (hasMetadataFilter) {
+                stmt.setString(i++, toJson(metadataFilter));
+            }
+            stmt.setString(i++, literal);
+            stmt.setInt(i, topK);
+
+            List<SearchResult> results = new ArrayList<>();
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    double score = rs.getDouble("similarity_score");
+                    if (score < minSimilarity) {
+                        continue;
+                    }
+                    results.add(new SearchResult(
+                            rs.getObject("id", UUID.class).toString(),
+                            rs.getString("text"),
+                            Math.round(score * 10000.0) / 10000.0,
+                            rs.getObject("document_id", UUID.class).toString(),
+                            rs.getString("document_name"),
+                            rs.getInt("chunk_index")
+                    ));
+                }
+            }
+            int finalTopK = topK;
+            logger.info(() -> String.format("Vector search returned %d chunks (top_k=%d)", results.size(), finalTopK));
+            return results;
+        } catch (SQLException e) {
+            logger.log(Level.SEVERE, "Vector search error: " + e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    /** Sparse (keyword/full-text) retrieval via Postgres text search. */
+    public List<SearchResult> searchSparseChunks(String queryText, int topK,
+                                                    String documentId, Map<String, Object> metadataFilter) throws SQLException {
+        if (queryText == null || queryText.isBlank()) {
+            return List.of();
+        }
+
+        StringBuilder sql = new StringBuilder(
+                "SELECT id, text, document_id, document_name, chunk_index, " +
+                "ts_rank(text_search_vector, websearch_to_tsquery('english', ?)) AS rank_score " +
+                "FROM chunks " +
+                "WHERE text_search_vector @@ websearch_to_tsquery('english', ?)");
+
+        if (documentId != null) {
+            sql.append(" AND document_id = ?");
+        }
+        boolean hasMetadataFilter = metadataFilter != null && !metadataFilter.isEmpty();
+        if (hasMetadataFilter) {
+            sql.append(" AND metadata @> ?::jsonb");
+        }
+        sql.append(" ORDER BY rank_score DESC LIMIT ?");
+
+        try (Connection conn = pool.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql.toString())) {
+            int i = 1;
+            stmt.setString(i++, queryText);
+            stmt.setString(i++, queryText);
+            if (documentId != null) {
+                stmt.setObject(i++, UUID.fromString(documentId));
+            }
+            if (hasMetadataFilter) {
+                stmt.setString(i++, toJson(metadataFilter));
+            }
+            stmt.setInt(i, topK);
+
+            List<SearchResult> results = new ArrayList<>();
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    results.add(new SearchResult(
+                            rs.getObject("id", UUID.class).toString(),
+                            rs.getString("text"),
+                            Math.round(rs.getDouble("rank_score") * 10000.0) / 10000.0,
+                            rs.getObject("document_id", UUID.class).toString(),
+                            rs.getString("document_name"),
+                            rs.getInt("chunk_index")
+                    ));
+                }
+            }
+            int finalTopK = topK;
+            logger.info(() -> String.format("Sparse search returned %d chunks (top_k=%d)", results.size(), finalTopK));
+            return results;
+        } catch (SQLException e) {
+            logger.log(Level.SEVERE, "Sparse search error: " + e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    /**
+     * Combines dense + sparse via Reciprocal Rank Fusion. similarityScore
+     * in the returned results is the RRF-fused score, meaningful only for
+     * ranking within this result set (not a 0-1 cosine similarity).
+     */
+    public List<SearchResult> searchHybridChunks(String queryText, List<Double> queryEmbedding, int topK,
+                                                    String documentId, Map<String, Object> metadataFilter) throws SQLException {
+        List<SearchResult> dense = searchSimilarChunks(queryEmbedding, topK * 3, documentId, metadataFilter);
+        List<SearchResult> sparse = searchSparseChunks(queryText, topK * 3, documentId, metadataFilter);
+
+        Map<String, Integer> denseRanks = new LinkedHashMap<>();
+        for (int i = 0; i < dense.size(); i++) {
+            denseRanks.put(dense.get(i).chunkId(), i);
+        }
+        Map<String, Integer> sparseRanks = new LinkedHashMap<>();
+        for (int i = 0; i < sparse.size(); i++) {
+            sparseRanks.put(sparse.get(i).chunkId(), i);
+        }
+
+        Map<String, SearchResult> lookup = new LinkedHashMap<>();
+        for (SearchResult c : dense) {
+            lookup.put(c.chunkId(), c);
+        }
+        for (SearchResult c : sparse) {
+            lookup.putIfAbsent(c.chunkId(), c);
+        }
+
+        Set<String> allIds = new LinkedHashSet<>();
+        allIds.addAll(denseRanks.keySet());
+        allIds.addAll(sparseRanks.keySet());
+        if (allIds.isEmpty()) {
+            return List.of();
+        }
+
+        Map<String, Double> rrfScores = new LinkedHashMap<>();
+        for (String cid : allIds) {
+            double score = 0.0;
+            if (denseRanks.containsKey(cid)) {
+                score += 1.0 / (RRF_K + denseRanks.get(cid) + 1);
+            }
+            if (sparseRanks.containsKey(cid)) {
+                score += 1.0 / (RRF_K + sparseRanks.get(cid) + 1);
+            }
+            rrfScores.put(cid, score);
+        }
+
+        List<SearchResult> results = new ArrayList<>();
+        for (String cid : allIds) {
+            SearchResult base = lookup.get(cid);
+            double score = Math.round(rrfScores.get(cid) * 1_000_000.0) / 1_000_000.0;
+            results.add(new SearchResult(base.chunkId(), base.text(), score,
+                    base.documentId(), base.documentName(), base.chunkIndex(), "hybrid_rrf"));
+        }
+        results.sort((a, b) -> Double.compare(b.similarityScore(), a.similarityScore()));
+
+        List<SearchResult> topResults = results.size() > topK ? results.subList(0, topK) : results;
+        int denseSize = dense.size();
+        int sparseSize = sparse.size();
+        int fusedSize = results.size();
+        int returned = topResults.size();
+        logger.info(() -> String.format(
+                "Hybrid search: %d dense + %d sparse -> %d fused, returning top %d",
+                denseSize, sparseSize, fusedSize, returned));
+
+        return topResults;
+    }
+
+    private static String toVectorLiteral(List<Double> embedding) {
+        StringJoiner joiner = new StringJoiner(",", "[", "]");
+        for (Double v : embedding) {
+            joiner.add(String.valueOf(v));
+        }
+        return joiner.toString();
+    }
+
+    private static String toJson(Map<String, Object> map) throws SQLException {
+        try {
+            return MAPPER.writeValueAsString(map != null ? map : Map.of());
+        } catch (Exception e) {
+            throw new SQLException("Failed to serialize metadata to JSON", e);
+        }
+    }
+}

--- a/java/ragleap-rag/src/test/java/com/ragleap/rag/retrieval/VectorRetrievalServiceTest.java
+++ b/java/ragleap-rag/src/test/java/com/ragleap/rag/retrieval/VectorRetrievalServiceTest.java
@@ -1,0 +1,233 @@
+package com.ragleap.rag.retrieval;
+
+import com.ragleap.rag.db.ConnectionPool;
+import com.ragleap.rag.schema.SchemaManager;
+import com.ragleap.rag.vectorstore.SearchResult;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Real integration test against the live ragleap_java_test database -
+ * NOT mocked. Uses raw SQL to insert test data directly (bypassing
+ * PgVectorBackend) since VectorRetrievalService operates on a raw
+ * ConnectionPool, matching the Python source's actual structure.
+ */
+class VectorRetrievalServiceTest {
+
+    private static final String DATABASE_URL = System.getenv().getOrDefault(
+            "RAGLEAP_JAVA_TEST_DATABASE_URL",
+            "postgresql://ragleap:ragleap@localhost:5433/ragleap_java_test"
+    );
+    private static final int DIMS = 8;
+
+    private static ConnectionPool pool;
+    private static VectorRetrievalService service;
+
+    @BeforeAll
+    static void setUp() throws SQLException {
+        pool = new ConnectionPool(DATABASE_URL, 1, 10);
+        SchemaManager.initCoreSchema(pool, DIMS);
+        service = new VectorRetrievalService(pool, DIMS, 0.0); // 0.0 threshold: don't filter in tests
+    }
+
+    @AfterEach
+    void cleanUpRows() throws SQLException {
+        try (Connection conn = pool.getConnection();
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("TRUNCATE documents CASCADE");
+            conn.commit();
+        }
+    }
+
+    @AfterAll
+    static void tearDown() throws SQLException {
+        try (Connection conn = pool.getConnection();
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("DROP TABLE IF EXISTS chunks CASCADE");
+            stmt.execute("DROP TABLE IF EXISTS documents CASCADE");
+            conn.commit();
+        }
+        pool.close();
+    }
+
+    private static List<Double> vec(double... values) {
+        List<Double> list = new ArrayList<>();
+        for (double v : values) {
+            list.add(v);
+        }
+        return list;
+    }
+
+    private static String insertDocument(String filename) throws SQLException {
+        String docId = UUID.randomUUID().toString();
+        try (Connection conn = pool.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(
+                     "INSERT INTO documents (id, filename, metadata) VALUES (?, ?, '{}'::jsonb)")) {
+            stmt.setObject(1, UUID.fromString(docId));
+            stmt.setString(2, filename);
+            stmt.executeUpdate();
+            conn.commit();
+        }
+        return docId;
+    }
+
+    private static void insertChunk(String docId, String docName, int chunkIndex, String text,
+                                      List<Double> embedding, String metadataJson) throws SQLException {
+        StringJoiner joiner = new StringJoiner(",", "[", "]");
+        for (Double v : embedding) {
+            joiner.add(String.valueOf(v));
+        }
+        try (Connection conn = pool.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(
+                     "INSERT INTO chunks (document_id, document_name, chunk_index, text, token_count, embedding, metadata) " +
+                     "VALUES (?, ?, ?, ?, ?, ?::vector, ?::jsonb)")) {
+            stmt.setObject(1, UUID.fromString(docId));
+            stmt.setString(2, docName);
+            stmt.setInt(3, chunkIndex);
+            stmt.setString(4, text);
+            stmt.setInt(5, 5);
+            stmt.setString(6, joiner.toString());
+            stmt.setString(7, metadataJson != null ? metadataJson : "{}");
+            stmt.executeUpdate();
+            conn.commit();
+        }
+    }
+
+    @Test
+    void searchSimilarChunksReturnsEmptyForEmptyEmbedding() throws SQLException {
+        assertEquals(List.of(), service.searchSimilarChunks(List.of(), 5, null, null));
+    }
+
+    @Test
+    void searchSimilarChunksReturnsEmptyOnDimensionMismatch() throws SQLException {
+        // Service configured for DIMS=8, but this embedding has only 3 -
+        // must warn and return empty, NOT throw or attempt the query.
+        // Distinct behavior from PgVectorBackend, which has no such check.
+        List<SearchResult> results = service.searchSimilarChunks(vec(1, 0, 0), 5, null, null);
+        assertEquals(List.of(), results);
+    }
+
+    @Test
+    void searchSimilarChunksFindsExactMatchFirst() throws SQLException {
+        String docId = insertDocument("doc.txt");
+        insertChunk(docId, "doc.txt", 0, "about cats", vec(1, 0, 0, 0, 0, 0, 0, 0), null);
+        insertChunk(docId, "doc.txt", 1, "about dogs", vec(0, 1, 0, 0, 0, 0, 0, 0), null);
+
+        List<SearchResult> results = service.searchSimilarChunks(vec(1, 0, 0, 0, 0, 0, 0, 0), 5, null, null);
+
+        assertFalse(results.isEmpty());
+        assertEquals("about cats", results.get(0).text());
+    }
+
+    @Test
+    void searchSimilarChunksFiltersByDocumentId() throws SQLException {
+        String doc1 = insertDocument("doc1.txt");
+        String doc2 = insertDocument("doc2.txt");
+        insertChunk(doc1, "doc1.txt", 0, "chunk in doc1", vec(1, 0, 0, 0, 0, 0, 0, 0), null);
+        insertChunk(doc2, "doc2.txt", 0, "chunk in doc2", vec(1, 0, 0, 0, 0, 0, 0, 0), null);
+
+        List<SearchResult> results = service.searchSimilarChunks(vec(1, 0, 0, 0, 0, 0, 0, 0), 10, doc1, null);
+
+        assertEquals(1, results.size());
+        assertEquals("chunk in doc1", results.get(0).text());
+    }
+
+    @Test
+    void searchSimilarChunksFiltersByMetadata() throws SQLException {
+        String docId = insertDocument("doc.txt");
+        insertChunk(docId, "doc.txt", 0, "public chunk", vec(1, 0, 0, 0, 0, 0, 0, 0), "{\"visibility\": \"public\"}");
+        insertChunk(docId, "doc.txt", 1, "private chunk", vec(1, 0, 0, 0, 0, 0, 0, 0), "{\"visibility\": \"private\"}");
+
+        List<SearchResult> results = service.searchSimilarChunks(
+                vec(1, 0, 0, 0, 0, 0, 0, 0), 10, null, Map.of("visibility", "public"));
+
+        assertEquals(1, results.size());
+        assertEquals("public chunk", results.get(0).text());
+    }
+
+    @Test
+    void searchSparseChunksReturnsEmptyForBlankQuery() throws SQLException {
+        assertEquals(List.of(), service.searchSparseChunks("", 5, null, null));
+        assertEquals(List.of(), service.searchSparseChunks(null, 5, null, null));
+    }
+
+    @Test
+    void searchSparseChunksFindsKeywordMatch() throws SQLException {
+        String docId = insertDocument("doc.txt");
+        insertChunk(docId, "doc.txt", 0, "the quick brown fox", vec(1, 0, 0, 0, 0, 0, 0, 0), null);
+        insertChunk(docId, "doc.txt", 1, "unrelated weather content", vec(0, 1, 0, 0, 0, 0, 0, 0), null);
+
+        List<SearchResult> results = service.searchSparseChunks("fox", 5, null, null);
+
+        assertFalse(results.isEmpty());
+        assertTrue(results.get(0).text().contains("fox"));
+    }
+
+    @Test
+    void searchSparseChunksFiltersByDocumentId() throws SQLException {
+        String doc1 = insertDocument("doc1.txt");
+        String doc2 = insertDocument("doc2.txt");
+        insertChunk(doc1, "doc1.txt", 0, "shared keyword here", vec(1, 0, 0, 0, 0, 0, 0, 0), null);
+        insertChunk(doc2, "doc2.txt", 0, "shared keyword here too", vec(1, 0, 0, 0, 0, 0, 0, 0), null);
+
+        List<SearchResult> results = service.searchSparseChunks("keyword", 10, doc1, null);
+
+        assertEquals(1, results.size());
+    }
+
+    @Test
+    void searchHybridChunksCombinesDenseAndSparseWithRrf() throws SQLException {
+        String docId = insertDocument("doc.txt");
+        insertChunk(docId, "doc.txt", 0, "the quick brown fox", vec(1, 0, 0, 0, 0, 0, 0, 0), null);
+        insertChunk(docId, "doc.txt", 1, "a fox in the forest", vec(0, 0, 0, 0, 0, 0, 0, 1), null);
+        insertChunk(docId, "doc.txt", 2, "completely different topic", vec(0.99, 0.01, 0, 0, 0, 0, 0, 0), null);
+
+        List<SearchResult> results = service.searchHybridChunks(
+                "fox", vec(1, 0, 0, 0, 0, 0, 0, 0), 10, null, null);
+
+        assertFalse(results.isEmpty());
+        assertEquals("the quick brown fox", results.get(0).text());
+        assertEquals("hybrid_rrf", results.get(0).retrievalMethod());
+    }
+
+    @Test
+    void searchHybridChunksRespectsTopK() throws SQLException {
+        String docId = insertDocument("doc.txt");
+        for (int i = 0; i < 5; i++) {
+            insertChunk(docId, "doc.txt", i, "shared keyword " + i, vec(1, 0, 0, 0, 0, 0, 0, 0), null);
+        }
+
+        List<SearchResult> results = service.searchHybridChunks(
+                "shared keyword", vec(1, 0, 0, 0, 0, 0, 0, 0), 2, null, null);
+
+        assertEquals(2, results.size());
+    }
+
+    @Test
+    void searchHybridChunksFiltersByDocumentId() throws SQLException {
+        String doc1 = insertDocument("doc1.txt");
+        String doc2 = insertDocument("doc2.txt");
+        insertChunk(doc1, "doc1.txt", 0, "shared keyword", vec(1, 0, 0, 0, 0, 0, 0, 0), null);
+        insertChunk(doc2, "doc2.txt", 0, "shared keyword", vec(1, 0, 0, 0, 0, 0, 0, 0), null);
+
+        List<SearchResult> results = service.searchHybridChunks(
+                "shared keyword", vec(1, 0, 0, 0, 0, 0, 0, 0), 10, doc1, null);
+
+        assertEquals(1, results.size());
+    }
+}


### PR DESCRIPTION
Fourth of five core-pipeline modules (see java/HANDOVER.md roadmap - db.py/embedding.py/pgvector.py done via PRs #337/#338/#344/#345/#350/#351). Ports VectorRetrievalService: dense/sparse/hybrid search against a raw ConnectionPool. Deliberately overlaps with PgVectorBackend (documented why in the javadoc) - has real behavioral differences (dimension validation, documentId filtering, rethrow-on-error) worth preserving faithfully rather than collapsing into a shared implementation. 11 new JUnit tests against real live Postgres. 144/144 passing overall. One module left in the core pipeline: generation.py.